### PR TITLE
Fixed memory corruption bug with yielding from Lua code and using the LuaJIT2 VM.

### DIFF
--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -963,7 +963,6 @@ ngx_http_lua_run_thread(lua_State *L, ngx_http_request_t *r,
                 ngx_http_lua_dump_postponed(r);
 #endif
 
-                lua_settop(cc, 0);
                 return NGX_AGAIN;
 
             case 0:


### PR DESCRIPTION
If you turn on LUA_USE_APICHECK in LuaJIT2, then an exception will be raised in lua_settop(cc, 0) when called after the Lua code yields.  I do not see any reason why lua_settop() should be call when Lua yields.
