### PR TITLE
Allow other modules to get "L"

### DIFF
--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -167,6 +167,15 @@ ngx_http_lua_new_state(ngx_conf_t *cf, ngx_http_lua_main_conf_t *lmcf)
 
 
 lua_State *
+ngx_http_lua_get_state(ngx_conf_t *cf)
+{
+    ngx_http_lua_main_conf_t *lmcf;
+
+    lmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_lua_module);
+    return lmcf->lua;
+}
+
+lua_State *
 ngx_http_lua_new_thread(ngx_http_request_t *r, lua_State *L, int *ref)
 {
     int              top;

--- a/src/ngx_http_lua_util.h
+++ b/src/ngx_http_lua_util.h
@@ -20,6 +20,8 @@
 lua_State * ngx_http_lua_new_state(ngx_conf_t *cf,
     ngx_http_lua_main_conf_t *lmcf);
 
+lua_State * ngx_http_lua_get_state(ngx_conf_t *cf);
+
 lua_State * ngx_http_lua_new_thread(ngx_http_request_t *r, lua_State *l,
     int *ref);
 


### PR DESCRIPTION
I really just want to be able to add stuff to package.preload. I have some exploring in exposing some other modules interfaces via Lua and don't want to hack the Lua module everytime.
