### PR TITLE
Ngx http lua add preload

### DIFF
--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -75,6 +75,20 @@ ngx_http_lua_set_path(ngx_conf_t *cf, lua_State *L, int tab_idx,
     lua_setfield(L, tab_idx, fieldname);
 }
 
+
+ngx_http_request_t *
+ngx_http_lua_get_request(lua_State *L)
+{
+  ngx_http_request_t *r;
+
+  lua_getglobal(L, GLOBALS_SYMBOL_REQUEST);
+  r = lua_touserdata(L, -1);
+  lua_pop(L, 1);
+
+  return r;
+}  
+
+
 void
 ngx_http_lua_add_preload(ngx_conf_t *cf, const char *package, lua_CFunction func)
 {

--- a/src/ngx_http_lua_util.h
+++ b/src/ngx_http_lua_util.h
@@ -16,6 +16,8 @@
     (str)->len = sizeof(text) - 1; (str)->data = (u_char *) text
 #endif
 
+ngx_http_request_t *ngx_http_lua_get_request(lua_State *L);
+
 void ngx_http_lua_add_preload(ngx_conf_t *cf, const char *package,
     lua_CFunction func);
 


### PR DESCRIPTION
Here's the version that just allows adding module preloads.  2nd commit adds a way to get the request without having to know the internals of "core" Lua modules.  

A very simpe example module using this is at: https://github.com/bakins/nginx-example-lua-module
