### PR TITLE
Conditionally compile regex cache config option

### DIFF
--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -76,8 +76,10 @@ typedef struct {
 
     ngx_pool_t      *pool;
 
+#if (NGX_PCRE)
     ngx_int_t        regex_cache_entries;
     ngx_int_t        regex_cache_max_entries;
+#endif
 
     ngx_array_t     *shm_zones;  /* of ngx_shm_zone_t* */
 

--- a/src/ngx_http_lua_conf.c
+++ b/src/ngx_http_lua_conf.c
@@ -34,7 +34,9 @@ ngx_http_lua_create_main_conf(ngx_conf_t *cf)
      */
 
     lmcf->pool = cf->pool;
+#if (NGX_PCRE)
     lmcf->regex_cache_max_entries = NGX_CONF_UNSET;
+#endif
 
     dd("nginx Lua module main config structure initialized!");
 
@@ -47,9 +49,11 @@ ngx_http_lua_init_main_conf(ngx_conf_t *cf, void *conf)
 {
     ngx_http_lua_main_conf_t *lmcf = conf;
 
+#if (NGX_PCRE)
     if (lmcf->regex_cache_max_entries == NGX_CONF_UNSET) {
         lmcf->regex_cache_max_entries = 1024;
     }
+#endif
 
     if (lmcf->lua == NULL) {
         if (ngx_http_lua_init_vm(cf, lmcf) != NGX_CONF_OK) {

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -32,12 +32,14 @@ static ngx_command_t ngx_http_lua_cmds[] = {
       0,
       NULL },
 
+#if (NGX_PCRE)
     { ngx_string("lua_regex_cache_max_entries"),
       NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_num_slot,
       NGX_HTTP_MAIN_CONF_OFFSET,
       offsetof(ngx_http_lua_main_conf_t, regex_cache_max_entries),
       NULL },
+#endif
 
     { ngx_string("lua_package_cpath"),
       NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,


### PR DESCRIPTION
The regex bindings are not compiled when the PCRE module is not included.
This patch also removes support for the config options in that case.
