### PR TITLE
Fix issue with unused variable when compiling without PCRE support.

### DIFF
--- a/src/ngx_http_lua_conf.c
+++ b/src/ngx_http_lua_conf.c
@@ -56,9 +56,9 @@ ngx_http_lua_create_main_conf(ngx_conf_t *cf)
 char *
 ngx_http_lua_init_main_conf(ngx_conf_t *cf, void *conf)
 {
+#if (NGX_PCRE)
     ngx_http_lua_main_conf_t *lmcf = conf;
 
-#if (NGX_PCRE)
     if (lmcf->regex_cache_max_entries == NGX_CONF_UNSET) {
         lmcf->regex_cache_max_entries = 1024;
     }


### PR DESCRIPTION
I found a small issue with a variable becoming unused if compiling with PCRE support disabled. This breaks the build when -Werror is on.
