### PR TITLE
Added an optional parameter for ngx.req.set_header and ngx.req.clear_header...

### DIFF
--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -589,15 +589,9 @@ ngx_http_lua_ngx_req_header_clear(lua_State *L)
     }
 
     if (n == 2) {
-        u_char  *p;
-        size_t   len;
-        int replace_underscores = 1;
-        p = (u_char *) luaL_checklstring(L, 1, &len);
-        replace_underscores = lua_toboolean(L, 2);
-        lua_pop(L, 2);
-        lua_pushlstring(L, (char *) p, len);
         lua_pushnil(L);
-        lua_pushboolean(L, replace_underscores);
+        /* Top element is now 3, replace it with element 3 */
+        lua_insert(L, 2);
     } else {
         lua_pushnil(L);
     }


### PR DESCRIPTION
... that determines whether or not to replace underscores with hyphens. Previously, underscores were replaced unconditionally. Currently each of the functions has another boolean argument that determines whether or not to replace underscores with hyphens.

Previously, underscores were replaced unconditionally.
Currently each of the functions has another boolean argument. If it's false, underscores would not be touched. If it's true, they would.
The default value of the argument is true.
