### PR TITLE
give the argument of 'void' to function definitions which has no arguments

### DIFF
--- a/src/ngx_http_lua_bodyfilterby.c
+++ b/src/ngx_http_lua_bodyfilterby.c
@@ -359,7 +359,7 @@ ngx_http_lua_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
 
 ngx_int_t
-ngx_http_lua_body_filter_init()
+ngx_http_lua_body_filter_init(void)
 {
     dd("calling body filter init");
     ngx_http_next_body_filter = ngx_http_top_body_filter;

--- a/src/ngx_http_lua_headerfilterby.c
+++ b/src/ngx_http_lua_headerfilterby.c
@@ -302,7 +302,7 @@ ngx_http_lua_header_filter(ngx_http_request_t *r)
 
 
 ngx_int_t
-ngx_http_lua_header_filter_init()
+ngx_http_lua_header_filter_init(void)
 {
     dd("calling header filter init");
     ngx_http_next_header_filter = ngx_http_top_header_filter;


### PR DESCRIPTION
A function definition which has no arguments is traditional-style and deprecated.
