### PR TITLE
fix filters init logic

### DIFF
--- a/src/ngx_http_lua_bodyfilterby.c
+++ b/src/ngx_http_lua_bodyfilterby.c
@@ -249,6 +249,12 @@ ngx_http_lua_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     ngx_chain_t                 *out;
     ngx_buf_tag_t                tag;
 
+    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
+
+    if (!lmcf->requires_body_filter) {
+        return ngx_http_next_body_filter(r, in);
+    }
+
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "lua body filter for user lua code, uri \"%V\"", &r->uri);
 
@@ -308,8 +314,6 @@ ngx_http_lua_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     if (rc != NGX_OK) {
         return NGX_ERROR;
     }
-
-    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
 
     L = lmcf->lua;
 

--- a/src/ngx_http_lua_capturefilter.c
+++ b/src/ngx_http_lua_capturefilter.c
@@ -47,8 +47,15 @@ ngx_http_lua_capture_header_filter(ngx_http_request_t *r)
     ngx_http_post_subrequest_t      *psr;
     ngx_http_lua_ctx_t              *old_ctx;
     ngx_http_lua_ctx_t              *ctx;
+    ngx_http_lua_main_conf_t        *lmcf;
 
     ngx_http_lua_post_subrequest_data_t      *psr_data;
+
+    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
+
+    if (!lmcf->requires_capture_filter) {
+        return ngx_http_lua_next_header_filter(r);
+    }
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "lua capture header filter, uri \"%V\"", &r->uri);
@@ -111,6 +118,13 @@ ngx_http_lua_capture_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     ngx_int_t                        eof;
     ngx_http_lua_ctx_t              *ctx;
     ngx_http_lua_ctx_t              *pr_ctx;
+    ngx_http_lua_main_conf_t        *lmcf;
+
+    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
+
+    if (!lmcf->requires_capture_filter) {
+        return ngx_http_lua_next_body_filter(r, in);
+    }
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "lua capture body filter, uri \"%V\"", &r->uri);

--- a/src/ngx_http_lua_headerfilterby.c
+++ b/src/ngx_http_lua_headerfilterby.c
@@ -231,6 +231,13 @@ ngx_http_lua_header_filter(ngx_http_request_t *r)
     ngx_int_t                    rc;
     ngx_http_cleanup_t          *cln;
     uint16_t                     old_context;
+    ngx_http_lua_main_conf_t    *lmcf;
+
+    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
+
+    if (!lmcf->requires_header_filter) {
+        return ngx_http_next_header_filter(r);
+    }
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "lua header filter for user lua code, uri \"%V\"", &r->uri);

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -397,11 +397,9 @@ ngx_http_lua_init(ngx_conf_t *cf)
 
     lmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_lua_module);
 
-    if (lmcf->requires_capture_filter) {
-        rc = ngx_http_lua_capture_filter_init(cf);
-        if (rc != NGX_OK) {
-            return rc;
-        }
+    rc = ngx_http_lua_capture_filter_init(cf);
+    if (rc != NGX_OK) {
+        return rc;
     }
 
     if (lmcf->postponed_to_rewrite_phase_end == NGX_CONF_UNSET) {
@@ -446,18 +444,14 @@ ngx_http_lua_init(ngx_conf_t *cf)
         *h = ngx_http_lua_log_handler;
     }
 
-    if (lmcf->requires_header_filter) {
-        rc = ngx_http_lua_header_filter_init();
-        if (rc != NGX_OK) {
-            return rc;
-        }
+    rc = ngx_http_lua_header_filter_init();
+    if (rc != NGX_OK) {
+        return rc;
     }
 
-    if (lmcf->requires_body_filter) {
-        rc = ngx_http_lua_body_filter_init();
-        if (rc != NGX_OK) {
-            return rc;
-        }
+    rc = ngx_http_lua_body_filter_init();
+    if (rc != NGX_OK) {
+        return rc;
     }
 
     if (lmcf->lua == NULL) {


### PR DESCRIPTION
When there are multiple `http` block in conf file, the filter list will be initialized according the last block. 
e.g.

``` c
http {
    server {
        listen 80;
        location / {
            proxy_pass http://127.0.0.1:8080;
            header_filter_by_lua_file "hf.lua";
        }
    }
}

http {
    server {
        listen 8080;
        location / {
            return 200 "8080";
        }
    }
}
```

Or maybe NGINX should ensure only one `http` block in conf. 
Please review the code. Thanks. 
