### PR TITLE
bugfix: the client will get a empty Cache_Control header when set Cache_...

### DIFF
--- a/src/ngx_http_lua_headers_out.c
+++ b/src/ngx_http_lua_headers_out.c
@@ -337,7 +337,14 @@ create:
     }
 
     ho->value = *value;
-    ho->hash = hv->hash;
+
+    if (value->len == 0) {
+        ho->hash = 0;
+
+    } else {
+        ho->hash = hv->hash;
+    }
+
     ngx_str_set(&ho->key, "Cache-Control");
     *ph = ho;
 


### PR DESCRIPTION
For example:  
header_filter_by_lua 'ngx.header.Cache_Control = nil'; 

When there is no Cache_Control  header in the original output headers, the client will get a  Cache_Control  header with a empty value.
