### PR TITLE
Subrequest headers copying

### DIFF
--- a/src/ngx_http_lua_subrequest.c
+++ b/src/ngx_http_lua_subrequest.c
@@ -627,8 +627,7 @@ ngx_http_lua_adjust_subrequest(ngx_http_request_t *sr, ngx_uint_t method,
 
     r = sr->parent;
 
-    sr->headers_in.content_length_n = -1;
-    sr->headers_in.keep_alive_n = -1;
+    sr->header_in = r->header_in;
 
     if (body) {
         sr->request_body = body;
@@ -1487,6 +1486,9 @@ ngx_http_lua_subrequest(ngx_http_request_t *r,
     sr->loc_conf = cscf->ctx->loc_conf;
 
     sr->pool = r->pool;
+
+    sr->headers_in.content_length_n = -1;
+    sr->headers_in.keep_alive_n = -1;
 
     ngx_http_clear_content_length(sr);
     ngx_http_clear_accept_ranges(sr);


### PR DESCRIPTION
When ngx_lua creates a subrequest, it performs the following line:

`sr->headers_in = r->headers_in;`

Where `sr` is the subrequest object and `r` is the parent request object.

This performs a shallow copy of the headers_in structure, copying the built-in headers and the list of headers.
Later on, the subrequest's list of headers is re-initiated with a deep copy of the headers (this happens either in `ngx_http_lua_copy_request_headers` or in `ngx_http_lua_set_content_length_header`).
However, the fields of the built-in headers still point to the list of headers of the main request. 

This causes two main issues:
- The built-in headers aren't really changeable in the context of the subrequest.
- When changing the built-in headers in the context of the subrequest, it may change the values of the built-in headers of the main request.

Therefore, I'm offering the following patch, that would perform a real deep-copy of the main request's headers_in structure to the one of the subrequest.
