### PR TITLE
Fix two bugs in src/ngx_http_lua_shdict.c

### DIFF
--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -1270,6 +1270,8 @@ ngx_http_lua_shared_dict_get(ngx_shm_zone_t *zone, u_char *key_data,
         if (value->value.s.data == NULL || value->value.s.len == 0) {
             ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "no string buffer "
                           "initialized");
+
+            ngx_shmtx_unlock(&ctx->shpool->mutex);
             return NGX_ERROR;
         }
 


### PR DESCRIPTION
Patches are simple.
- miss `return NGX_ERROR` in ngx_http_lua_ffi_shdict_get()
- ngx_http_lua_shared_dict_get() returns with mutex locked if buffer of LUA_TSTRING value is not initialized.
