### PR TITLE
doc: added missing method name under ngx.shared.DICT, fixed order

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5189,10 +5189,11 @@ The resulting object `dict` has the following methods:
 * [add](#ngxshareddictadd)
 * [safe_add](#ngxshareddictsafe_add)
 * [replace](#ngxshareddictreplace)
-* [incr](#ngxshareddictincr)
 * [delete](#ngxshareddictdelete)
+* [incr](#ngxshareddictincr)
 * [flush_all](#ngxshareddictflush_all)
 * [flush_expired](#ngxshareddictflush_expired)
+* [get_keys](#ngxshareddictget_keys)
 
 Here is an example:
 


### PR DESCRIPTION
Noticed this method was missing while working on openresty/lua-resty-lock#2. Also noticed they were in slightly the wrong order so I fixed that too.
