### PR TITLE
Fix #430

### DIFF
--- a/src/ngx_http_lua_output.c
+++ b/src/ngx_http_lua_output.c
@@ -587,12 +587,6 @@ ngx_http_lua_ngx_flush(lua_State *L)
 
         wev = r->connection->write;
 
-        if (wev->ready && wev->delayed) {
-            lua_pushnil(L);
-            lua_pushliteral(L, "delayed");
-            return 2;
-        }
-
         clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
 
         if (!wev->delayed) {

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -1710,6 +1710,7 @@ ngx_http_lua_flush_pending_output(ngx_http_request_t *r,
 #if 1
         if (wev->timer_set) {
             ngx_del_timer(wev);
+            wev->delayed = 0;
         }
 #endif
     }


### PR DESCRIPTION
- When use limit_rate in nginx.conf, wev->delayed will be set if needed. We shoud set wev->delayed to 0 when delete the delayed timer in `ngx_http_lua_flush_pending_output`. It will hang the outout forever otherwise because the `ngx_http_write_filter` will return before outout if wev->delaye = 1. 
- ngx.flush(true) should block until all the delayed data has been sent, or ngx.flush(true) will be useless with limit_rate being set.
