### PR TITLE
bugfix: ngx.re.gsub swallowed the character after a 0-width match that happens to be the last match

### DIFF
--- a/src/ngx_http_lua_regex.c
+++ b/src/ngx_http_lua_regex.c
@@ -1850,11 +1850,12 @@ exec:
 
     } else {
         if (offset < (int) subj.len) {
-            dd("adding trailer: %s (len %d)", &subj.data[offset],
-               (int) (subj.len - offset));
+            dd("adding trailer: %s (len %d)", &subj.data[cp_offset],
+               (int) (subj.len - cp_offset));
 
-            luaL_addlstring(&luabuf, (char *) &subj.data[offset],
-                            subj.len - offset);
+
+            luaL_addlstring(&luabuf, (char *) &subj.data[cp_offset],
+                            subj.len - cp_offset);
         }
 
         luaL_pushresult(&luabuf);

--- a/t/054-gsub-dfa.t
+++ b/t/054-gsub-dfa.t
@@ -200,3 +200,38 @@ s: aa
 --- no_error_log
 [error]
 
+
+
+=== TEST 9: bug: gsub incorrectly swallowed a character is the first character
+Original bad result: estCase
+--- config
+    location /re {
+        content_by_lua '
+            local s, n = ngx.re.gsub("TestCase", "^ *", "", "")
+            if s then
+                ngx.say(s)
+            end
+        ';
+    }
+--- request
+    GET /re
+--- response_body
+TestCase
+
+
+
+=== TEST 10: bug: gsub incorrectly swallowed a character is not the first character
+Original bad result: .b.d
+--- config
+    location /re {
+        content_by_lua '
+            local s, n = ngx.re.gsub("abcd", "a|(?=c)", ".", "")
+            if s then
+                ngx.say(s)
+            end
+        ';
+    }
+--- request
+    GET /re
+--- response_body
+.b.cd


### PR DESCRIPTION
ngx.re.gsub() will mistakenly swallow the character when 0-width match that happens to be the last match. 

To reproduce:

```
newstr, n, err = ngx.re.gsub('TestCase', '^ *', '', '')                                                                                                                                     
ngx.say(newstr)
```

Result: 

```
estCase
```
