### PR TITLE
sql quote str should convert ASCII 26 to \Z according to MySQL Manual

### DIFF
--- a/src/ngx_http_lua_string.c
+++ b/src/ngx_http_lua_string.c
@@ -285,7 +285,7 @@ ngx_http_lua_ngx_escape_sql_str(u_char *dst, u_char *src, size_t size)
 
                 case 26:
                     *dst++ = '\\';
-                    *dst++ = 'z';
+                    *dst++ = 'Z';
                     break;
 
                 case '\\':


### PR DESCRIPTION
SQL quote str should convert ASCII 26 to \Z according to MySQL Reference Manual, not \z. 
It may cause insert wrong binary data in MySQL 5 or above.

MySQL 4.x server is compatible with \z. 
But MySQL 5 is strictly following the standard. '\z' will convert to 'z', not ASCII 26.

3.x 4.x version Manual: http://dev.mysql.com/doc/refman/4.1/en/string-literals.html
5.7 version Manual: http://dev.mysql.com/doc/refman/5.7/en/string-literals.html
Thus manual never define \z, even 4.x version.