### PR TITLE
readme: add note on possible uninitialized variables in rewrite phase

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,6 +41,7 @@ Table of Contents
     * [Special PCRE Sequences](#special-pcre-sequences)
     * [Mixing with SSI Not Supported](#mixing-with-ssi-not-supported)
     * [SPDY Mode Not Fully Supported](#spdy-mode-not-fully-supported)
+    * [Missing data on short circuited requests](#missing-data-on-short-circuited-requests)
 * [TODO](#todo)
 * [Changes](#changes)
 * [Test Suite](#test-suite)
@@ -850,6 +851,27 @@ SPDY Mode Not Fully Supported
 -----------------------------
 
 Certain Lua APIs provided by ngx_lua do not work in Nginx's SPDY mode yet: [ngx.location.capture](#ngxlocationcapture), [ngx.location.capture_multi](#ngxlocationcapture_multi), and [ngx.req.socket](#ngxreqsocket).
+
+[Back to TOC](#table-of-contents)
+
+Missing data on short circuited requests
+----------------------------------------
+
+Nginx may terminate a request early with (at least):
+
+* `400 (Bad Request)`
+* `405 (Not Allowed)`
+* `408 (Request Timeout)`
+* `414 (Request URI Too Large)`
+* `494 (Request Headers Too Large)
+* `499 (Client Closed Request)`
+* `500 (Internal Server Error)`
+* `501 (Not Implemented)`
+
+This means that phases that normally run are skipped, such as the rewrite or
+access phase. This also means that later phases that are run regardless, e.g.
+`log_by_lua`, will not have access to information that is normally set in those
+phases.
 
 [Back to TOC](#table-of-contents)
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -700,6 +700,24 @@ Mixing SSI with ngx_lua in the same Nginx request is not supported at all. Just 
 
 Certain Lua APIs provided by ngx_lua do not work in Nginx's SPDY mode yet: [[#ngx.location.capture|ngx.location.capture]], [[#ngx.location.capture_multi|ngx.location.capture_multi]], and [[#ngx.req.socket|ngx.req.socket]].
 
+== Missing data on short circuited requests ==
+
+Nginx may terminate a request early with (at least):
+
+* `400 (Bad Request)`
+* `405 (Not Allowed)`
+* `408 (Request Timeout)`
+* `414 (Request URI Too Large)`
+* `494 (Request Headers Too Large)
+* `499 (Client Closed Request)`
+* `500 (Internal Server Error)`
+* `501 (Not Implemented)`
+
+This means that phases that normally run are skipped, such as the rewrite or
+access phase. This also means that later phases that are run regardless, e.g.
+`log_by_lua`, will not have access to information that is normally set in those
+phases.
+
 = TODO =
 
 * add <code>*_by_lua_block</code> directives for existing <code>*_by_lua</code> directives so that we put literal Lua code directly in curly braces instead of an nginx literal string. For example,


### PR DESCRIPTION
We noticed in production testing that some Nginx variables would be empty in some cases in the logging phase. Through investigation this seemed to be due to the possibility of Nginx short circuiting requests in `ngx_http_request.c`, meaning the rewrite phase would be skipped completely.

If we send a bad request, for example with an empty host header (`curl -H "Host: " localhost:80`), to a configuration that had something like:

```nginx
set $animal "walrus";
log_by_lua 'ngx.log(ngx.ERR, ngx.var.animal)';
```

We would get a warning that `ngx.var.animal` is uninitialized.

This is fairly painful to track down and not immediately obvious, so I thought it'd save someone some time by mentioning it in the `log_by_lua` documentation.