### PR TITLE
missing use lib

### DIFF
--- a/t/034-match.t
+++ b/t/034-match.t
@@ -1,5 +1,5 @@
 # vim:set ft= ts=4 sw=4 et fdm=marker:
-
+use lib 'lib';
 use Test::Nginx::Socket::Lua;
 
 #worker_connections(1014);

--- a/t/089-phase.t
+++ b/t/089-phase.t
@@ -1,5 +1,5 @@
 # vim:set ft= ts=4 sw=4 et fdm=marker:
-
+use lib 'lib';
 use Test::Nginx::Socket::Lua;
 
 #worker_connections(1014);

--- a/t/120-re-find.t
+++ b/t/120-re-find.t
@@ -1,5 +1,5 @@
 # vim:set ft= ts=4 sw=4 et fdm=marker:
-
+use lib 'lib';
 use Test::Nginx::Socket::Lua;
 
 #worker_connections(1014);

--- a/t/122-worker.t
+++ b/t/122-worker.t
@@ -1,5 +1,5 @@
 # vim:set ft= ts=4 sw=4 et fdm=marker:
-
+use lib 'lib';
 use Test::Nginx::Socket::Lua;
 
 #worker_connections(1014);

--- a/t/124-init-worker.t
+++ b/t/124-init-worker.t
@@ -1,5 +1,5 @@
 # vim:set ft= ts=4 sw=4 et fdm=marker:
-
+use lib 'lib';
 use Test::Nginx::Socket::Lua;
 
 #worker_connections(1014);


### PR DESCRIPTION
Some tests are missing use lib mantra.

You can check if use lib is missing:

```
grep -cr 'use lib' t|grep '\.t:'|grep -v :1
```
