### PR TITLE
fix env tests

### DIFF
--- a/t/123-lua-path.t
+++ b/t/123-lua-path.t
@@ -24,6 +24,10 @@ run_tests();
 __DATA__
 
 === TEST 1: LUA_PATH & LUA_CPATH env (code cache on)
+--- main_config
+env LUA_PATH;
+env LUA_CPATH;
+
 --- config
     location /lua {
         content_by_lua '
@@ -43,6 +47,10 @@ GET /lua
 
 
 === TEST 2: LUA_PATH & LUA_CPATH env (code cache off)
+--- main_config
+env LUA_PATH;
+env LUA_CPATH;
+
 --- config
     lua_code_cache off;
     location /lua {


### PR DESCRIPTION
In my nginx implementation only explicitly set envs are visible.

Other strategy is to handle this is to add these at Test::Nginx::Util write_config_file lines 814-815.