### PR TITLE
util: don't set content type header on 304

### DIFF
--- a/src/ngx_http_lua_util.h
+++ b/src/ngx_http_lua_util.h
@@ -379,7 +379,9 @@ ngx_http_lua_set_content_type(ngx_http_request_t *r)
     ngx_http_lua_loc_conf_t     *llcf;
 
     llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
-    if (llcf->use_default_type) {
+    if (llcf->use_default_type
+        && r->headers_out.status != NGX_HTTP_NOT_MODIFIED)
+    {
         return ngx_http_set_content_type(r);
     }
 

--- a/t/118-use-default-type.t
+++ b/t/118-use-default-type.t
@@ -120,3 +120,22 @@ hello
 --- no_error_log
 [error]
 
+
+
+=== TEST 6: lua_use_default_type on does not set content type on 304
+--- config
+    lua_use_default_type on;
+    location /lua {
+        default_type text/plain;
+        content_by_lua '
+            ngx.status = ngx.HTTP_NOT_MODIFIED
+        ';
+    }
+--- request
+GET /lua
+--- response_body
+--- response_headers
+!Content-Type
+--- no_error_log
+[error]
+--- error_code: 304


### PR DESCRIPTION
This is a violation of HTTP. 304 doesn't allow a body, and therefore should not specify the `Content-Type`. [`nginx` handles this situation correctly](https://github.com/nginx/nginx/blob/aa248e453fd0df9623d5da0f13727049e69e503d/src/http/modules/ngx_http_not_modified_filter_module.c#L96), however `ngx-lua` does not. It always sets it, even on empty responses. Note also that `nginx` [does the same thing in `ngx_http_special_response `](https://github.com/nginx/nginx/blob/aa248e453fd0df9623d5da0f13727049e69e503d/src/http/ngx_http_special_response.c#L402).

Some clients cope with this, others do not. Our symptom in production was that some users would hit a cached page and be prompted to download a file with a dialog (because our default type: `Content-Type: application/octet-stream`). We could only reproduce this for users behind the Squid proxy.

For now, we've just disabled `lua_use_default_type`. However, it seems to me that this is a bug in the `ngx-lua` defaults.

@agentzh 