### PR TITLE
fix ssl_cert_by_lua_file can't work correctly issue

### DIFF
--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -420,9 +420,9 @@ static ngx_command_t ngx_http_lua_cmds[] = {
       (void *) ngx_http_lua_ssl_cert_handler_inline },
 
     { ngx_string("ssl_certificate_by_lua_file"),
-      NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
       ngx_http_lua_ssl_cert_by_lua,
-      NGX_HTTP_LOC_CONF_OFFSET,
+      NGX_HTTP_SRV_CONF_OFFSET,
       0,
       (void *) ngx_http_lua_ssl_cert_handler_file },
 


### PR DESCRIPTION
ssl_certificate_by_lua_file directive can't work correctly in server {...}

the error log is like this:
```
2015/03/13 17:42:13 [emerg] 5271#0: "ssl_certificate_by_lua_file" directive is not allowed here 
```