### PR TITLE
bugfix: fixed compilation error when added `--with-threads`.

### DIFF
--- a/src/ddebug.h
+++ b/src/ddebug.h
@@ -9,6 +9,7 @@
 
 
 #include <nginx.h>
+#include <ngx_config.h>
 #include <ngx_core.h>
 
 

--- a/src/ngx_http_lua_socket_udp.c
+++ b/src/ngx_http_lua_socket_udp.c
@@ -1400,7 +1400,7 @@ ngx_http_lua_udp_connect(ngx_udp_connection_t *uc)
 
     c->number = ngx_atomic_fetch_add(ngx_connection_counter, 1);
 
-#if (NGX_THREADS)
+#if (NGX_OLD_THREADS)
 
     /* TODO: lock event when call completion handler */
 

--- a/src/ngx_http_lua_socket_udp.c
+++ b/src/ngx_http_lua_socket_udp.c
@@ -1400,7 +1400,8 @@ ngx_http_lua_udp_connect(ngx_udp_connection_t *uc)
 
     c->number = ngx_atomic_fetch_add(ngx_connection_counter, 1);
 
-#if (NGX_OLD_THREADS)
+#if ((nginx_version > 1007010) && (NGX_OLD_THREADS)) || \
+    ((nginx_version <= 1007010) && (NGX_THREADS))
 
     /* TODO: lock event when call completion handler */
 


### PR DESCRIPTION
From [r6016](http://hg.nginx.org/nginx/rev/457ec43dd8d5) and [r6018](http://hg.nginx.org/nginx/rev/466bd63b63d1), The compilation of `nginx` with `ngx_lua` fails when added `--with-threads`.

## compilation error 1

FYI, The compilations of [echo-nginx-module](https://github.com/openresty/echo-nginx-module) and [headers-more-nginx-module](https://github.com/openresty/headers-more-nginx-module) fail by the same issue also.

```
In file included from ../lua-nginx-module/src/ngx_http_lua_script.c:10:
In file included from ../lua-nginx-module/src/ddebug.h:12:
In file included from src/core/ngx_core.h:49:
src/os/unix/ngx_files.h:387:25: error: unknown type name 'ngx_thread_task_t'; did you mean 'ngx_thread_cond_t'?
ssize_t ngx_thread_read(ngx_thread_task_t **taskp, ngx_file_t *file,
                        ^~~~~~~~~~~~~~~~~
                        ngx_thread_cond_t
src/os/unix/ngx_thread.h:127:25: note: 'ngx_thread_cond_t' declared here
typedef pthread_cond_t  ngx_thread_cond_t;
                        ^
In file included from ../lua-nginx-module/src/ngx_http_lua_script.c:10:
In file included from ../lua-nginx-module/src/ddebug.h:12:
In file included from src/core/ngx_core.h:57:
src/core/ngx_buf.h:105:50: error: unknown type name 'ngx_thread_task_t'; did you mean 'ngx_thread_cond_t'?
    ngx_int_t                  (*thread_handler)(ngx_thread_task_t *task,
                                                 ^~~~~~~~~~~~~~~~~
                                                 ngx_thread_cond_t
src/os/unix/ngx_thread.h:127:25: note: 'ngx_thread_cond_t' declared here
typedef pthread_cond_t  ngx_thread_cond_t;
                        ^
In file included from ../lua-nginx-module/src/ngx_http_lua_script.c:10:
In file included from ../lua-nginx-module/src/ddebug.h:12:
In file included from src/core/ngx_core.h:57:
src/core/ngx_buf.h:107:5: error: unknown type name 'ngx_thread_task_t'; did you mean 'ngx_thread_cond_t'?
    ngx_thread_task_t           *thread_task;
    ^~~~~~~~~~~~~~~~~
    ngx_thread_cond_t
src/os/unix/ngx_thread.h:127:25: note: 'ngx_thread_cond_t' declared here
typedef pthread_cond_t  ngx_thread_cond_t;
                        ^
In file included from ../lua-nginx-module/src/ngx_http_lua_script.c:10:
In file included from ../lua-nginx-module/src/ddebug.h:12:
In file included from src/core/ngx_core.h:62:
src/core/ngx_file.h:27:48: error: unknown type name 'ngx_thread_task_t'; did you mean 'ngx_thread_cond_t'?
    ngx_int_t                (*thread_handler)(ngx_thread_task_t *task,
                                               ^~~~~~~~~~~~~~~~~
                                               ngx_thread_cond_t
src/os/unix/ngx_thread.h:127:25: note: 'ngx_thread_cond_t' declared here
typedef pthread_cond_t  ngx_thread_cond_t;

In file included from ../lua-nginx-module/src/ngx_http_lua_script.c:10:
In file included from ../lua-nginx-module/src/ddebug.h:12:
In file included from src/core/ngx_core.h:83:
src/core/ngx_connection.h:188:5: error: unknown type name 'ngx_thread_task_t'; did you mean 'ngx_thread_cond_t'?
    ngx_thread_task_t  *sendfile_task;
    ^~~~~~~~~~~~~~~~~
    ngx_thread_cond_t
src/os/unix/ngx_thread.h:127:25: note: 'ngx_thread_cond_t' declared here
typedef pthread_cond_t  ngx_thread_cond_t;
                        ^
In file included from ../lua-nginx-module/src/ngx_http_lua_script.c:13:
In file included from ../lua-nginx-module/src/ngx_http_lua_script.h:11:
In file included from ../lua-nginx-module/src/ngx_http_lua_common.h:14:
In file included from src/http/ngx_http.h:40:
In file included from src/http/ngx_http_core_module.h:17:
src/core/ngx_thread_pool.h:18:5: error: unknown type name 'ngx_thread_task_t'; did you mean 'ngx_thread_cond_t'?
    ngx_thread_task_t   *next;
    ^~~~~~~~~~~~~~~~~
    ngx_thread_cond_t
src/os/unix/ngx_thread.h:127:25: note: 'ngx_thread_cond_t' declared here
typedef pthread_cond_t  ngx_thread_cond_t;
                        ^
In file included from ../lua-nginx-module/src/ngx_http_lua_script.c:13:
In file included from ../lua-nginx-module/src/ngx_http_lua_script.h:11:
In file included from ../lua-nginx-module/src/ngx_http_lua_common.h:14:
In file included from src/http/ngx_http.h:40:
In file included from src/http/ngx_http_core_module.h:17:
src/core/ngx_thread_pool.h:32:1: error: unknown type name 'ngx_thread_task_t'
ngx_thread_task_t *ngx_thread_task_alloc(ngx_pool_t *pool, size_t size);
^
src/core/ngx_thread_pool.h:33:55: error: unknown type name 'ngx_thread_task_t'
ngx_int_t ngx_thread_task_post(ngx_thread_pool_t *tp, ngx_thread_task_t *task);
                                                      ^
8 errors generated.
make[1]: *** [objs/addon/src/ngx_http_lua_script.o] Error 1
make: *** [build] Error 2
```

## compilation error 2

```
../lua-nginx-module/src/ngx_http_lua_socket_udp.c:1407:10: error: no member named 'lock' in 'struct ngx_event_s'
rev->lock = &c->lock;
~~~  ^
../lua-nginx-module/src/ngx_http_lua_socket_udp.c:1407:21: error: no member named 'lock' in 'struct ngx_connection_s'
rev->lock = &c->lock;
~  ^
../lua-nginx-module/src/ngx_http_lua_socket_udp.c:1408:10: error: no member named 'lock' in 'struct ngx_event_s'
wev->lock = &c->lock;
~~~  ^
../lua-nginx-module/src/ngx_http_lua_socket_udp.c:1408:21: error: no member named 'lock' in 'struct ngx_connection_s'
wev->lock = &c->lock;
~  ^
../lua-nginx-module/src/ngx_http_lua_socket_udp.c:1409:10: error: no member named 'own_lock' in 'struct ngx_event_s'
rev->own_lock = &c->lock;
~~~  ^
../lua-nginx-module/src/ngx_http_lua_socket_udp.c:1409:25: error: no member named 'lock' in 'struct ngx_connection_s'
rev->own_lock = &c->lock;
~  ^
../lua-nginx-module/src/ngx_http_lua_socket_udp.c:1410:10: error: no member named 'own_lock' in 'struct ngx_event_s'
wev->own_lock = &c->lock;
~~~  ^
../lua-nginx-module/src/ngx_http_lua_socket_udp.c:1410:25: error: no member named 'lock' in 'struct ngx_connection_s'
    wev->own_lock = &c->lock;
```