### PR TITLE
ngx.thread.kill - give all threads the permissions to kill each other

### DIFF
--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -268,6 +268,7 @@ typedef struct ngx_http_lua_posted_thread_s  ngx_http_lua_posted_thread_t;
 
 struct ngx_http_lua_posted_thread_s {
     ngx_http_lua_co_ctx_t               *co_ctx;
+    ngx_int_t                            nrets;
     ngx_http_lua_posted_thread_t        *next;
 };
 

--- a/src/ngx_http_lua_uthread.c
+++ b/src/ngx_http_lua_uthread.c
@@ -242,6 +242,12 @@ ngx_http_lua_uthread_kill(lua_State *L)
         return 2;
     }
 
+    if (ctx->cur_co_ctx == sub_coctx) {
+        lua_pushnil(L);
+        lua_pushliteral(L, "not allowed to kill self");
+        return 2;
+    }
+
     if (sub_coctx->pending_subreqs > 0) {
         lua_pushnil(L);
         lua_pushliteral(L, "pending subrequests");

--- a/src/ngx_http_lua_uthread.c
+++ b/src/ngx_http_lua_uthread.c
@@ -209,7 +209,7 @@ ngx_http_lua_uthread_kill(lua_State *L)
     lua_State                   *parent_co;
     ngx_http_request_t          *r;
     ngx_http_lua_ctx_t          *ctx;
-    ngx_http_lua_co_ctx_t       *coctx, *sub_coctx;
+    ngx_http_lua_co_ctx_t       *sub_coctx;
     ngx_http_lua_co_ctx_t       *parent_coctx;
 
     r = ngx_http_lua_get_req(L);
@@ -226,8 +226,6 @@ ngx_http_lua_uthread_kill(lua_State *L)
                                | NGX_HTTP_LUA_CONTEXT_ACCESS
                                | NGX_HTTP_LUA_CONTEXT_CONTENT
                                | NGX_HTTP_LUA_CONTEXT_TIMER);
-
-    coctx = ctx->cur_co_ctx;
 
     sub_co = lua_tothread(L, 1);
     luaL_argcheck(L, sub_co, 1, "lua thread expected");

--- a/src/ngx_http_lua_uthread.c
+++ b/src/ngx_http_lua_uthread.c
@@ -242,12 +242,6 @@ ngx_http_lua_uthread_kill(lua_State *L)
         return 2;
     }
 
-    if (sub_coctx->parent_co_ctx != coctx) {
-        lua_pushnil(L);
-        lua_pushliteral(L, "killer not parent");
-        return 2;
-    }
-
     if (sub_coctx->pending_subreqs > 0) {
         lua_pushnil(L);
         lua_pushliteral(L, "pending subrequests");

--- a/src/ngx_http_lua_uthread.c
+++ b/src/ngx_http_lua_uthread.c
@@ -89,7 +89,7 @@ ngx_http_lua_uthread_spawn(lua_State *L)
 
     ctx->cur_co_ctx->thread_spawn_yielded = 1;
 
-    if (ngx_http_lua_post_thread(r, ctx, ctx->cur_co_ctx) != NGX_OK) {
+    if (ngx_http_lua_post_thread(r, ctx, ctx->cur_co_ctx, 0) != NGX_OK) {
         return luaL_error(L, "no memory");
     }
 
@@ -206,9 +206,11 @@ static int
 ngx_http_lua_uthread_kill(lua_State *L)
 {
     lua_State                   *sub_co;
+    lua_State                   *parent_co;
     ngx_http_request_t          *r;
     ngx_http_lua_ctx_t          *ctx;
     ngx_http_lua_co_ctx_t       *coctx, *sub_coctx;
+    ngx_http_lua_co_ctx_t       *parent_coctx;
 
     r = ngx_http_lua_get_req(L);
     if (r == NULL) {
@@ -266,6 +268,15 @@ ngx_http_lua_uthread_kill(lua_State *L)
         ngx_http_lua_cleanup_pending_operation(sub_coctx);
         ngx_http_lua_del_thread(r, L, ctx, sub_coctx);
         ctx->uthreads--;
+
+        /* notify the parent that the thread was killed */
+        parent_coctx = sub_coctx->parent_co_ctx;
+        if (sub_coctx->waited_by_parent && parent_coctx) {
+            parent_co = parent_coctx->co;
+            lua_pushboolean(parent_co, 0);
+            lua_pushstring(parent_co, "user thread killed");
+            ngx_http_lua_post_thread(r, ctx, parent_coctx, 2);
+        }
 
         lua_pushinteger(L, 1);
         return 1;

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -1123,7 +1123,7 @@ ngx_http_lua_run_thread(lua_State *L, ngx_http_request_t *r,
                         ctx->cur_co_ctx->co_status = NGX_HTTP_LUA_CO_RUNNING;
 
                         if (ctx->posted_threads) {
-                            ngx_http_lua_post_thread(r, ctx, ctx->cur_co_ctx);
+                            ngx_http_lua_post_thread(r, ctx, ctx->cur_co_ctx, 0);
                             ctx->cur_co_ctx = NULL;
                             return NGX_AGAIN;
                         }
@@ -3050,7 +3050,7 @@ ngx_http_lua_run_posted_threads(ngx_connection_t *c, lua_State *L,
 
         ctx->cur_co_ctx = pt->co_ctx;
 
-        rc = ngx_http_lua_run_thread(L, r, ctx, 0);
+        rc = ngx_http_lua_run_thread(L, r, ctx, pt->nrets);
 
         if (rc == NGX_AGAIN) {
             continue;
@@ -3076,7 +3076,7 @@ ngx_http_lua_run_posted_threads(ngx_connection_t *c, lua_State *L,
 
 ngx_int_t
 ngx_http_lua_post_thread(ngx_http_request_t *r, ngx_http_lua_ctx_t *ctx,
-    ngx_http_lua_co_ctx_t *coctx)
+    ngx_http_lua_co_ctx_t *coctx, ngx_int_t nrets)
 {
     ngx_http_lua_posted_thread_t  **p;
     ngx_http_lua_posted_thread_t   *pt;
@@ -3087,6 +3087,7 @@ ngx_http_lua_post_thread(ngx_http_request_t *r, ngx_http_lua_ctx_t *ctx,
     }
 
     pt->co_ctx = coctx;
+    pt->nrets = nrets;
     pt->next = NULL;
 
     for (p = &ctx->posted_threads; *p; p = &(*p)->next) { /* void */ }

--- a/src/ngx_http_lua_util.h
+++ b/src/ngx_http_lua_util.h
@@ -197,7 +197,7 @@ ngx_int_t ngx_http_lua_run_posted_threads(ngx_connection_t *c, lua_State *L,
     ngx_http_request_t *r, ngx_http_lua_ctx_t *ctx);
 
 ngx_int_t ngx_http_lua_post_thread(ngx_http_request_t *r,
-    ngx_http_lua_ctx_t *ctx, ngx_http_lua_co_ctx_t *coctx);
+    ngx_http_lua_ctx_t *ctx, ngx_http_lua_co_ctx_t *coctx, ngx_int_t nrets);
 
 void ngx_http_lua_del_thread(ngx_http_request_t *r, lua_State *L,
     ngx_http_lua_ctx_t *ctx, ngx_http_lua_co_ctx_t *coctx);


### PR DESCRIPTION
Removed the restriction that only a parent of a thread can kill it, making the ngx.thread.kill API a bit more like the UNIX-style interface. In my code, I have a case in which a thread should kill another (non child) thread.
