### PR TITLE
Update builtin nginx headers

### DIFF
--- a/src/ngx_http_lua_headers_in.c
+++ b/src/ngx_http_lua_headers_in.c
@@ -67,6 +67,18 @@ static ngx_http_lua_set_header_t  ngx_http_lua_set_handlers[] = {
                  offsetof(ngx_http_headers_in_t, if_modified_since),
                  ngx_http_set_builtin_header },
 
+    { ngx_string("If-Unmodified-Since"),
+                 offsetof(ngx_http_headers_in_t, if_unmodified_since),
+                 ngx_http_set_builtin_header },
+
+    { ngx_string("If-Match"),
+                 offsetof(ngx_http_headers_in_t, if_match),
+                 ngx_http_set_builtin_header },
+
+    { ngx_string("If-None-Match"),
+                 offsetof(ngx_http_headers_in_t, if_none_match),
+                 ngx_http_set_builtin_header },
+
     { ngx_string("User-Agent"),
                  offsetof(ngx_http_headers_in_t, user_agent),
                  ngx_http_set_user_agent_header },
@@ -93,6 +105,10 @@ static ngx_http_lua_set_header_t  ngx_http_lua_set_handlers[] = {
 
     { ngx_string("Expect"),
                  offsetof(ngx_http_headers_in_t, expect),
+                 ngx_http_set_builtin_header },
+
+    { ngx_string("Upgrade"),
+                 offsetof(ngx_http_headers_in_t, upgrade),
                  ngx_http_set_builtin_header },
 
     { ngx_string("Authorization"),


### PR DESCRIPTION
The following built-in headers will now be set in Nginx - `If-Unmodified-Since`, `If-Match`, `If-None-Match`, `Upgrade` and `X-Forwarded-For` (if X-Forwarded-For is enabled in compile time).

Note that the following built-in headers will still not be set by this patch:
* `Accept`, `Accept-Language` - it seems that there is not use in the built-in field in Nginx's source code, and so there's no way to test that (and it seems irrelevant anyway).
* The WebDAV headers `Depth`, `Destination`, `Overwrite` and `Date`.

@agentzh , notice that this patch includes a change in the function that sets the cookies header - it has been generalized to support all multiline built-in headers. I've verified that all the cookies header test pass.

Also, added tests to set and clear the headers that were added.

This patch should resolve issue #482.