### PR TITLE
doc: fixed the context for the lua_need_request_body.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2001,7 +2001,7 @@ lua_need_request_body
 
 **default:** *off*
 
-**context:** *http | server | location | location if*
+**context:** *http, server, location, location if*
 
 **phase:** *depends on usage*
 

--- a/README.markdown
+++ b/README.markdown
@@ -2001,7 +2001,7 @@ lua_need_request_body
 
 **default:** *off*
 
-**context:** *main | server | location*
+**context:** *http | server | location | location if*
 
 **phase:** *depends on usage*
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -1680,7 +1680,7 @@ This directive was first introduced in the <code>v0.5.0rc31</code> release.
 
 '''default:''' ''off''
 
-'''context:''' ''main | server | location''
+'''context:''' ''http, server, location, location if''
 
 '''phase:''' ''depends on usage''
 


### PR DESCRIPTION
`lua_need_request body` directive is defined as the following code.

```c
    { ngx_string("lua_need_request_body"),
      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
                        |NGX_CONF_FLAG,
      ngx_conf_set_flag_slot,
      NGX_HTTP_LOC_CONF_OFFSET,
      offsetof(ngx_http_lua_loc_conf_t, force_read_body),
      NULL },
```