### PR TITLE
Discard request-body if it's not read at all.

### DIFF
--- a/src/ngx_http_lua_contentby.c
+++ b/src/ngx_http_lua_contentby.c
@@ -103,6 +103,14 @@ ngx_http_lua_content_by_chunk(lua_State *L, ngx_http_request_t *r)
     rc = ngx_http_lua_run_thread(L, r, ctx, 0);
 
     if (rc == NGX_ERROR || rc >= NGX_OK) {
+        if (r->keepalive &&
+            (rc == NGX_OK ||
+            (rc < NGX_HTTP_SPECIAL_RESPONSE && rc >= NGX_HTTP_OK))) {
+            /* need to discard the request body (if any) if the return code
+             * indicates the request was successfully fullfilled.
+             */
+            return ngx_http_discard_request_body(r);
+        }
         return rc;
     }
 

--- a/t/044-req-body.t
+++ b/t/044-req-body.t
@@ -8,7 +8,7 @@ log_level('warn');
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 4 + 35);
+plan tests => repeat_each() * (blocks() * 4 + 33);
 
 #no_diff();
 no_long_string();
@@ -159,11 +159,8 @@ hiya, world"]
 hello, world",
 "POST /bar
 hiya, world"]
---- response_body eval
-["body: nil\n",
-qr/400 Bad Request/]
 --- error_code eval
-[200, 400]
+[200, 200]
 --- no_error_log
 [error]
 [alert]
@@ -1481,4 +1478,65 @@ Will you change this world?
 --- no_error_log
 [error]
 [alert]
+
+
+
+=== TEST 45: content_by_lua quit normally
+--- config
+    location /t {
+        content_by_lua '
+            ngx.exit(200)
+        ';
+    }
+
+--- pipelined_requests eval
+[
+"POST /t
+hello",
+"POST /t
+world"
+]
+--- response_body eval
+["",
+""]
+
+=== TEST 46: content_by_lua quit normally
+--- config
+    location /t {
+        content_by_lua '
+            return
+        ';
+    }
+
+--- pipelined_requests eval
+[
+"POST /t
+hello",
+"POST /t
+world"
+]
+--- response_body eval
+["",
+""]
+
+=== TEST 47: access_by_lua early abort
+-- ONLY
+--- config
+    location /t {
+        access_by_lua '
+            --ngx.req.read_body()
+            ngx.exit(200)
+        ';
+    }
+
+--- pipelined_requests eval
+[
+"POST /t
+hello",
+"POST /t
+world"
+]
+--- response_body eval
+["",
+""]
 


### PR DESCRIPTION
This is necessary in the case of pipelined request; the un-discarded request-body would otherwise linger to the next request, and will be mistakenly recognized as part of the header of the next pipelined request.

This change is to explicitly discard request-body for two directives: access_by_lua and content_by_lua. It leave out two situations without fixed: when the directive handler returns NGX_DONE and NGX_EAGAIN. Quite honestly, I don't know for sure how to fix right at this moment. But I think I catch the most common cases.