### PR TITLE
Handle changed function name in nginx > 1.9.0

### DIFF
--- a/src/ngx_http_lua_initworkerby.c
+++ b/src/ngx_http_lua_initworkerby.c
@@ -225,9 +225,13 @@ ngx_http_lua_init_worker(ngx_cycle_t *cycle)
 
     clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
 
-#if defined(nginx_version) && nginx_version >= 1003014
+#if defined(nginx_version) && nginx_version >= 1003014 && nginx_version < 1009000
 
     ngx_http_set_connection_log(r->connection, clcf->error_log);
+
+#elseif defined(nginx_version) && nginx_version >= 1009000
+
+    ngx_set_connection_log(r->connection, clcf->error_log);
 
 #else
 

--- a/src/ngx_http_lua_timer.c
+++ b/src/ngx_http_lua_timer.c
@@ -348,9 +348,13 @@ ngx_http_lua_timer_handler(ngx_event_t *ev)
 
     clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
 
-#if defined(nginx_version) && nginx_version >= 1003014
+#if defined(nginx_version) && nginx_version >= 1003014 && nginx_version < 1009000
 
     ngx_http_set_connection_log(r->connection, clcf->error_log);
+
+#elseif defined(nginx_version) && nginx_version >= 1009000
+
+    ngx_set_connection_log(r->connection, clcf->error_log);
 
 #else
 


### PR DESCRIPTION
It looks like in nginx 1.9.0, the function

`ngx_http_set_connection_log(c, log);`

was changed to

`ngx_set_connection_log(c, log);`

This is just a quick patch to compensate for that so it will compile. I *think* I've done the right thing to make it still build properly on older versions but please sanity check that for me.

If this is right, I think it should close #501.