### PR TITLE
Support for dynamic generated certificates

### DIFF
--- a/lua/ngx/ssl.lua
+++ b/lua/ngx/ssl.lua
@@ -19,9 +19,11 @@ local FFI_DECLINED = base.FFI_DECLINED
 
 
 ffi.cdef[[
-
 struct ngx_ssl_conn_s;
 typedef struct ngx_ssl_conn_s  ngx_ssl_conn_t;
+
+struct csr_info { const unsigned char *common_name, *country, *state, *city, *organisation; };
+typedef struct csr_info csr_info_t;
 
 int ngx_http_lua_ffi_ssl_set_der_certificate(ngx_http_request_t *r,
     const char *data, size_t len, char **err);
@@ -47,6 +49,13 @@ int ngx_http_lua_ffi_ssl_get_ocsp_responder_from_der_chain(
 int ngx_http_lua_ffi_ssl_create_ocsp_request(const char *chain_data,
     size_t chain_len, unsigned char *out, size_t *out_size, char **err);
 
+int ngx_http_lua_ffi_ssl_rsa_generate_key(int bits, unsigned char *out, size_t *out_size, char **err);
+
+int ngx_http_lua_ffi_ssl_generate_certificate_sign_request(const char *data,
+    size_t data_len, csr_info_t* info, unsigned char *out, size_t *out_size, char **err);
+
+int ngx_http_lua_ffi_ssl_sign_certificate_sign_request(const char *cadata,
+    size_t calen, const char* csr, size_t csrlen, unsigned char *out, size_t *out_size, char **err);
 int ngx_http_lua_ffi_ssl_validate_ocsp_response(const unsigned char *resp,
     size_t resp_len, const char *chain_data, size_t chain_len,
     unsigned char *errbuf, size_t *errbuf_size);
@@ -208,6 +217,92 @@ function _M.get_ocsp_responder_from_der_chain(data, maxlen)
     return nil, ffi_str(errmsg[0])
 end
 
+
+function _M.rsa_generate_key(bits)
+    if not bits then
+        bits = 4096
+    end
+
+    local buf_size = maxlen
+    if not buf_size then
+        buf_size = get_string_buf_size()
+    end
+
+    local buf = get_string_buf(buf_size)
+
+    local sizep = get_size_ptr()
+    sizep[0] = buf_size
+
+    local rc = C.ngx_http_lua_ffi_ssl_rsa_generate_key(bits, buf, sizep, errmsg);
+
+    if rc == FFI_OK then
+        return ffi_str(buf, sizep[0])
+    elseif rc == FFI_BUSY then
+        return nil, ffi_str(errmsg[0]) .. ": "
+        .. tonumber(sizep[0])
+        .. " > " .. buf_size
+    else
+        return nil, ffi_str(errmsg[0])
+    end
+end
+
+function _M.generate_certificate_sign_request(data, args)
+    local buf_size = maxlen
+    if not buf_size then
+        buf_size = get_string_buf_size()
+    end
+
+    local buf = get_string_buf(buf_size)
+
+    local sizep = get_size_ptr()
+    sizep[0] = buf_size
+
+    local csr_info = ffi.new ('struct csr_info', {
+        common_name = args.common_name,
+        country = args.country,
+        state = args.state,
+        city = args.city,
+        organisation = args.organisation
+    })
+
+    local rc = C.ngx_http_lua_ffi_ssl_generate_certificate_sign_request(data,
+        #data, csr_info, buf, sizep,
+        errmsg)
+
+    if rc == FFI_OK then
+        return ffi_str(buf, sizep[0])
+    elseif rc == FFI_BUSY then
+        return nil, ffi_str(errmsg[0]) .. ": "
+            .. tonumber(sizep[0])
+            .. " > " .. buf_size
+    else
+        return nil, ffi_str(errmsg[0])
+    end
+end
+
+function _M.sign_csr(args)
+    local buf_size = maxlen
+    if not buf_size then
+        buf_size = get_string_buf_size()
+    end
+
+    local buf = get_string_buf(buf_size)
+
+    local sizep = get_size_ptr()
+    sizep[0] = buf_size
+
+    local rc = C.ngx_http_lua_ffi_ssl_sign_certificate_sign_request(args.ca, #args.ca, args.csr, #args.csr, buf, sizep, errmsg)
+
+    if rc == FFI_OK then
+        return ffi_str(buf, sizep[0])
+    elseif rc == FFI_BUSY then
+        return nil, ffi_str(errmsg[0]) .. ": "
+            .. tonumber(sizep[0])
+            .. " > " .. buf_size
+    else
+        return nil, ffi_str(errmsg[0])
+    end
+end
 
 function _M.create_ocsp_request(data, maxlen)
 

--- a/src/ngx_http_lua_sslcertby.h
+++ b/src/ngx_http_lua_sslcertby.h
@@ -20,6 +20,13 @@ typedef struct {
     unsigned                 aborted;    /* :1 */
 } ngx_http_lua_ssl_cert_ctx_t;
 
+typedef struct {
+	const unsigned char *common_name;
+	const unsigned char *country;
+	const unsigned char *state;
+	const unsigned char *city;
+	const unsigned char *organisation;
+} csr_info_t;
 
 ngx_int_t ngx_http_lua_ssl_cert_handler_inline(ngx_http_request_t *r,
     ngx_http_lua_srv_conf_t *lscf, lua_State *L);


### PR DESCRIPTION
Dynamic generated certificates can be used to generate ca signed
certificates on each SSL request. Allowing to filter requests and
responses.

See example config at:
http://blog.dutchcoders.io/openresty-with-dynamic-generated-certificates/
