### PR TITLE
Fix built-in response headers not being accessible via lowercase (ngx.resp.get_headers)

### DIFF
--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -488,7 +488,7 @@ ngx_http_lua_ngx_resp_get_headers(lua_State *L)
 
 #if 1
     if (r->headers_out.content_type.len) {
-        lua_pushliteral(L, "Content-Type");
+        lua_pushliteral(L, "content-type");
         lua_pushlstring(L, (char *) r->headers_out.content_type.data,
                         r->headers_out.content_type.len);
         lua_rawset(L, -3);
@@ -497,12 +497,12 @@ ngx_http_lua_ngx_resp_get_headers(lua_State *L)
     if (r->headers_out.content_length == NULL
         && r->headers_out.content_length_n >= 0)
     {
-        lua_pushliteral(L, "Content-Length");
+        lua_pushliteral(L, "content-length");
         lua_pushfstring(L, "%d", (int) r->headers_out.content_length_n);
         lua_rawset(L, -3);
     }
 
-    lua_pushliteral(L, "Connection");
+    lua_pushliteral(L, "connection");
     if (r->headers_out.status == NGX_HTTP_SWITCHING_PROTOCOLS) {
         lua_pushliteral(L, "upgrade");
 
@@ -515,7 +515,7 @@ ngx_http_lua_ngx_resp_get_headers(lua_State *L)
     lua_rawset(L, -3);
 
     if (r->chunked) {
-        lua_pushliteral(L, "Transfer-Encoding");
+        lua_pushliteral(L, "transfer-encoding");
         lua_pushliteral(L, "chunked");
         lua_rawset(L, -3);
     }

--- a/t/016-resp-header.t
+++ b/t/016-resp-header.t
@@ -9,7 +9,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 3 + 26);
+plan tests => repeat_each() * (blocks() * 3 + 34);
 
 #no_diff();
 no_long_string();
@@ -1237,6 +1237,8 @@ bar: baz
         header_filter_by_lua '
             local hs = ngx.resp.get_headers()
             print("my Content-Type: ", hs["Content-Type"])
+            print("my content-type: ", hs["content-type"])
+            print("my content_type: ", hs["content_type"])
         ';
     }
 --- request
@@ -1248,6 +1250,8 @@ hi
 [alert]
 --- error_log
 my Content-Type: text/plain
+my content-type: text/plain
+my content_type: text/plain
 
 
 
@@ -1262,6 +1266,8 @@ my Content-Type: text/plain
         header_filter_by_lua '
             local hs = ngx.resp.get_headers()
             print("my Content-Length: ", hs["Content-Length"])
+            print("my content-length: ", hs["content-length"])
+            print("my content_length: ", hs.content_length)
         ';
     }
 --- request
@@ -1273,6 +1279,8 @@ hi
 [alert]
 --- error_log
 my Content-Length: 3
+my content-length: 3
+my content_length: 3
 
 
 
@@ -1287,6 +1295,7 @@ my Content-Length: 3
         header_filter_by_lua '
             local hs = ngx.resp.get_headers()
             print("my Connection: ", hs["Connection"])
+            print("my connection: ", hs["connection"])
         ';
     }
 --- request
@@ -1298,6 +1307,7 @@ hi
 [alert]
 --- error_log
 my Connection: close
+my connection: close
 
 
 
@@ -1312,6 +1322,8 @@ my Connection: close
         body_filter_by_lua '
             local hs = ngx.resp.get_headers()
             print("my Transfer-Encoding: ", hs["Transfer-Encoding"])
+            print("my transfer-encoding: ", hs["transfer-encoding"])
+            print("my transfer_encoding: ", hs.transfer_encoding)
         ';
     }
 --- request
@@ -1323,6 +1335,7 @@ hi
 [alert]
 --- error_log
 my Transfer-Encoding: chunked
+my transfer-encoding: chunked
 
 
 
@@ -1337,6 +1350,8 @@ my Transfer-Encoding: chunked
         body_filter_by_lua '
             local hs = ngx.resp.get_headers()
             print("my Transfer-Encoding: ", hs["Transfer-Encoding"])
+            print("my transfer-encoding: ", hs["transfer-encoding"])
+            print("my transfer_encoding: ", hs.transfer_encoding)
         ';
     }
 --- request
@@ -1348,6 +1363,8 @@ hi
 [alert]
 --- error_log
 my Transfer-Encoding: nil
+my transfer-encoding: nil
+my transfer_encoding: nil
 
 
 


### PR DESCRIPTION
While most response headers were accessible via the original case or normalized lowercase (for example, `ngx.resp.get_headers()["Foo"]` and `ngx.resp.get_headers()["foo"]`), there were several built-in headers that were not available when trying to access the normalized, lowercase version of these headers. These special built-in headers were:

- Content-Length
- Content-Type
- Connection
- Transfer-Encoding

This fixes the issue so these response headers are available via both title case and now lowercase to match the behavior of the other response headers.

I wasn't able to get the full openresty test suite running locally, so hopefully this hasn't inadvertently affected anything else, but I was at least able to get the `t/016-resp-header.t` test suite running and passing with the additional tests added for this.

And this is based on the assumption that these headers should be accessible via lowercase or underscored names, as the [`ngx.req.get_headers`](https://github.com/openresty/lua-nginx-module#ngxreqget_headers) docs indicate all headers should be (but if this assumption is incorrect, just let me know).