### PR TITLE
doc fix: ngx.exit is not disabled within header_filter_by_lua

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1770,7 +1770,7 @@ Uses Lua code specified in `<lua-script-str>` to define an output header filter.
 Note that the following API functions are currently disabled within this context:
 
 * Output API functions (e.g., [ngx.say](#ngxsay) and [ngx.send_headers](#ngxsend_headers))
-* Control API functions (e.g., [ngx.exit](#ngxexit) and [ngx.exec](#ngxexec))
+* Control API functions (e.g., [ngx.redirect](#ngxredirect) and [ngx.exec](#ngxexec))
 * Subrequest API functions (e.g., [ngx.location.capture](#ngxlocationcapture) and [ngx.location.capture_multi](#ngxlocationcapture_multi))
 * Cosocket API functions (e.g., [ngx.socket.tcp](#ngxsockettcp) and [ngx.req.socket](#ngxreqsocket)).
 


### PR DESCRIPTION
I have checked the code also.