### PR TITLE
timer: expose pending and running counts

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2509,6 +2509,8 @@ Nginx API for Lua
 * [ngx.thread.kill](#ngxthreadkill)
 * [ngx.on_abort](#ngxon_abort)
 * [ngx.timer.at](#ngxtimerat)
+* [ngx.timer.running_count](#ngxtimerrunning_count)
+* [ngx.timer.pending_count](#ngxtimerpending_count)
 * [ngx.config.debug](#ngxconfigdebug)
 * [ngx.config.prefix](#ngxconfigprefix)
 * [ngx.config.nginx_version](#ngxconfignginx_version)
@@ -6753,6 +6755,30 @@ this context.
 You can pass most of the standard Lua values (nils, booleans, numbers, strings, tables, closures, file handles, and etc) into the timer callback, either explicitly as user arguments or implicitly as upvalues for the callback closure. There are several exceptions, however: you *cannot* pass any thread objects returned by [coroutine.create](#coroutinecreate) and [ngx.thread.spawn](#ngxthreadspawn) or any cosocket objects returned by [ngx.socket.tcp](#ngxsockettcp), [ngx.socket.udp](#ngxsocketudp), and [ngx.req.socket](#ngxreqsocket) because these objects' lifetime is bound to the request context creating them while the timer callback is detached from the creating request's context (by design) and runs in its own (fake) request context. If you try to share the thread or cosocket objects across the boundary of the creating request, then you will get the "no co ctx found" error (for threads) or "bad request" (for cosockets). It is fine, however, to create all these objects inside your timer callback.
 
 This API was first introduced in the `v0.8.0` release.
+
+[Back to TOC](#nginx-api-for-lua)
+
+ngx.timer.running_count
+-----------------------
+**syntax:** *count = ngx.timer.running_count()*
+
+**context:** *init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
+
+Returns the number of timers currently running.
+
+This directive was first introduced in the `v0.9.17` release.
+
+[Back to TOC](#nginx-api-for-lua)
+
+ngx.timer.pending_count
+-----------------------
+**syntax:** *count = ngx.timer.pending_count()*
+
+**context:** *init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
+
+Returns the number of pending timers.
+
+This directive was first introduced in the `v0.9.17` release.
 
 [Back to TOC](#nginx-api-for-lua)
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -5736,6 +5736,24 @@ You can pass most of the standard Lua values (nils, booleans, numbers, strings, 
 
 This API was first introduced in the <code>v0.8.0</code> release.
 
+== ngx.timer.running_count ==
+'''syntax:''' ''count = ngx.timer.running_count()''
+
+'''context:''' ''init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*''
+
+Returns the number of timers currently running.
+
+This directive was first introduced in the <code>v0.9.17</code> release.
+
+== ngx.timer.pending_count ==
+'''syntax:''' ''count = ngx.timer.pending_count()''
+
+'''context:''' ''init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*''
+
+Returns the number of pending timers.
+
+This directive was first introduced in the <code>v0.9.17</code> release.
+
 == ngx.config.debug ==
 '''syntax:''' ''debug = ngx.config.debug''
 

--- a/src/ngx_http_lua_timer.c
+++ b/src/ngx_http_lua_timer.c
@@ -40,6 +40,8 @@ typedef struct {
 
 
 static int ngx_http_lua_ngx_timer_at(lua_State *L);
+static int ngx_http_lua_ngx_timer_running_count(lua_State *L);
+static int ngx_http_lua_ngx_timer_pending_count(lua_State *L);
 static void ngx_http_lua_timer_handler(ngx_event_t *ev);
 static u_char *ngx_http_lua_log_timer_error(ngx_log_t *log, u_char *buf,
     size_t len);
@@ -49,12 +51,56 @@ static void ngx_http_lua_abort_pending_timers(ngx_event_t *ev);
 void
 ngx_http_lua_inject_timer_api(lua_State *L)
 {
-    lua_createtable(L, 0 /* narr */, 1 /* nrec */);    /* ngx.timer. */
+    lua_createtable(L, 0 /* narr */, 3 /* nrec */);    /* ngx.timer. */
 
     lua_pushcfunction(L, ngx_http_lua_ngx_timer_at);
     lua_setfield(L, -2, "at");
 
+    lua_pushcfunction(L, ngx_http_lua_ngx_timer_running_count);
+    lua_setfield(L, -2, "running_count");
+
+    lua_pushcfunction(L, ngx_http_lua_ngx_timer_pending_count);
+    lua_setfield(L, -2, "pending_count");
+
     lua_setfield(L, -2, "timer");
+}
+
+
+static int
+ngx_http_lua_ngx_timer_running_count(lua_State *L)
+{
+    ngx_http_request_t          *r;
+    ngx_http_lua_main_conf_t    *lmcf;
+
+    r = ngx_http_lua_get_req(L);
+    if (r == NULL) {
+        return luaL_error(L, "no request");
+    }
+
+    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
+
+    lua_pushnumber(L, lmcf->running_timers);
+
+    return 1;
+}
+
+
+static int
+ngx_http_lua_ngx_timer_pending_count(lua_State *L)
+{
+    ngx_http_request_t          *r;
+    ngx_http_lua_main_conf_t    *lmcf;
+
+    r = ngx_http_lua_get_req(L);
+    if (r == NULL) {
+        return luaL_error(L, "no request");
+    }
+
+    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
+
+    lua_pushnumber(L, lmcf->pending_timers);
+
+    return 1;
 }
 
 

--- a/t/132-timer-counts.t
+++ b/t/132-timer-counts.t
@@ -1,0 +1,49 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use lib 'lib';
+use Test::Nginx::Socket::Lua;
+
+repeat_each(1);
+
+plan tests => blocks() * repeat_each() * 2;
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: running count with no running timers
+--- config
+    location /timers {
+        content_by_lua 'ngx.say(ngx.timer.running_count())';
+    }
+--- request
+GET /timers
+--- response_body
+0
+
+
+
+=== TEST 2: running count with no pending timers
+--- config
+    location /timers {
+        content_by_lua 'ngx.say(ngx.timer.pending_count())';
+    }
+--- request
+GET /timers
+--- response_body
+0
+
+
+
+=== TEST 3: pending count with pending timer
+--- config
+    location /timers {
+        content_by_lua '
+            ngx.timer.at(0.05, function() end)
+            ngx.say(ngx.timer.pending_count())
+        ';
+    }
+--- request
+GET /timers
+--- response_body
+1


### PR DESCRIPTION
Fixes https://github.com/openresty/lua-nginx-module/issues/549, this is really useful for monitoring. Currently internally we reach into nginx via FFI to grab these numbers into statsd.

I didn't have a simple idea to test the running timers when it's `> 0`, let me know if anyone has one. 

\cc @thefosk @csfrancis @grollest