### PR TITLE
Ngx shared rbtree

### DIFF
--- a/config
+++ b/config
@@ -393,3 +393,7 @@ ngx_feature_test='setsockopt(1, SOL_SOCKET, SO_PASSCRED, NULL, 0);'
 #CFLAGS=$"$CFLAGS -DLUA_DEFAULT_PATH='\"/usr/local/openresty/lualib/?.lua\"'"
 #CFLAGS=$"$CFLAGS -DLUA_DEFAULT_CPATH='\"/usr/local/openresty/lualib/?.so\"'"
 
+
+ngx_lua_dquote='"'
+CFLAGS="$CFLAGS -DLUA_DEFAULT_PATH='$ngx_lua_dquote/usr/local/openresty/lualib/?.lua;/usr/local/openresty/lualib/?/init.lua$ngx_lua_dquote'"
+CFLAGS="$CFLAGS -DLUA_DEFAULT_CPATH='$ngx_lua_dquote/usr/local/openresty/lualib/?.so$ngx_lua_dquote'"

--- a/config
+++ b/config
@@ -268,6 +268,7 @@ NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
                 $ngx_addon_dir/src/ngx_http_lua_pcrefix.c \
                 $ngx_addon_dir/src/ngx_http_lua_headerfilterby.c \
                 $ngx_addon_dir/src/ngx_http_lua_shdict.c \
+                $ngx_addon_dir/src/ngx_http_lua_shrbtree.c \
                 $ngx_addon_dir/src/ngx_http_lua_socket_tcp.c \
                 $ngx_addon_dir/src/ngx_http_lua_api.c \
                 $ngx_addon_dir/src/ngx_http_lua_logby.c \
@@ -320,6 +321,7 @@ NGX_ADDON_DEPS="$NGX_ADDON_DEPS \
                 $ngx_addon_dir/src/ngx_http_lua_pcrefix.h \
                 $ngx_addon_dir/src/ngx_http_lua_headerfilterby.h \
                 $ngx_addon_dir/src/ngx_http_lua_shdict.h \
+                $ngx_addon_dir/src/ngx_http_lua_shrbtree.h \
                 $ngx_addon_dir/src/ngx_http_lua_socket_tcp.h \
                 $ngx_addon_dir/src/api/ngx_http_lua_api.h \
                 $ngx_addon_dir/src/ngx_http_lua_logby.h \

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -1473,7 +1473,7 @@ Uses Lua code specified in <code><lua-script-str></code> to define an output hea
 Note that the following API functions are currently disabled within this context:
 
 * Output API functions (e.g., [[#ngx.say|ngx.say]] and [[#ngx.send_headers|ngx.send_headers]])
-* Control API functions (e.g., [[#ngx.exit|ngx.exit]] and [[#ngx.exec|ngx.exec]])
+* Control API functions (e.g., [[#ngx.redirect|ngx.redirect]] and [[#ngx.exec|ngx.exec]])
 * Subrequest API functions (e.g., [[#ngx.location.capture|ngx.location.capture]] and [[#ngx.location.capture_multi|ngx.location.capture_multi]])
 * Cosocket API functions (e.g., [[#ngx.socket.tcp|ngx.socket.tcp]] and [[#ngx.req.socket|ngx.req.socket]]).
 

--- a/src/ngx_http_lua_directive.h
+++ b/src/ngx_http_lua_directive.h
@@ -13,6 +13,7 @@
 
 
 char *ngx_http_lua_shared_dict(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+char * ngx_http_lua_shared_rbtree(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 char *ngx_http_lua_package_cpath(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 char *ngx_http_lua_package_path(ngx_conf_t *cf, ngx_command_t *cmd,

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -87,6 +87,13 @@ static ngx_command_t ngx_http_lua_cmds[] = {
       0,
       NULL },
 
+    { ngx_string("lua_shared_rbtree"),
+      NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE2,
+      ngx_http_lua_shared_rbtree,
+      0,
+      0,
+      NULL },
+
 #if (NGX_PCRE)
     { ngx_string("lua_regex_cache_max_entries"),
       NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -342,14 +342,19 @@ ngx_http_lua_inject_shdict_api(ngx_http_lua_main_conf_t *lmcf, lua_State *L)
         zone = lmcf->shm_zones->elts;
 
         for (i = 0; i < lmcf->shm_zones->nelts; i++) {
+            if (zone[i]->tag != (void *)&ngx_http_lua_module_shdict) {
+                continue;
+            }
             ctx = zone[i]->data;
 
             lua_pushlstring(L, (char *) ctx->name.data, ctx->name.len);
                 /* shared mt key */
 
-            lua_pushlightuserdata(L, zone[i]); /* shared mt key ud */
-            lua_pushvalue(L, -3); /* shared mt key ud mt */
-            lua_setmetatable(L, -2); /* shared mt key ud */
+            lua_createtable(L, 1 /* narr */, 0 /* nrec */);
+            lua_pushlightuserdata(L, zone[i]);
+            lua_rawseti(L, -2, 1); /* {zone[i]} */
+            lua_pushvalue(L, -3); /* mt of zone[i] */
+            lua_setmetatable(L, -2); /* setmetatable for {zone[i]} */
             lua_rawset(L, -4); /* shared mt */
         }
 
@@ -401,7 +406,12 @@ ngx_http_lua_shdict_get_helper(lua_State *L, int get_stale)
                           "but only seen %d", n);
     }
 
-    zone = lua_touserdata(L, 1);
+    if (LUA_TTABLE != lua_type(L, 1)) {
+        return luaL_error(L, "bad \"zone\" argument");
+    }
+    lua_rawgeti(L, 1, 1);
+    zone = lua_touserdata(L, -1);
+    lua_pop(L, 1);
     if (zone == NULL) {
         return luaL_error(L, "bad \"zone\" argument");
     }
@@ -572,9 +582,11 @@ ngx_http_lua_shdict_flush_all(lua_State *L)
         return luaL_error(L, "expecting 1 argument, but seen %d", n);
     }
 
-    luaL_checktype(L, 1, LUA_TLIGHTUSERDATA);
+    luaL_checktype(L, 1, LUA_TTABLE);
 
-    zone = lua_touserdata(L, 1);
+    lua_rawgeti(L, 1, 1);
+    zone = lua_touserdata(L, -1);
+    lua_pop(L, 1);
     if (zone == NULL) {
         return luaL_error(L, "bad user data for the ngx_shm_zone_t pointer");
     }
@@ -619,9 +631,11 @@ ngx_http_lua_shdict_flush_expired(lua_State *L)
         return luaL_error(L, "expecting 1 or 2 argument(s), but saw %d", n);
     }
 
-    luaL_checktype(L, 1, LUA_TLIGHTUSERDATA);
+    luaL_checktype(L, 1, LUA_TTABLE);
 
-    zone = lua_touserdata(L, 1);
+    lua_rawgeti(L, 1, 1);
+    zone = lua_touserdata(L, -1);
+    lua_pop(L, 1);
     if (zone == NULL) {
         return luaL_error(L, "bad user data for the ngx_shm_zone_t pointer");
     }
@@ -700,9 +714,11 @@ ngx_http_lua_shdict_get_keys(lua_State *L)
                           "but saw %d", n);
     }
 
-    luaL_checktype(L, 1, LUA_TLIGHTUSERDATA);
+    luaL_checktype(L, 1, LUA_TTABLE);
 
-    zone = lua_touserdata(L, 1);
+    lua_rawgeti(L, 1, 1);
+    zone = lua_touserdata(L, -1);
+    lua_pop(L, 1);
     if (zone == NULL) {
         return luaL_error(L, "bad user data for the ngx_shm_zone_t pointer");
     }
@@ -840,7 +856,12 @@ ngx_http_lua_shdict_set_helper(lua_State *L, int flags)
                           "but only seen %d", n);
     }
 
-    zone = lua_touserdata(L, 1);
+    if (LUA_TTABLE != lua_type(L, 1)) {
+        return luaL_error(L, "bad \"zone\" argument");
+    }
+    lua_rawgeti(L, 1, 1);
+    zone = lua_touserdata(L, -1);
+    lua_pop(L, 1);
     if (zone == NULL) {
         return luaL_error(L, "bad \"zone\" argument");
     }
@@ -1147,11 +1168,13 @@ ngx_http_lua_shdict_incr(lua_State *L)
         return luaL_error(L, "expecting 3 arguments, but only seen %d", n);
     }
 
-    if (lua_type(L, 1) != LUA_TLIGHTUSERDATA) {
+    if (lua_type(L, 1) != LUA_TTABLE) {
         return luaL_error(L, "bad \"zone\" argument");
     }
 
-    zone = lua_touserdata(L, 1);
+    lua_rawgeti(L, 1, 1);
+    zone = lua_touserdata(L, -1);
+    lua_pop(L, 1);
     if (zone == NULL) {
         return luaL_error(L, "bad user data for the ngx_shm_zone_t pointer");
     }

--- a/src/ngx_http_lua_shdict.h
+++ b/src/ngx_http_lua_shdict.h
@@ -39,6 +39,7 @@ typedef struct {
     ngx_log_t                    *log;
 } ngx_http_lua_shdict_ctx_t;
 
+#define ngx_http_lua_module_shdict (ngx_http_lua_module.spare0)
 
 ngx_int_t ngx_http_lua_shdict_init_zone(ngx_shm_zone_t *shm_zone, void *data);
 void ngx_http_lua_shdict_rbtree_insert_value(ngx_rbtree_node_t *temp,

--- a/src/ngx_http_lua_shrbtree.c
+++ b/src/ngx_http_lua_shrbtree.c
@@ -1,0 +1,771 @@
+
+/*
+ * Copyright (C) helloyi
+ */
+
+
+#ifndef DDEBUG
+#define DDEBUG 0
+#endif
+#include "ddebug.h"
+
+
+#include "ngx_http_lua_shrbtree.h"
+#include "ngx_http_lua_util.h"
+#include "ngx_http_lua_api.h"
+
+
+ngx_int_t ngx_http_lua_shrbtree_init_zone(ngx_shm_zone_t *shm_zone,
+                                          void *data);
+void ngx_http_lua_inject_shrbtree_api(ngx_http_lua_main_conf_t *lmcf,
+                                      lua_State *L);
+void ngx_http_lua_shrbtree_rbtree_insert_value(ngx_rbtree_node_t *node1,
+                                               ngx_rbtree_node_t *node2,
+                                               ngx_rbtree_node_t *sentinel);
+
+/* START declare of pushlvalue */
+static void ngx_http_lua_shrbtree_pushlvalue(lua_State *L,
+                                             u_char *data,
+                                             u_char type,
+                                             size_t len);
+static void ngx_http_lua_shrbtree_pushltable(lua_State *L,
+                                             ngx_http_lua_shrbtree_ltable_t *ltable);
+static void ngx_http_lua_shrbtree_pushlfield(lua_State *L,
+                                             ngx_rbtree_node_t *node,
+                                             ngx_rbtree_node_t *sentinel);
+/* END declare of pushlvalue */
+
+
+/* START declare of tolvalue */
+static ngx_int_t ngx_http_lua_shrbtree_tolvalue(lua_State *L, int index,
+                                                u_char **data,
+                                                u_char *type, size_t *len);
+static ngx_int_t ngx_http_lua_shrbtree_toltable(lua_State *L,
+                                                int index,
+                                                ngx_http_lua_shrbtree_ltable_t *ltable);
+/* END declare of tolvalue */
+
+
+/* START declare of get */
+static int ngx_http_lua_shrbtree_get(lua_State *L);
+static void ngx_http_lua_shrbtree_get_node(lua_State *L,
+                                           ngx_http_lua_shrbtree_node_t **srbtnp,
+                                           ngx_rbtree_node_t **nodep);
+static void ngx_http_lua_shrbtree_get_lfield(ngx_http_lua_shrbtree_ltable_t *ltable,
+                                             void *kdata, size_t klen,
+                                             ngx_http_lua_shrbtree_lfield_t **lfieldp);
+/* END declare of get */
+
+/* START declare of insert */
+static int ngx_http_lua_shrbtree_insert(lua_State *L);
+static void ngx_http_lua_shrbtree_insert_real(lua_State *L,
+                                                   ngx_rbtree_node_t *node);
+/* END declare of insert */
+
+static int ngx_http_lua_shrbtree_delete(lua_State *L);
+
+#define NGX_HTTP_LUA_SHRBTREE_LVALUE_SIZE sizeof(ngx_http_lua_shrbtree_lvalue_t)
+
+ngx_int_t
+ngx_http_lua_shrbtree_init_zone(ngx_shm_zone_t *shm_zone, void *data)
+{
+    ngx_http_lua_shrbtree_ctx_t  *octx = data;
+
+    size_t                      len;
+    ngx_http_lua_shrbtree_ctx_t  *ctx;
+    ngx_http_lua_main_conf_t   *lmcf;
+
+    dd("init zone");
+
+    ctx = shm_zone->data;
+
+    if (octx) {
+        ctx->sh = octx->sh;
+        ctx->shpool = octx->shpool;
+
+        goto done;
+    }
+
+    ctx->shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
+
+    if (shm_zone->shm.exists) {
+        ctx->sh = ctx->shpool->data;
+
+        goto done;
+    }
+
+    ctx->sh = ngx_slab_alloc(ctx->shpool, sizeof(ngx_http_lua_shrbtree_shctx_t));
+    if (ctx->sh == NULL) {
+        return NGX_ERROR;
+    }
+
+    ctx->shpool->data = ctx->sh;
+
+    ngx_rbtree_init(&ctx->sh->rbtree, &ctx->sh->sentinel,
+                    ngx_http_lua_shrbtree_rbtree_insert_value);
+
+    len = sizeof(" in lua_shared_rbtree_zone \"\"") + shm_zone->shm.name.len;
+
+    ctx->shpool->log_ctx = ngx_slab_alloc(ctx->shpool, len);
+    if (ctx->shpool->log_ctx == NULL) {
+        return NGX_ERROR;
+    }
+
+    ngx_sprintf(ctx->shpool->log_ctx, " in lua_shared_rbtree_zone \"%V\"%Z",
+                &shm_zone->shm.name);
+
+#if defined(nginx_version) && nginx_version >= 1005013
+    ctx->shpool->log_nomem = 0;
+#endif
+
+done:
+
+    dd("get lmcf");
+
+    lmcf = ctx->main_conf;
+
+    dd("lmcf->lua: %p", lmcf->lua);
+
+    lmcf->shm_zones_inited++;
+
+    if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts
+        && lmcf->init_handler)
+    {
+        if (lmcf->init_handler(ctx->log, lmcf, lmcf->lua) != NGX_OK) {
+            /* an error happened */
+            return NGX_ERROR;
+        }
+    }
+
+    return NGX_OK;
+}
+
+void
+ngx_http_lua_inject_shrbtree_api(ngx_http_lua_main_conf_t *lmcf, lua_State *L)
+{
+    ngx_http_lua_shrbtree_ctx_t   *ctx;
+    ngx_uint_t                   i;
+    ngx_shm_zone_t             **zone;
+
+    if (lmcf->shm_zones != NULL) {
+        lua_createtable(L, 0, lmcf->shm_zones->nelts /* nrec */);
+
+        lua_createtable(L, 0 /* narr */, 4 /* nrec */);
+
+        lua_pushcfunction(L, ngx_http_lua_shrbtree_get);
+        lua_setfield(L, -2, "get");
+
+        lua_pushcfunction(L, ngx_http_lua_shrbtree_insert);
+        lua_setfield(L, -2, "insert");
+
+        lua_pushcfunction(L, ngx_http_lua_shrbtree_delete);
+        lua_setfield(L, -2, "delete");
+
+        lua_pushvalue(L, -1);
+        lua_setfield(L, -2, "__index");
+
+        zone = lmcf->shm_zones->elts;
+
+        for (i = 0; i < lmcf->shm_zones->nelts; i++) {
+            if (zone[i]->tag != (void *)&ngx_http_lua_module_shrbtree) {
+                continue;
+            }
+            ctx = zone[i]->data;
+
+            lua_pushlstring(L, (char *) ctx->name.data, ctx->name.len);
+            lua_createtable(L, 1 /* narr */, 0 /* nrec */);
+            lua_pushlightuserdata(L, zone[i]);
+            lua_rawseti(L, -2, 1); /* {zone[i]} */
+            lua_pushvalue(L, -3);  /* mt of {zone[i]}*/
+            lua_setmetatable(L, -2);
+            lua_rawset(L, -4);
+        }
+
+        lua_pop(L, 1);
+
+    } else {
+        lua_newtable(L);    /* ngx.shrbtree*/
+    }
+
+    lua_setfield(L, -2, "shrbtree");
+}
+
+/* START ngx_http_lua_shrbtree api */
+static int
+ngx_http_lua_shrbtree_get(lua_State *L)
+{
+    ngx_int_t                      n;
+    ngx_http_lua_shrbtree_ctx_t    *ctx;
+    ngx_http_lua_shrbtree_node_t   *srbtn;
+    ngx_http_lua_shrbtree_ltable_t *ltable;
+    ngx_http_lua_shrbtree_lfield_t *lfield;
+    ngx_shm_zone_t                 *zone;
+
+    u_char key[NGX_HTTP_LUA_SHRBTREE_LVALUE_SIZE];
+    u_char *kdata = &key[0];
+    u_char ktype;
+    size_t klen;
+
+    ngx_int_t num_of_result;
+    ngx_int_t is_getlfield = 0;
+
+    n = lua_gettop(L);
+    if (2 != n) {
+        return luaL_error(L, "expecting exactly 2 arguments, "
+                      "but only seen %d", n);
+    }
+
+    if (LUA_TTABLE != lua_type(L, 2)) {
+        return luaL_error(L, "expecting table type of 2th argument.");
+    }
+    /* [zone, {key, [field, cmpf}]*/
+    n = lua_objlen(L, 2);
+    if (3 == n) {
+        is_getlfield = 1;
+    }
+
+    lua_rawgeti(L, 1, 1);
+    zone = lua_touserdata(L, -1);
+    lua_pop(L, 1);
+    if (zone == NULL) {
+        return luaL_error(L, "bad \"zone\" argument");
+    }
+
+    ctx = zone->data;
+
+    ngx_shmtx_lock(&ctx->shpool->mutex);
+    ngx_http_lua_shrbtree_get_node(L, &srbtn, NULL);
+    if (NULL == srbtn) {
+        ngx_shmtx_unlock(&ctx->shpool->mutex);
+        lua_pushnil(L);
+        lua_pushliteral(L, "no exists");
+        return 2;
+    }
+
+    if (!is_getlfield) {
+        ngx_http_lua_shrbtree_pushlvalue(L, (&srbtn->data) + srbtn->klen,
+                                         srbtn->vtype, srbtn->vlen);
+        ngx_shmtx_unlock(&ctx->shpool->mutex);
+        return 1;
+    }
+
+ getfield:
+    if (LUA_TTABLE != srbtn->vtype) {
+        ngx_shmtx_unlock(&ctx->shpool->mutex);
+        lua_pushnil(L);
+        lua_pushliteral(L, "the value type isn't a table");
+        return 2;
+    }
+
+    /* field */
+    lua_rawgeti(L, 2, 2);
+    num_of_result = ngx_http_lua_shrbtree_tolvalue(L, -1, &kdata, &ktype, &klen);
+    if (0 != num_of_result) {return num_of_result;}
+
+    ltable = (ngx_http_lua_shrbtree_ltable_t *)((&srbtn->data) + srbtn->klen);
+    ngx_http_lua_shrbtree_get_lfield(ltable, kdata, klen, &lfield);
+
+    if (NULL == lfield) {
+        ngx_shmtx_unlock(&ctx->shpool->mutex);
+        lua_pushnil(L);
+        lua_pushliteral(L, "no exists this field");
+        return 2;
+    }
+
+    ngx_http_lua_shrbtree_pushlvalue(L, &lfield->data + lfield->klen,
+                                     lfield->vtype, lfield->vlen);
+    ngx_shmtx_unlock(&ctx->shpool->mutex);
+    return 1;
+}
+
+static int
+ngx_http_lua_shrbtree_insert(lua_State *L)
+{
+    ngx_int_t                    n;
+    ngx_shm_zone_t               *zone;
+    ngx_http_lua_shrbtree_ctx_t  *ctx;
+    ngx_rbtree_node_t            *node;
+    ngx_http_lua_shrbtree_node_t *srbtn;
+    ngx_int_t                    num_of_result;
+    u_char key[NGX_HTTP_LUA_SHRBTREE_LVALUE_SIZE];
+    u_char value[NGX_HTTP_LUA_SHRBTREE_LVALUE_SIZE];
+    u_char *kdata = &key[0];
+    u_char *vdata = &value[0];
+    size_t klen, vlen;
+    u_char ktype, vtype;
+    void *p;
+
+    n = lua_gettop(L);
+    if (n != 2) {
+        return luaL_error(L, "expecting 2 arguments, "
+                          "but only seen %d", n);
+    }
+
+    if (!lua_istable(L, 2)) {
+      return luaL_error(L, "expecting table type of 2th argument");
+    }
+
+    if (3 != lua_objlen(L, 2)) {
+        return luaL_error(L, "expecting  3 elements(\"key\" \"value\" "
+                          "and \"compare function\") of 2th argument");
+    }
+
+    lua_rawgeti(L, 1, 1);
+    zone = lua_touserdata(L, -1);
+    lua_pop(L, 1);
+    if (zone == NULL) {
+        return luaL_error(L, "bad \"zone\" argument");
+    }
+
+    ctx = zone->data;
+
+    /* {key, value, cmpf} */
+    lua_rawgeti(L, 2, 1); /* key */
+    num_of_result = ngx_http_lua_shrbtree_tolvalue(L, -1, &kdata, &ktype, &klen);
+    if (0 != num_of_result) {return num_of_result;}
+
+    lua_rawgeti(L, 2, 2); /* value */
+    num_of_result = ngx_http_lua_shrbtree_tolvalue(L, -1, &vdata, &vtype, &vlen);
+    if (0 != num_of_result) {return num_of_result;}
+
+    /* start node alloc*/
+    n = offsetof(ngx_rbtree_node_t, data)
+      + offsetof(ngx_http_lua_shrbtree_node_t, data)
+      + klen
+      + vlen;
+
+    ngx_shmtx_lock(&ctx->shpool->mutex);
+    node = ngx_slab_alloc_locked(ctx->shpool, n);
+
+    if (node == NULL) {
+        ngx_shmtx_unlock(&ctx->shpool->mutex);
+
+        lua_pushboolean(L, 0);
+        lua_pushliteral(L, "no memory");
+        return 2;
+    }
+    /* end node alloc*/
+
+    /* start insert */
+    srbtn = (ngx_http_lua_shrbtree_node_t *)&node->data;
+
+    srbtn->ktype = ktype;
+    srbtn->vtype = vtype;
+    srbtn->klen = klen;
+    srbtn->vlen = vlen;
+    p = ngx_copy(&srbtn->data, kdata, klen);
+    ngx_memcpy(p, vdata, vlen);
+
+    lua_pop(L, 2);
+
+    ngx_http_lua_shrbtree_insert_real(L, node);
+    ngx_shmtx_unlock(&ctx->shpool->mutex);
+    /* end insert */
+
+    lua_pushboolean(L, 1);
+    return 1;
+}
+/* END ngx_http_lua_shrbtree api*/
+
+/* START get helper */
+static void
+ngx_http_lua_shrbtree_get_lfield(ngx_http_lua_shrbtree_ltable_t *ltable,
+                                 void *kdata,
+                                 size_t klen,
+                                 ngx_http_lua_shrbtree_lfield_t **lfieldp)
+{
+    ngx_int_t                      rc;
+    ngx_rbtree_node_t              *node, *sentinel;
+    ngx_http_lua_shrbtree_lfield_t *lfield;
+    uint32_t  hash;
+
+    node = ltable->rbtree.root;
+    sentinel = ltable->rbtree.sentinel;
+    hash = ngx_crc32_short(kdata, klen);
+
+    while (node != sentinel) {
+
+        if (hash < node->key) {
+            node = node->left;
+            continue;
+        }
+
+        if (hash > node->key) {
+            node = node->right;
+            continue;
+        }
+
+        /* hash == node->key */
+        lfield = (ngx_http_lua_shrbtree_lfield_t *) &node->data;
+
+        rc = ngx_memn2cmp(kdata, &lfield->data, klen, (size_t)lfield->klen);
+
+        if (rc == 0) {
+            *lfieldp = lfield;
+            return;
+        }
+
+        node = (rc < 0) ? node->left : node->right;
+    }
+
+    *lfieldp = NULL;
+}
+
+static void
+ngx_http_lua_shrbtree_get_node(lua_State *L,
+                               ngx_http_lua_shrbtree_node_t **srbtnp,
+                               ngx_rbtree_node_t **nodep)
+{
+    ngx_int_t                    rc;
+    ngx_rbtree_node_t            *node, *sentinel;
+    ngx_http_lua_shrbtree_ctx_t  *ctx;
+    ngx_http_lua_shrbtree_node_t *srbtn;
+    ngx_shm_zone_t *zone;
+    ngx_int_t cmpf_index;
+
+    lua_rawgeti(L, 1, 1);
+    zone = lua_touserdata(L, -1);
+    lua_pop(L, 1);
+    ctx = zone->data;
+
+    node = ctx->sh->rbtree.root;
+    sentinel = ctx->sh->rbtree.sentinel;
+
+    cmpf_index = lua_objlen(L, 2);
+    while (node != sentinel) {
+        /* start call cmpf of lua*/
+        lua_rawgeti(L, 2, cmpf_index);
+        lua_rawgeti(L, 2, 1);
+        srbtn = (ngx_http_lua_shrbtree_node_t *)&node->data;
+        ngx_http_lua_shrbtree_pushlvalue(L, &srbtn->data, srbtn->ktype, srbtn->klen);
+        lua_call(L, 2, 1);
+        /* end call cmpf of lua*/
+
+        rc = (ngx_int_t)lua_tonumber(L, -1);
+        lua_pop(L, 1);
+        if (0 == rc) {
+            if (srbtnp) *srbtnp = srbtn;
+            if (nodep)  *nodep = node;
+            return;
+        }
+
+        node = (rc < 0) ? node->left : node->right;
+    }
+
+    if (srbtnp) *srbtnp = NULL;
+    if (nodep)  *nodep = NULL;
+}
+
+/* END get helper */
+
+/* START insert helper */
+void
+ngx_http_lua_shrbtree_rbtree_insert_value(ngx_rbtree_node_t *node1,
+                                          ngx_rbtree_node_t *node2,
+                                          ngx_rbtree_node_t *sentinel)
+{
+    /* nothing to do, */
+    return;
+}
+
+
+static void
+ngx_http_lua_shrbtree_insert_real(lua_State *L,
+                                  ngx_rbtree_node_t *node)
+{
+    ngx_int_t                    rc;
+    ngx_rbtree_node_t            **root, *temp, *sentinel;
+    ngx_rbtree_node_t            **p;
+    ngx_http_lua_shrbtree_ctx_t  *ctx;
+    ngx_http_lua_shrbtree_node_t *srbtn;
+    ngx_shm_zone_t *zone;
+    ngx_int_t n;
+
+    lua_rawgeti(L, 1, 1);
+    zone = lua_touserdata(L, -1);
+    lua_pop(L, 1);
+    ctx = zone->data;
+
+    root = &ctx->sh->rbtree.root;
+    temp = *root;
+    sentinel = ctx->sh->rbtree.sentinel;
+
+    if (*root == sentinel) {
+        node->parent = NULL;
+        node->left = sentinel;
+        node->right = sentinel;
+        ngx_rbt_black(node);
+        *root = node;
+
+        return;
+    }
+
+    /* [zone, {key, value, cmpf}] */
+    for (;;) {
+        /* start call cmpf of lua */
+        lua_rawgeti(L, 2, 3);
+        lua_rawgeti(L, 2, 1);
+        srbtn = (ngx_http_lua_shrbtree_node_t *)&temp->data;
+        ngx_http_lua_shrbtree_pushlvalue(L, &srbtn->data, srbtn->ktype, srbtn->klen);
+        lua_call(L, 2, 1);
+        /* end call cmpf of lua*/
+
+        rc = (ngx_int_t)lua_tonumber(L, -1);
+        lua_pop(L, 1);
+        if (0 > rc) {
+            p = &temp->left;
+
+        } else if (0 < rc) {
+            p = &temp->right;
+
+        } else {
+            return;
+        }
+
+        if (*p == sentinel) {
+            break;
+        }
+
+        temp = *p;
+    }
+
+    *p = node;
+    node->parent = temp;
+    node->left = sentinel;
+    node->right = sentinel;
+    ngx_rbt_red(node);
+
+    ngx_rbtree_insert(&ctx->sh->rbtree, node);
+}
+/* END insert helper */
+
+
+/* START pushlvalue */
+static void
+ngx_http_lua_shrbtree_pushlvalue(lua_State *L,
+                                 u_char *data,
+                                 u_char type,
+                                 size_t len)
+{
+    switch (type) {
+    case LUA_TBOOLEAN:
+        lua_pushboolean(L, *(int *)data);
+        break;
+    case LUA_TNUMBER:
+        lua_pushnumber(L, *(lua_Number *)data);
+        break;
+    case LUA_TSTRING:
+        lua_pushlstring(L, (char *)data, len);
+        break;
+    case LUA_TTABLE:
+        ngx_http_lua_shrbtree_pushltable(L, (ngx_http_lua_shrbtree_ltable_t *)data);
+        break;
+    default:
+        luaL_error(L, "bad type of value,"
+                      " expecting number string boolean or table type");
+    }
+}
+
+static void
+ngx_http_lua_shrbtree_pushltable(lua_State *L,
+                                 ngx_http_lua_shrbtree_ltable_t *ltable)
+{
+    ngx_rbtree_node_t *root = ltable->rbtree.root;
+    ngx_rbtree_node_t *sentinel = ltable->rbtree.sentinel;
+    lua_newtable(L);
+    ngx_http_lua_shrbtree_pushlfield(L, root, sentinel);
+    // metatable
+}
+
+static void
+ngx_http_lua_shrbtree_pushlfield(lua_State *L,
+                                 ngx_rbtree_node_t *node,
+                                 ngx_rbtree_node_t *sentinel)
+{
+    ngx_http_lua_shrbtree_lfield_t *lfield;
+
+    if (node == sentinel) return;
+
+    lfield = (ngx_http_lua_shrbtree_lfield_t *)&node->data;
+    ngx_http_lua_shrbtree_pushlvalue(L, &lfield->data,
+                                     lfield->ktype, lfield->klen);
+    ngx_http_lua_shrbtree_pushlvalue(L, &lfield->data + lfield->klen,
+                                     lfield->vtype, lfield->vlen);
+    lua_settable(L, -3);
+
+    ngx_http_lua_shrbtree_pushlfield(L, node->left, sentinel);
+    ngx_http_lua_shrbtree_pushlfield(L, node->right, sentinel);
+}
+/*END pushlvalue */
+
+/* START tolvalue */
+static ngx_int_t
+ngx_http_lua_shrbtree_tolvalue(lua_State *L,
+                               int index,
+                               u_char **data,
+                               u_char *type,
+                               size_t *len)
+{
+
+    int num_of_result;
+    ngx_http_lua_shrbtree_ltable_t *ltable;
+    const char *str;
+
+    switch (lua_type(L, index)) {
+    case LUA_TBOOLEAN:
+        *type = LUA_TBOOLEAN;
+        *(int *)(*data) = lua_toboolean(L, index);
+        *len = sizeof(int);
+        break;
+
+    case LUA_TNUMBER:
+        *type = LUA_TNUMBER;
+        *(lua_Number *)(*data) = lua_tonumber(L, index);
+        *len = sizeof(lua_Number);
+        break;
+
+    case LUA_TSTRING:
+        *type = LUA_TSTRING;
+        *data = (u_char *)lua_tolstring(L, index, len);
+        break;
+
+    case LUA_TTABLE:
+        *type = LUA_TTABLE;
+        ltable = (ngx_http_lua_shrbtree_ltable_t *)(*data);
+        ngx_rbtree_init(&ltable->rbtree,
+                        &ltable->sentinel,
+                        ngx_rbtree_insert_value);
+
+        *len = sizeof(ngx_http_lua_shrbtree_ltable_t);
+        return ngx_http_lua_shrbtree_toltable(L, index, ltable);
+
+    default:
+        lua_pushnil(L);
+        lua_pushliteral(L, "bad \"type\" argument");
+        return 2;
+    }
+    return 0;
+}
+
+static ngx_int_t
+ngx_http_lua_shrbtree_toltable(lua_State *L,
+                               int index,
+                               ngx_http_lua_shrbtree_ltable_t *ltable)
+{
+    ngx_shm_zone_t              *zone;
+    ngx_http_lua_shrbtree_ctx_t *ctx;
+    ngx_rbtree_node_t           *node;
+    ngx_http_lua_shrbtree_lfield_t *lfield;
+    void *p;
+
+    u_char key[NGX_HTTP_LUA_SHRBTREE_LVALUE_SIZE];
+    u_char value[NGX_HTTP_LUA_SHRBTREE_LVALUE_SIZE];
+    u_char *kdata = &key[0];
+    u_char *vdata = &value[0];
+    int num_of_result, n;
+    size_t klen, vlen;
+    u_char ktype, vtype;
+
+    lua_rawgeti(L, 1, 1);
+    zone = lua_touserdata(L, -1);
+    lua_pop(L, 1);
+    ctx = zone->data;
+
+
+    lua_pushnil(L);
+    if (index < 0) {
+        index -= 1;
+    }
+    while (lua_next(L, index)) {
+        num_of_result = ngx_http_lua_shrbtree_tolvalue(L, -2, &kdata, &ktype, &klen);
+        if (0 != num_of_result) {return num_of_result;}
+        num_of_result = ngx_http_lua_shrbtree_tolvalue(L, -1, &vdata, &vtype, &vlen);
+        if (0 != num_of_result) {return num_of_result;}
+
+        /* start alloc*/
+        n = offsetof(ngx_rbtree_node_t, data)
+          + offsetof(ngx_http_lua_shrbtree_lfield_t, data)
+          + klen
+          + vlen;
+
+        ngx_shmtx_lock(&ctx->shpool->mutex);
+        node = (ngx_rbtree_node_t *)ngx_slab_alloc_locked(ctx->shpool, n);
+
+        if (node == NULL) {
+            ngx_shmtx_unlock(&ctx->shpool->mutex);
+            lua_pushnil(L);
+            lua_pushliteral(L, "no memory");
+            return 2;
+        }
+        /* end alloc*/
+
+        /* start insert*/
+        /* copy data */
+        lfield = (ngx_http_lua_shrbtree_lfield_t *)&node->data;
+
+        lfield->ktype = ktype;
+        lfield->vtype = vtype;
+        lfield->klen = klen;
+        lfield->vlen = vlen;
+        p = ngx_copy(&lfield->data, kdata, klen);
+        ngx_memcpy(p, vdata, vlen);
+        node->key = ngx_crc32_short((u_char *)kdata, klen);
+        /* end copy data */
+
+        ngx_rbtree_insert(&ltable->rbtree, node);
+        ngx_shmtx_unlock(&ctx->shpool->mutex);
+        /* end insert*/
+        lua_pop(L, 1);
+    }
+
+    return 0;
+}
+/* END tolvalue */
+
+static int
+ngx_http_lua_shrbtree_delete(lua_State *L)
+{
+    ngx_int_t                    n;
+    ngx_shm_zone_t               *zone;
+    ngx_http_lua_shrbtree_ctx_t  *ctx;
+    ngx_rbtree_node_t            *node;
+
+    n = lua_gettop(L);
+    if (n != 2) {
+        return luaL_error(L, "expecting 2 arguments, "
+                          "but only seen %d", n);
+    }
+
+    if (!lua_istable(L, 2)) {
+        return luaL_error(L, "expecting table of 2th argument");
+    }
+
+    if (2 != lua_objlen(L, 2)) {
+        return luaL_error(L, "expecting \"key\" and \"compare function\" of 2th argument");
+    }
+
+    lua_rawgeti(L, 1, 1);
+    zone = lua_touserdata(L, -1);
+    lua_pop(L, 1);
+    if (zone == NULL) {
+        return luaL_error(L, "bad \"zone\" argument");
+    }
+
+    ctx = zone->data;
+
+    ngx_shmtx_lock(&ctx->shpool->mutex);
+    ngx_http_lua_shrbtree_get_node(L, NULL, &node);
+    if (NULL == node) {
+        ngx_shmtx_unlock(&ctx->shpool->mutex);
+        lua_pushboolean(L, 0);
+        lua_pushliteral(L, "no exists");
+        return 2;
+    }
+
+    ngx_rbtree_delete(&ctx->sh->rbtree, node);
+    ngx_slab_free_locked(ctx->shpool, node);
+    ngx_shmtx_unlock(&ctx->shpool->mutex);
+
+    lua_pushboolean(L, 1);
+    return 1;
+}

--- a/src/ngx_http_lua_shrbtree.h
+++ b/src/ngx_http_lua_shrbtree.h
@@ -1,0 +1,69 @@
+
+/*
+ * Copyright (C) helloyi
+ */
+
+
+#ifndef _NGX_HTTP_LUA_SHRBTREE_H_INCLUDED_
+#define _NGX_HTTP_LUA_SHRBTREE_H_INCLUDED_
+
+
+#include "ngx_http_lua_common.h"
+
+typedef struct ngx_http_lua_shrbtree_ltable_s ngx_http_lua_shrbtree_ltable_t;
+typedef struct ngx_http_lua_shrbtree_node_s ngx_http_lua_shrbtree_node_t;
+
+/* talbe start*/
+typedef ngx_http_lua_shrbtree_node_t ngx_http_lua_shrbtree_lfield_t;
+
+struct ngx_http_lua_shrbtree_ltable_s {
+  ngx_rbtree_t rbtree;
+  ngx_rbtree_node_t sentinel;
+  ngx_http_lua_shrbtree_ltable_t *metatable;
+};
+/* talbe end*/
+
+typedef union ngx_http_lua_shrbtree_lvalue_s {
+  lua_Number n;
+  ngx_http_lua_shrbtree_ltable_t t;
+  char *s;
+} ngx_http_lua_shrbtree_lvalue_t;
+
+
+/* START rbtree node */
+struct ngx_http_lua_shrbtree_node_s {
+  size_t klen;
+  size_t vlen;
+  u_char ktype;
+  u_char vtype;
+  u_char data; /* lua_Integer/lua_Number/string/ltable */
+};
+/* END rbtree node*/
+
+typedef struct {
+  ngx_rbtree_t                  rbtree;
+  ngx_rbtree_node_t             sentinel;
+} ngx_http_lua_shrbtree_shctx_t;
+
+typedef struct {
+    ngx_http_lua_shrbtree_shctx_t  *sh;
+    ngx_slab_pool_t              *shpool;
+    ngx_str_t                     name;
+    ngx_http_lua_main_conf_t     *main_conf;
+    ngx_log_t                    *log;
+} ngx_http_lua_shrbtree_ctx_t;
+
+
+#define ngx_http_lua_module_shrbtree (ngx_http_lua_module.spare1)
+
+ngx_int_t ngx_http_lua_shrbtree_init_zone(ngx_shm_zone_t *shm_zone, void *data);
+void ngx_http_lua_shrbtree_rbtree_insert_value(ngx_rbtree_node_t *node1,
+                                               ngx_rbtree_node_t *node2,
+                                               ngx_rbtree_node_t *sentinel);
+void ngx_http_lua_inject_shrbtree_api(ngx_http_lua_main_conf_t *lmcf,
+                                      lua_State *L);
+
+
+#endif /* _NGX_HTTP_LUA_SHRBTREE_H_INCLUDED_ */
+
+/* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -33,6 +33,7 @@
 #include "ngx_http_lua_consts.h"
 #include "ngx_http_lua_req_method.h"
 #include "ngx_http_lua_shdict.h"
+#include "ngx_http_lua_shrbtree.h"
 #include "ngx_http_lua_coroutine.h"
 #include "ngx_http_lua_socket_tcp.h"
 #include "ngx_http_lua_socket_udp.h"
@@ -747,6 +748,7 @@ ngx_http_lua_inject_ngx_api(lua_State *L, ngx_http_lua_main_conf_t *lmcf,
     ngx_http_lua_create_headers_metatable(log, L);
     ngx_http_lua_inject_variable_api(L);
     ngx_http_lua_inject_shdict_api(lmcf, L);
+    ngx_http_lua_inject_shrbtree_api(lmcf, L);
     ngx_http_lua_inject_socket_tcp_api(log, L);
     ngx_http_lua_inject_socket_udp_api(log, L);
     ngx_http_lua_inject_uthread_api(log, L);

--- a/t/132-shrbtree.t
+++ b/t/132-shrbtree.t
@@ -1,0 +1,628 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use lib 'lib';
+use Test::Nginx::Socket::Lua;
+
+#worker_connections(1014);
+#master_process_enabled(1);
+#log_level('warn');
+
+#repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 3 );
+
+#no_diff();
+no_long_string();
+#master_on();
+#workers(2);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: string key, int value
+--- http_config
+    lua_shared_rbtree rbtree 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local cmp = function(s1, s2)
+                if s1 > s2 then
+                    return 1
+
+                elseif s1 < s2 then
+                    return -1
+
+                else
+                    return 0
+                end 
+            end
+            local rbtree = ngx.shrbtree.rbtree
+            rbtree:insert{"a", 1, cmp}
+            rbtree:insert{"b", 12, cmp}
+            rbtree:insert{"c", 123, cmp}
+            rbtree:insert{"d", 1234, cmp}
+            rbtree:insert{"e", 12345, cmp}
+
+            local val
+            val = rbtree:get{"a", cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{"b", cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{"c", cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{"d", cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{"e", cmp}
+            ngx.say(val, " ", type(val))
+        ';
+    }
+--- request
+GET /test
+--- response_body
+1 number
+12 number
+123 number
+1234 number
+12345 number
+--- no_error_log
+[error]
+
+=== TEST 2: string key, float-point value
+--- http_config
+    lua_shared_rbtree rbtree 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local cmp = function(s1, s2)
+                if s1 > s2 then
+                    return 1
+
+                elseif s1 < s2 then
+                    return -1
+
+                else
+                    return 0
+                end
+
+            end
+            local rbtree = ngx.shrbtree.rbtree
+            rbtree:insert{"a", 0.1, cmp}
+            rbtree:insert{"b", 0.12, cmp}
+            rbtree:insert{"c", 0.123, cmp}
+            rbtree:insert{"d", 0.1234, cmp}
+            rbtree:insert{"e", 0.12345, cmp}
+
+            local val
+            val = rbtree:get{"a", cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{"b", cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{"c", cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{"d", cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{"e", cmp}
+            ngx.say(val, " ", type(val))
+        ';
+    }
+--- request
+GET /test
+--- response_body
+0.1 number
+0.12 number
+0.123 number
+0.1234 number
+0.12345 number
+--- no_error_log
+[error]
+
+=== TEST 3: number key, string value
+--- http_config
+    lua_shared_rbtree rbtree 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local cmp = function(a, b)
+                if a > b then
+                    return 1
+
+                elseif a < b then
+                    return -1
+
+                else
+                    return 0
+                end
+
+            end
+            
+            local rbtree = ngx.shrbtree.rbtree
+            rbtree:insert{1, "s", cmp}
+            rbtree:insert{2, "ss", cmp}
+            rbtree:insert{3, "sss", cmp}
+            rbtree:insert{4, "ssss", cmp}
+            rbtree:insert{5, "sssss", cmp}
+
+            local val
+            val = rbtree:get{1, cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{2, cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{3, cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{4, cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{5, cmp}
+            ngx.say(val, " ", type(val))
+        ';
+    }
+--- request
+GET /test
+--- response_body
+s string
+ss string
+sss string
+ssss string
+sssss string
+
+--- no_error_log
+[error]
+
+=== TEST 4: table key, number/string value
+--- http_config
+    lua_shared_rbtree rbtree 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local cmp = function(a, b)
+                local x
+                if type(a) == "table" then
+                    x = a[1]
+                else
+                    x= a
+                end
+
+                if x > b[2] then
+                    return 1
+
+                elseif x < b[1] then
+                    return -1
+
+                else
+                    return 0
+                end
+            end
+
+            local rbtree = ngx.shrbtree.rbtree
+            local node = {}
+
+            node[1] = {1, 3}
+            node[2] = "string"
+            node[3] = cmp
+            rbtree:insert(node)
+
+            node[1] = {4, 6}
+            node[2] = 1234
+            node[3] = cmp
+            rbtree:insert(node)
+
+            node[1] = {7, 9}
+            node[2] = "gnirts"
+            node[3] = cmp
+            rbtree:insert(node)
+
+            node[1] = {11, 19}
+            node[2] = 4321
+            node[3] = cmp
+            rbtree:insert(node)
+
+            local val
+            val = rbtree:get{3, cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{5, cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{7, cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{19, cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{20, cmp}
+            ngx.say(val, " ", type(val))
+        ';
+    }
+--- request
+GET /test
+--- response_body
+string string
+1234 number
+gnirts string
+4321 number
+nil nil
+--- no_error_log
+[error]
+
+=== TEST 5: number key, table value
+--- http_config
+    lua_shared_rbtree rbtree 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local cmp = function(a, b)
+                if a > b then
+                    return 1
+
+                elseif a < b then
+                    return -1
+
+                else
+                    return 0
+                end
+
+            end
+
+            local rbtree = ngx.shrbtree.rbtree
+            local node = {}
+
+            node[1] = 10
+            node[2] = {1, 2, 3, "4", "5", {1, 2, {1, 2}}}
+            node[3] = cmp
+            rbtree:insert(node)
+
+            node[1] = 11
+            node[2] = {k1 = "v1", k2="v2", k3="v3"}
+            node[3] = cmp
+            rbtree:insert(node);
+
+            node[1] = 12.34
+            node[2] = {1, "2", {3, "4", 5}, {"aa", "bb", "cc", {1, 2, 3}}} 
+            node[3] = cmp
+            rbtree:insert(node);
+
+            node[1] = 111
+            node[2] = {is_false = false, is_true = true}
+            node[3] = cmp
+            rbtree:insert(node)
+
+            local val
+            val = rbtree:get{10, 1, cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{10, 4, cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{10, 6, cmp}
+            ngx.say(val[3][2], " ", type(val[3][2]))
+            
+            val = rbtree:get{11, "k1", cmp}
+            ngx.say(val, " ", type(val))
+            
+            val = rbtree:get{12.34, cmp}
+
+            ngx.say(val[1], " ", type(val[1]))
+            ngx.say(val[4][4][1], " ", type(val[4][4][1]))
+
+            val = rbtree:get{111, "is_false", cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{111, "is_true", cmp}
+            ngx.say(val, " ", type(val))
+        ';
+    }
+--- request
+GET /test
+--- response_body
+1 number
+4 string
+2 number
+v1 string
+1 number
+1 number
+false boolean
+true boolean
+--- no_error_log
+[error]
+
+=== TEST 6: table key, table value
+--- http_config
+    lua_shared_rbtree rbtree 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local cmp = function(a, b)
+                local x
+                if type(a) == "table" then
+                    x = a[1]
+                else
+                    x= a
+                end
+
+                if x > b[2] then
+                    return 1
+
+                elseif x < b[1] then
+                    return -1
+
+                else
+                    return 0
+                end
+            end
+
+            local rbtree = ngx.shrbtree.rbtree
+            local node = {}
+
+            node[1] = {1, 3}
+            node[2] = {1, 2, 3, "4", "5"}
+            node[3] = cmp
+            rbtree:insert(node)
+
+            node[1] = {4, 6}
+            node[2] = {k1 = "v1", k2="v2", k3="v3"}
+            node[3] = cmp
+            rbtree:insert(node)
+
+            node[1] = {7, 9}
+            node[2] = {1, "2", {3, "4", 5}}
+            node[3] = cmp
+            rbtree:insert(node)
+
+            node[1] = {11, 19}
+            node[2] = {{1, 2, 3}, {"1", "2", "3"}}
+            node[3] = cmp
+            rbtree:insert(node)
+
+            local val
+            val = rbtree:get{3, 1, cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{3, 4,  cmp}
+            ngx.say(val, " ", type(val))
+
+            val = rbtree:get{5, "k1", cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{{4, 6}, "k3", cmp}
+            ngx.say(val, " ", type(val))
+
+            val = rbtree:get{7, 3, cmp}
+            ngx.say(val[2], " ", type(val[2]))
+            val = rbtree:get{19, 1, cmp}
+            ngx.say(val[1], " ", type(val[1]))
+
+        ';
+    }
+--- request
+GET /test
+--- response_body
+1 number
+4 string
+v1 string
+v3 string
+4 string
+1 number
+--- no_error_log
+[error]
+
+=== TEST 7: multi shrbtree
+--- http_config
+    lua_shared_rbtree rbtree1 1m;
+    lua_shared_rbtree rbtree2 1m;
+    lua_shared_rbtree rbtree3 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local cmp = function(s1, s2)
+                if s1 > s2 then
+                    return 1
+
+                elseif s1 < s2 then
+                    return -1
+
+                else
+                    return 0
+                end
+
+            end
+            local rbtree1 = ngx.shrbtree.rbtree1
+            local rbtree2 = ngx.shrbtree.rbtree2
+            local rbtree3 = ngx.shrbtree.rbtree3
+
+            rbtree1:insert{"a", 11, cmp}
+            rbtree1:insert{"b", 112, cmp}
+            rbtree1:insert{"c", 1123, cmp}
+            rbtree2:insert{"a", 21, cmp}
+            rbtree2:insert{"b", 212, cmp}
+            rbtree2:insert{"c", 2123, cmp}
+            rbtree3:insert{"a", 31, cmp}
+            rbtree3:insert{"b", 312, cmp}
+            rbtree3:insert{"c", 3123, cmp}
+
+            local val
+            val = rbtree1:get{"a", cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree2:get{"b", cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree3:get{"c", cmp}
+            ngx.say(val, " ", type(val))
+        ';
+    }
+--- request
+GET /test
+--- response_body
+11 number
+212 number
+3123 number
+--- no_error_log
+[error]
+
+=== TEST 8: manay nodes
+--- http_config
+    lua_shared_rbtree rbtree 10m;
+--- config
+    location = /test {
+        content_by_lua '
+            local cmp = function(a, b)
+                local x
+                if type(a) == "table" then
+                    x = a[1]
+                else
+                    x= a
+                end
+
+                if x > b[2] then
+                    return 1
+
+                elseif x < b[1] then
+                    return -1
+
+                else
+                    return 0
+                end
+            end
+
+            local rbtree = ngx.shrbtree.rbtree
+
+            local node = {}
+            node[3] = cmp
+            for i = 1, 1000, 1 do
+                node[1] = {(i-1)*10+1, i*10}
+                node[2] = {k1 = 1, k2 = 2, k3 = 3}
+                rbtree:insert(node)
+            end
+
+            for i = 1, 1000, 1 do
+                val = rbtree:get{(i-1)*10+1, "k1", cmp}
+                if not val == 1 then
+                    ngx.say("error")
+                end
+            end
+            ngx.say("ok")
+        ';
+    }
+--- request
+GET /test
+--- response_body
+ok
+--- no_error_log
+[error]
+
+=== TEST 9: "shared dict" and "shared shrbtree" conflict test
+--- http_config
+    lua_shared_dict     shdict   1m;
+    lua_shared_rbtree   shrbtree 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local dict = ngx.shared.shdict
+            dict:set("Jim", 8)
+            dict:set("Tim", 9)
+            dict:set("Lim", 10)
+
+            local cmp = function(s1, s2)
+                if s1 > s2 then
+                    return 1
+
+                elseif s1 < s2 then
+                    return -1
+
+                else
+                    return 0
+                end 
+            end
+
+            local rbtree = ngx.shrbtree.shrbtree
+            rbtree:insert{"Jim", 8,  cmp}
+            rbtree:insert{"Tim", 9,  cmp}
+            rbtree:insert{"Lim", 10, cmp}
+            
+            local val
+            val = rbtree:get{"Jim", cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{"Tim", cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{"Lim", cmp}
+            ngx.say(val, " ", type(val))
+           
+            val = dict:get("Jim")
+            ngx.say(val, " ", type(val))
+            val = dict:get("Tim")
+            ngx.say(val, " ", type(val))
+            val = dict:get("Lim")
+            ngx.say(val, " ", type(val))
+        ';
+    }
+--- request
+GET /test
+--- response_body
+8 number
+9 number
+10 number
+8 number
+9 number
+10 number
+--- no_error_log
+[error]
+
+=== TEST 10: delete function
+--- http_config
+    lua_shared_rbtree rbtree 10m;
+--- config
+    location = /test {
+        content_by_lua '
+            local cmp = function(a, b)
+                local x
+                if type(a) == "table" then
+                    x = a[1]
+                else
+                    x= a
+                end
+
+                if x > b[2] then
+                    return 1
+
+                elseif x < b[1] then
+                    return -1
+
+                else
+                    return 0
+                end
+            end
+
+            local rbtree = ngx.shrbtree.rbtree
+
+            local node = {}
+            node[3] = cmp
+            for i = 1, 1000, 1 do
+                node[1] = {(i-1)*10+1, i*10}
+                node[2] = {k1 = 1, k2 = 2, k3 = 3}
+                rbtree:insert(node)
+            end
+
+            val = rbtree:get{123, "k2", cmp}
+            ngx.say(val, " ", type(val))
+
+            for i = 1, 1000, 2 do
+                if not rbtree:delete{(i-1)*10+1, cmp} then
+                    print("error")
+                end
+            end
+
+            val = rbtree:get{123, "k2", cmp}
+            ngx.say(val, " ", type(val))
+
+            for i = 1, 1000, 2 do
+                val = rbtree:get{(i-1)*10+1, "k3", cmp}
+                if not val == nil then
+                    ngx.say("error");
+                end
+            end
+            
+            for i = 2, 1000, 2 do
+                val = rbtree:get{(i-1)*10+1, "k1", cmp}
+                if not val == 1 then
+                    ngx.say("error");
+                end
+            end
+            ngx.say("ok")
+        ';
+    }
+--- request
+GET /test
+--- response_body
+2 number
+nil nil
+ok
+--- no_error_log
+[error]

--- a/t/132-shrbtree.t
+++ b/t/132-shrbtree.t
@@ -8,7 +8,7 @@ use Test::Nginx::Socket::Lua;
 
 #repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 3 );
+plan tests => repeat_each(10) * (blocks() * 3);
 
 #no_diff();
 no_long_string();

--- a/t/132-shrbtree.t
+++ b/t/132-shrbtree.t
@@ -36,7 +36,7 @@ __DATA__
                     return 0
                 end 
             end
-            local rbtree = ngx.shrbtree.rbtree
+            local rbtree = ngx.shared.rbtree
             rbtree:insert{"a", 1, cmp}
             rbtree:insert{"b", 12, cmp}
             rbtree:insert{"c", 123, cmp}
@@ -85,7 +85,7 @@ GET /test
                 end
 
             end
-            local rbtree = ngx.shrbtree.rbtree
+            local rbtree = ngx.shared.rbtree
             rbtree:insert{"a", 0.1, cmp}
             rbtree:insert{"b", 0.12, cmp}
             rbtree:insert{"c", 0.123, cmp}
@@ -135,7 +135,7 @@ GET /test
 
             end
             
-            local rbtree = ngx.shrbtree.rbtree
+            local rbtree = ngx.shared.rbtree
             rbtree:insert{1, "s", cmp}
             rbtree:insert{2, "ss", cmp}
             rbtree:insert{3, "sss", cmp}
@@ -192,7 +192,7 @@ sssss string
                 end
             end
 
-            local rbtree = ngx.shrbtree.rbtree
+            local rbtree = ngx.shared.rbtree
             local node = {}
 
             node[1] = {1, 3}
@@ -239,84 +239,6 @@ nil nil
 --- no_error_log
 [error]
 
-=== TEST 5: number key, table value
---- http_config
-    lua_shared_rbtree rbtree 1m;
---- config
-    location = /test {
-        content_by_lua '
-            local cmp = function(a, b)
-                if a > b then
-                    return 1
-
-                elseif a < b then
-                    return -1
-
-                else
-                    return 0
-                end
-
-            end
-
-            local rbtree = ngx.shrbtree.rbtree
-            local node = {}
-
-            node[1] = 10
-            node[2] = {1, 2, 3, "4", "5", {1, 2, {1, 2}}}
-            node[3] = cmp
-            rbtree:insert(node)
-
-            node[1] = 11
-            node[2] = {k1 = "v1", k2="v2", k3="v3"}
-            node[3] = cmp
-            rbtree:insert(node);
-
-            node[1] = 12.34
-            node[2] = {1, "2", {3, "4", 5}, {"aa", "bb", "cc", {1, 2, 3}}} 
-            node[3] = cmp
-            rbtree:insert(node);
-
-            node[1] = 111
-            node[2] = {is_false = false, is_true = true}
-            node[3] = cmp
-            rbtree:insert(node)
-
-            local val
-            val = rbtree:get{10, 1, cmp}
-            ngx.say(val, " ", type(val))
-            val = rbtree:get{10, 4, cmp}
-            ngx.say(val, " ", type(val))
-            val = rbtree:get{10, 6, cmp}
-            ngx.say(val[3][2], " ", type(val[3][2]))
-            
-            val = rbtree:get{11, "k1", cmp}
-            ngx.say(val, " ", type(val))
-            
-            val = rbtree:get{12.34, cmp}
-
-            ngx.say(val[1], " ", type(val[1]))
-            ngx.say(val[4][4][1], " ", type(val[4][4][1]))
-
-            val = rbtree:get{111, "is_false", cmp}
-            ngx.say(val, " ", type(val))
-            val = rbtree:get{111, "is_true", cmp}
-            ngx.say(val, " ", type(val))
-        ';
-    }
---- request
-GET /test
---- response_body
-1 number
-4 string
-2 number
-v1 string
-1 number
-1 number
-false boolean
-true boolean
---- no_error_log
-[error]
-
 === TEST 6: table key, table value
 --- http_config
     lua_shared_rbtree rbtree 1m;
@@ -342,7 +264,7 @@ true boolean
                 end
             end
 
-            local rbtree = ngx.shrbtree.rbtree
+            local rbtree = ngx.shared.rbtree
             local node = {}
 
             node[1] = {1, 3}
@@ -415,9 +337,9 @@ v3 string
                 end
 
             end
-            local rbtree1 = ngx.shrbtree.rbtree1
-            local rbtree2 = ngx.shrbtree.rbtree2
-            local rbtree3 = ngx.shrbtree.rbtree3
+            local rbtree1 = ngx.shared.rbtree1
+            local rbtree2 = ngx.shared.rbtree2
+            local rbtree3 = ngx.shared.rbtree3
 
             rbtree1:insert{"a", 11, cmp}
             rbtree1:insert{"b", 112, cmp}
@@ -472,7 +394,7 @@ GET /test
                 end
             end
 
-            local rbtree = ngx.shrbtree.rbtree
+            local rbtree = ngx.shared.rbtree
 
             local node = {}
             node[3] = cmp
@@ -522,7 +444,7 @@ ok
                 end 
             end
 
-            local rbtree = ngx.shrbtree.shrbtree
+            local rbtree = ngx.shared.shrbtree
             rbtree:insert{"Jim", 8,  cmp}
             rbtree:insert{"Tim", 9,  cmp}
             rbtree:insert{"Lim", 10, cmp}
@@ -580,7 +502,7 @@ GET /test
                 end
             end
 
-            local rbtree = ngx.shrbtree.rbtree
+            local rbtree = ngx.shared.rbtree
 
             local node = {}
             node[3] = cmp

--- a/t/133-shrbtree-bug.t
+++ b/t/133-shrbtree-bug.t
@@ -19,7 +19,7 @@ run_tests();
 
 __DATA__
 
-=== TEST 1: number key, table value
+=== TEST 1: number key, table value(It's no error to "curl localhost/test", when conf in "nginx.conf")
 --- http_config
     lua_shared_rbtree rbtree 1m;
 --- config

--- a/t/133-shrbtree-bug.t
+++ b/t/133-shrbtree-bug.t
@@ -1,0 +1,98 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use lib 'lib';
+use Test::Nginx::Socket::Lua;
+
+#worker_connections(1014);
+#master_process_enabled(1);
+#log_level('warn');
+
+#repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 3 );
+
+#no_diff();
+no_long_string();
+#master_on();
+#workers(2);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: number key, table value
+--- http_config
+    lua_shared_rbtree rbtree 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local cmp = function(a, b)
+                if a > b then
+                    return 1
+
+                elseif a < b then
+                    return -1
+
+                else
+                    return 0
+                end
+
+            end
+
+            local rbtree = ngx.shared.rbtree
+            local node = {}
+
+            node[1] = 10
+            node[2] = {1, 2, 3, "4", "5", {1, 2, {1, 2}}}
+            node[3] = cmp
+            rbtree:insert(node)
+
+            node[1] = 11
+            node[2] = {k1 = "v1", k2="v2", k3="v3"}
+            node[3] = cmp
+            rbtree:insert(node);
+
+            node[1] = 12.34
+            node[2] = {1, "2", {3, "4", 5}, {"aa", "bb", "cc", {1, 2, 3}}} 
+            node[3] = cmp
+            rbtree:insert(node);
+
+            node[1] = 111
+            node[2] = {is_false = false, is_true = true}
+            node[3] = cmp
+            rbtree:insert(node)
+
+            local val
+            val = rbtree:get{10, 1, cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{10, 4, cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{10, 6, cmp}
+            ngx.say(val[3][2], " ", type(val[3][2]))
+            
+            val = rbtree:get{11, "k1", cmp}
+            ngx.say(val, " ", type(val))
+            
+            val = rbtree:get{12.34, cmp}
+
+            ngx.say(val[1], " ", type(val[1]))
+            ngx.say(val[4][4][1], " ", type(val[4][4][1]))
+
+            val = rbtree:get{111, "is_false", cmp}
+            ngx.say(val, " ", type(val))
+            val = rbtree:get{111, "is_true", cmp}
+            ngx.say(val, " ", type(val))
+        ';
+    }
+--- request
+GET /test
+--- response_body
+1 number
+4 string
+2 number
+v1 string
+1 number
+1 number
+false boolean
+true boolean
+--- no_error_log
+[error]


### PR DESCRIPTION
# Introduction

**directive:** *ngx_shared_rbtree <name> <size>;*

**get in ngx_lua:** *rbtree = ngx.shared.RBTREE*
**get in ngx_lua:** *rbtree = ngx.shared\[name_var\]*

**API:**

* insert
* get
* delete

**features:**

* support table as key of red-black tree node.
* support table as value of red-black tree node.
* support base store and access.

**how to use:**

* write a compare function and to compare your keys.
  **convention:** two argument of your key type,
  if first argument > second argument return 1;
  if first argument < second argument return -1;
  if first argument == second argument return 0;

* call the API to do what you want.

Here is an example:

```nginx
   http {
       lua_shared_rbtree rbtree 10m;
       server {
           location = /test {
               content_by_lua '
                   local cmp = function(a, b)
                       local x
                       if type(a) == "table" then
                           x = a[1]
                       else
                           x= a
                       end

                       if x > b[2] then
                           return 1

                       elseif x < b[1] then
                           return -1

                       else
                           return 0
                       end
                   end

                   local rbtree = ngx.shared.rbtree
                   local node = {}

                   node[1] = {1, 3}
                   node[2] = {1, 2, 3, "4", "5"}
                   node[3] = cmp
                   rbtree:insert(node)

                   node[1] = {4, 6}
                   node[2] = {k1 = "v1", k2="v2", k3="v3"}
                   node[3] = cmp
                   rbtree:insert(node)

                   node[1] = {7, 9}
                   node[2] = {1, "2", {3, "4", 5}}
                   node[3] = cmp
                   rbtree:insert(node)

                   node[1] = {11, 19}
                   node[2] = {{1, 2, 3}, {"1", "2", "3"}}
                   node[3] = cmp
                   rbtree:insert(node)

                   local val
                   val = rbtree:get{3, 1, cmp}
                   ngx.say(val, " ", type(val))
                   val = rbtree:get{3, 4,  cmp}
                   ngx.say(val, " ", type(val))

                   val = rbtree:get{5, "k1", cmp}
                   ngx.say(val, " ", type(val))
                   val = rbtree:get{{4, 6}, "k3", cmp}
                   ngx.say(val, " ", type(val))

                   val = rbtree:get{7, 3, cmp}
                   ngx.say(val[2], " ", type(val[2]))
                   val = rbtree:get{19, 1, cmp}
                   ngx.say(val[1], " ", type(val[1]))

               ';
           }
       }
   }
```

# API

## ngx.shared.RBTREE.insert

**syntax:** *success, message = ngx.shared.RBTREE:insert{key, value, compare_function}*

* `key`: key of insert node.
* `value`: value of insert node.
* `compare_function`: a function to compare two keys.

* `success`: boolean value to indicate whether the node is stored or not.
* `message`: textual error message, can be `"no memory"`.

## ngx.shared.RBTREE.get

**syntax:** *value, message = ngx.shrbtree.RBTREE:get{key, [field, compare_function}*

* `key`: key of want to get node.
* `field`: Optional, key of table that if the value is table type.
* `compare_function`: a function to compare two keys.

* `value`: value of get by *key and optional field*.
* `message`: textual error message, can be `"no memory"`.

## ngx.shared.RBTREE.delete

**syntax:** *success, message = ngx.shrbtree.RBTREE:delete{key, compare_function}*

* `key`: key of delete node.
* `compare_function`: a function to compare two keys.

* `success`: boolean value to indicate whether the node is delete or not.
* `message`: textual error message, can be `"no memory"`.

# implementation

## Why to use table as argument of API

The implementation of ngx.shared.RBTREE requires a *compare function*,
that is a base function of a workable *shrbtree*.
In fact, this is that to support key of table type.
Oh! it is a really wonderful demand.

There is usual way that calling lua from C:

1. Define a Global Variable as function in lua.
2. get the function from Global table.
3. calling it in lua stack.

But I don't like Global Variable, then I pass *compare function*
to the API.

1. Define a function in lua.
2. Pass the function to the API.
3. calling it in lua stack.

But after the call, the function pop from lua stack.
I need to call the function many times, so this way was rejected.

Almighty table! like the Titan, powerful but heavy.

1. Define a function in lua.
2. Pass table that contains the function to the API.
3. get the function from table of argument.
4. calling it in lua stack.

## handle error 

- Throw Exception, when some errors caused by users (example bad argument).
- Return Message, when some problems caused by API (example no shared memory).
- Crash, when some errors occurred that the program not be processed. (example call lua function with lua_call).

## How to store *lua tables*

I use red-black tree to store *lua tables*.

- The table context stored in a *rbtree node*.
- The table elements stored in a *rbtree*.


```
                                                                    +---------+ 
                    .                                               |         | ...
                    .                                               | element |
                    .                                               +---------+
               +---------------+                                     ^
               |               |                                    /
               | table context |----------------------->+---------+/
               +---------------+                        |         |
               /             \                          | element |
              /               \                         +---------+\
             V                 V                                    \ 
       +---------+       +---------+                                 V
       |         |       |         |                                +---------+
       |         |       |         |                                |         |
       +---------+       +---------+                                | element | ...
    ...                       ...                                   +---------+

```

## about ngx.shared.DICT and ngx.shared.RBTREE

Now, I inject shdict and shrbtree API to ngx.shared table,
for example:

```nginx
  ngx_shared_rbtree a 1m;
  ngx_shared_dict   b 1m;
  ngx_shared_rbtree c 1m;
  ngx_shared_dict   d 1m;
```

After conf parser, the ngx.shdict is:

```lua
   ngx.shdict = {a={zone1}, b={zone2}, c={zone3}, d={zone4}}
```

I think it's a good way:

- Semantically, the *shrbtree* is belong to *ngx.shared*.

- Semantically, the shared memory of *shrbtree* is belong to
*shm_zones* of *ngx_http_lua_main_conf_t*.

- In the implementation, this way doesn't need extra info,
and use of existing information efficiently.

Concrete:

```c
    /* ngx_http_lua_util.c */
    static void
    ngx_http_lua_inject_shared_api(ngx_http_lua_main_conf_t *lmcf, lua_State *L)
    {
        /* ngx.shared table*/
        if (lmcf->shm_zones != NULL) {
            /* ngx.shared table exactly  */
            lua_createtable(L, 0, lmcf->shm_zones->nelts/* nrec */);
            ngx_http_lua_inject_shdict_api(lmcf, L);
            ngx_http_lua_inject_shrbtree_api(lmcf, L);
        } else {
            lua_newtable(L);
        }
        lua_setfield(L, -2, "shared");
    }
```

But, this changed ngx_lua source really.

Thanks!