### PR TITLE
Shm zones registration capi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,3 @@ tthread
 addr2line
 hup
 theaders
-
-GTAGS
-GPATH
-GRTAGS

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,7 @@ tthread
 addr2line
 hup
 theaders
+
+GTAGS
+GPATH
+GRTAGS

--- a/src/api/ngx_http_lua_api.h
+++ b/src/api/ngx_http_lua_api.h
@@ -46,6 +46,9 @@ ngx_int_t ngx_http_lua_shared_dict_get(ngx_shm_zone_t *shm_zone,
 
 ngx_shm_zone_t *ngx_http_lua_find_zone(u_char *name_data, size_t name_len);
 
+ngx_shm_zone_t *ngx_http_lua_shared_memory_add(ngx_conf_t *cf, ngx_str_t *name,
+                                               size_t size, void *tag);
+
 
 #endif /* _NGX_HTTP_LUA_API_H_INCLUDED_ */
 

--- a/src/ngx_http_lua_api.c
+++ b/src/ngx_http_lua_api.c
@@ -124,9 +124,8 @@ ngx_http_lua_shared_memory_add(ngx_conf_t *cf,
     }
 
     if (zone->data) {
-        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                           "share memory \"%V\" of ngx_lua is already defined" , name);
-        return NULL;
+        ctx = (ngx_http_lua_shm_zone_ctx_t *)zone->data;
+        return (ngx_shm_zone_t *)&ctx->data;
     }
 
     n = offsetof(ngx_http_lua_shm_zone_ctx_t, data)
@@ -156,31 +155,6 @@ ngx_http_lua_shared_memory_add(ngx_conf_t *cf,
 
     return *zp;
 }
-
-
-/* ngx_int_t */
-/* ngx_http_lua_shared_memory_inited(ngx_log_t *log, ngx_conf_t *cf) */
-/* { */
-/*     ngx_http_lua_main_conf_t *lmcf; */
-
-    /* lmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_lua_module); */
-    /* if (lmcf == NULL) { */
-    /*     return NGX_ERROR; */
-    /* } */
-
-    /* lmcf->shm_zones_inited++; */
-
-    /* if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts */
-    /*     && lmcf->init_handler) */
-    /* { */
-    /*     if (lmcf->init_handler(cf->log, lmcf, lmcf->lua) != NGX_OK) { */
-    /*         /\* an error happened *\/ */
-    /*         return NGX_ERROR; */
-    /*     } */
-    /* } */
-
-/*     return NGX_OK; */
-/* } */
 
 
 static ngx_int_t

--- a/src/ngx_http_lua_api.c
+++ b/src/ngx_http_lua_api.c
@@ -11,6 +11,16 @@
 #include "ngx_http_lua_util.h"
 
 
+typedef struct ngx_http_lua_shm_zone_ctx_s {
+    ngx_log_t                *log;
+    ngx_http_lua_main_conf_t *lmcf;
+
+    u_char                    data; /* ngx_shm_zone_t */
+} ngx_http_lua_shm_zone_ctx_t;
+
+
+static ngx_int_t
+ngx_http_lua_shared_memory_init(ngx_shm_zone_t *shm_zone, void *data);
 
 
 lua_State *
@@ -76,14 +86,18 @@ ngx_http_lua_add_package_preload(ngx_conf_t *cf, const char *package,
     return NGX_OK;
 }
 
+
 ngx_shm_zone_t *
 ngx_http_lua_shared_memory_add(ngx_conf_t *cf,
                                ngx_str_t *name,
                                size_t size,
                                void *tag)
 {
+    ngx_int_t                n;
     ngx_http_lua_main_conf_t *lmcf;
     ngx_shm_zone_t           **zp;
+    ngx_shm_zone_t           *zone;
+    ngx_http_lua_shm_zone_ctx_t *ctx;
 
     lmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_lua_module);
     if (lmcf == NULL) {
@@ -99,14 +113,9 @@ ngx_http_lua_shared_memory_add(ngx_conf_t *cf,
         if (ngx_array_init(lmcf->shm_zones, cf->pool, 2,
                            sizeof(ngx_shm_zone_t *))
             != NGX_OK)
-            {
-                return NULL;
-            }
-    }
-
-    zone = ngx_http_lua_find_zone(name->data, name->len);
-    if (zone != NULL) {
-        return zone;
+        {
+            return NULL;
+        }
     }
 
     zone = ngx_shared_memory_add(cf, name, (size_t) size, tag);
@@ -114,15 +123,112 @@ ngx_http_lua_shared_memory_add(ngx_conf_t *cf,
         return NULL;
     }
 
+    if (zone->data) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "share memory \"%V\" of ngx_lua is already defined" , name);
+        return NULL;
+    }
+
+    n = offsetof(ngx_http_lua_shm_zone_ctx_t, data)
+        + sizeof(ngx_shm_zone_t);
+
+    ctx = ngx_pcalloc(cf->pool, n);
+    if (ctx == NULL) {
+        return NULL;
+    }
+
+    ctx->lmcf = lmcf;
+    ctx->log = &cf->cycle->new_log;
+    ngx_memcpy(&ctx->data, zone, sizeof(*zone));
+
     zp = ngx_array_push(lmcf->shm_zones);
     if (zp == NULL) {
         return NULL;
     }
 
-    *zp = zone;
+    *zp = (ngx_shm_zone_t *)&ctx->data;
+
+    /* set zone init */
+    zone->init = ngx_http_lua_shared_memory_init;
+    zone->data = ctx;
 
     lmcf->requires_shm = 1;
 
-    return zone;
+    return *zp;
+}
+
+
+/* ngx_int_t */
+/* ngx_http_lua_shared_memory_inited(ngx_log_t *log, ngx_conf_t *cf) */
+/* { */
+/*     ngx_http_lua_main_conf_t *lmcf; */
+
+    /* lmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_lua_module); */
+    /* if (lmcf == NULL) { */
+    /*     return NGX_ERROR; */
+    /* } */
+
+    /* lmcf->shm_zones_inited++; */
+
+    /* if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts */
+    /*     && lmcf->init_handler) */
+    /* { */
+    /*     if (lmcf->init_handler(cf->log, lmcf, lmcf->lua) != NGX_OK) { */
+    /*         /\* an error happened *\/ */
+    /*         return NGX_ERROR; */
+    /*     } */
+    /* } */
+
+/*     return NGX_OK; */
+/* } */
+
+
+static ngx_int_t
+ngx_http_lua_shared_memory_init(ngx_shm_zone_t *shm_zone, void *data)
+{
+    ngx_http_lua_shm_zone_ctx_t *octx = data;
+    ngx_shm_zone_t              *ozone;
+    void                        *odata;
+
+    ngx_http_lua_main_conf_t    *lmcf;
+    ngx_http_lua_shm_zone_ctx_t *ctx;
+    ngx_shm_zone_t              *zone;
+
+    ctx = (ngx_http_lua_shm_zone_ctx_t *)shm_zone->data;
+    zone = (ngx_shm_zone_t *)&ctx->data;
+
+    odata = NULL;
+    if (octx) {
+        ozone = (ngx_shm_zone_t *)&octx->data;
+        odata = ozone->data;
+        zone->shm  = ozone->shm;
+        zone->noreuse = ozone->noreuse;
+
+    } else {
+        zone->shm = shm_zone->shm;
+        zone->noreuse = shm_zone->noreuse;
+    }
+
+    if (zone->init(zone, odata) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    lmcf = ctx->lmcf;
+    if (lmcf == NULL) {
+        return NGX_ERROR;
+    }
+
+    lmcf->shm_zones_inited++;
+
+    if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts
+        && lmcf->init_handler)
+    {
+        if (lmcf->init_handler(ctx->log, lmcf, lmcf->lua) != NGX_OK) {
+            /* an error happened */
+            return NGX_ERROR;
+        }
+    }
+
+    return NGX_OK;
 }
 /* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -48,20 +48,6 @@ ngx_http_lua_shared_dict(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_http_lua_shdict_ctx_t  *ctx;
     ssize_t                     size;
 
-    if (lmcf->shm_zones == NULL) {
-        lmcf->shm_zones = ngx_palloc(cf->pool, sizeof(ngx_array_t));
-        if (lmcf->shm_zones == NULL) {
-            return NGX_CONF_ERROR;
-        }
-
-        if (ngx_array_init(lmcf->shm_zones, cf->pool, 2,
-                           sizeof(ngx_shm_zone_t *))
-            != NGX_OK)
-        {
-            return NGX_CONF_ERROR;
-        }
-    }
-
     value = cf->args->elts;
 
     ctx = NULL;
@@ -91,8 +77,8 @@ ngx_http_lua_shared_dict(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ctx->main_conf = lmcf;
     ctx->log = &cf->cycle->new_log;
 
-    zone = ngx_shared_memory_add(cf, &name, (size_t) size,
-                                 &ngx_http_lua_module);
+    zone = ngx_http_lua_shared_memory_add(cf, &name, (size_t)size,
+                                          &ngx_http_lua_module);
     if (zone == NULL) {
         return NGX_CONF_ERROR;
     }
@@ -108,15 +94,6 @@ ngx_http_lua_shared_dict(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     zone->init = ngx_http_lua_shdict_init_zone;
     zone->data = ctx;
-
-    zp = ngx_array_push(lmcf->shm_zones);
-    if (zp == NULL) {
-        return NGX_CONF_ERROR;
-    }
-
-    *zp = zone;
-
-    lmcf->requires_shm = 1;
 
     return NGX_CONF_OK;
 }

--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -24,7 +24,7 @@
 #include "ngx_http_lua_initby.h"
 #include "ngx_http_lua_initworkerby.h"
 #include "ngx_http_lua_shdict.h"
-
+#include "api/ngx_http_lua_api.h"
 
 #if defined(NDK) && NDK
 #include "ngx_http_lua_setby.h"
@@ -44,7 +44,7 @@ ngx_http_lua_shared_dict(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     ngx_str_t                  *value, name;
     ngx_shm_zone_t             *zone;
-    ngx_shm_zone_t            **zp;
+    /* ngx_shm_zone_t            **zp; */
     ngx_http_lua_shdict_ctx_t  *ctx;
     ssize_t                     size;
 

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -53,7 +53,6 @@ ngx_http_lua_shdict_init_zone(ngx_shm_zone_t *shm_zone, void *data)
 
     size_t                      len;
     ngx_http_lua_shdict_ctx_t  *ctx;
-    /* ngx_http_lua_main_conf_t   *lmcf; */
 
     dd("init zone");
 
@@ -63,7 +62,7 @@ ngx_http_lua_shdict_init_zone(ngx_shm_zone_t *shm_zone, void *data)
         ctx->sh = octx->sh;
         ctx->shpool = octx->shpool;
 
-        goto done;
+        return NGX_OK;
     }
 
     ctx->shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
@@ -71,7 +70,7 @@ ngx_http_lua_shdict_init_zone(ngx_shm_zone_t *shm_zone, void *data)
     if (shm_zone->shm.exists) {
         ctx->sh = ctx->shpool->data;
 
-        goto done;
+        return NGX_OK;
     }
 
     ctx->sh = ngx_slab_alloc(ctx->shpool, sizeof(ngx_http_lua_shdict_shctx_t));
@@ -100,26 +99,6 @@ ngx_http_lua_shdict_init_zone(ngx_shm_zone_t *shm_zone, void *data)
     ctx->shpool->log_nomem = 0;
 #endif
 
-done:
-
-    dd("get lmcf");
-
-    /* lmcf = ctx->main_conf; */
-
-    dd("lmcf->lua: %p", lmcf->lua);
-
-    /* lmcf->shm_zones_inited++; */
-
-    /* if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts */
-    /*     && lmcf->init_handler) */
-    /* { */
-    /*     if (lmcf->init_handler(ctx->log, lmcf, lmcf->lua) != NGX_OK) { */
-    /*         /\* an error happened *\/ */
-    /*         return NGX_ERROR; */
-    /*     } */
-    /* } */
-
-    /* return NGX_OK; */
     return NGX_OK;
 }
 

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -53,7 +53,7 @@ ngx_http_lua_shdict_init_zone(ngx_shm_zone_t *shm_zone, void *data)
 
     size_t                      len;
     ngx_http_lua_shdict_ctx_t  *ctx;
-    ngx_http_lua_main_conf_t   *lmcf;
+    /* ngx_http_lua_main_conf_t   *lmcf; */
 
     dd("init zone");
 
@@ -104,21 +104,22 @@ done:
 
     dd("get lmcf");
 
-    lmcf = ctx->main_conf;
+    /* lmcf = ctx->main_conf; */
 
     dd("lmcf->lua: %p", lmcf->lua);
 
-    lmcf->shm_zones_inited++;
+    /* lmcf->shm_zones_inited++; */
 
-    if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts
-        && lmcf->init_handler)
-    {
-        if (lmcf->init_handler(ctx->log, lmcf, lmcf->lua) != NGX_OK) {
-            /* an error happened */
-            return NGX_ERROR;
-        }
-    }
+    /* if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts */
+    /*     && lmcf->init_handler) */
+    /* { */
+    /*     if (lmcf->init_handler(ctx->log, lmcf, lmcf->lua) != NGX_OK) { */
+    /*         /\* an error happened *\/ */
+    /*         return NGX_ERROR; */
+    /*     } */
+    /* } */
 
+    /* return NGX_OK; */
     return NGX_OK;
 }
 

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -34,12 +34,17 @@ static int ngx_http_lua_shdict_delete(lua_State *L);
 static int ngx_http_lua_shdict_flush_all(lua_State *L);
 static int ngx_http_lua_shdict_flush_expired(lua_State *L);
 static int ngx_http_lua_shdict_get_keys(lua_State *L);
+static inline ngx_shm_zone_t* ngx_http_lua_shdict_get_zone(lua_State *L,
+                                                           int index);
 
 
 #define NGX_HTTP_LUA_SHDICT_ADD         0x0001
 #define NGX_HTTP_LUA_SHDICT_REPLACE     0x0002
 #define NGX_HTTP_LUA_SHDICT_SAFE_STORE  0x0004
 
+enum {
+    SHDICT_USERDATA_INDEX = 1,
+};
 
 ngx_int_t
 ngx_http_lua_shdict_init_zone(ngx_shm_zone_t *shm_zone, void *data)
@@ -353,7 +358,6 @@ ngx_http_lua_inject_shdict_api(ngx_http_lua_main_conf_t *lmcf, lua_State *L)
             lua_pushvalue(L, -3); /* shared mt key ud mt */
             lua_setmetatable(L, -2); /* shared mt key ud */
             lua_rawset(L, -4); /* shared mt */
-                /* name = {zone[i]} */
         }
 
         lua_pop(L, 1); /* shared */
@@ -379,6 +383,17 @@ ngx_http_lua_shdict_get_stale(lua_State *L)
   return ngx_http_lua_shdict_get_helper(L, 1 /* stale */);
 }
 
+static inline ngx_shm_zone_t *
+ngx_http_lua_shdict_get_zone(lua_State *L, int index)
+{
+    ngx_shm_zone_t *zone;
+
+    lua_rawgeti(L, index, SHDICT_USERDATA_INDEX);
+    zone = lua_touserdata(L, -1);
+    lua_pop(L, 1);
+
+    return zone;
+}
 
 static int
 ngx_http_lua_shdict_get_helper(lua_State *L, int get_stale)
@@ -404,13 +419,11 @@ ngx_http_lua_shdict_get_helper(lua_State *L, int get_stale)
                           "but only seen %d", n);
     }
 
-    if (LUA_TTABLE != lua_type(L, 1)) {
+    if (lua_type(L, 1) != LUA_TTABLE ) {
         return luaL_error(L, "bad \"zone\" argument");
     }
 
-    lua_rawgeti(L, 1, 1);
-    zone = lua_touserdata(L, -1);
-    lua_pop(L, 1);
+    zone = ngx_http_lua_shdict_get_zone(L, 1);
     if (zone == NULL) {
         return luaL_error(L, "bad \"zone\" argument");
     }
@@ -583,9 +596,7 @@ ngx_http_lua_shdict_flush_all(lua_State *L)
 
     luaL_checktype(L, 1, LUA_TTABLE);
 
-    lua_rawgeti(L, 1, 1);
-    zone = lua_touserdata(L, -1);
-    lua_pop(L, 1);
+    zone = ngx_http_lua_shdict_get_zone(L, 1);
     if (zone == NULL) {
         return luaL_error(L, "bad user data for the ngx_shm_zone_t pointer");
     }
@@ -632,9 +643,7 @@ ngx_http_lua_shdict_flush_expired(lua_State *L)
 
     luaL_checktype(L, 1, LUA_TTABLE);
 
-    lua_rawgeti(L, 1, 1);
-    zone = lua_touserdata(L, -1);
-    lua_pop(L, 1);
+    zone = ngx_http_lua_shdict_get_zone(L, 1);
     if (zone == NULL) {
         return luaL_error(L, "bad user data for the ngx_shm_zone_t pointer");
     }
@@ -715,9 +724,7 @@ ngx_http_lua_shdict_get_keys(lua_State *L)
 
     luaL_checktype(L, 1, LUA_TTABLE);
 
-    lua_rawgeti(L, 1, 1);
-    zone = lua_touserdata(L, -1);
-    lua_pop(L, 1);
+    zone = ngx_http_lua_shdict_get_zone(L, 1);
     if (zone == NULL) {
         return luaL_error(L, "bad user data for the ngx_shm_zone_t pointer");
     }
@@ -855,13 +862,11 @@ ngx_http_lua_shdict_set_helper(lua_State *L, int flags)
                           "but only seen %d", n);
     }
 
-    if (LUA_TTABLE != lua_type(L, 1)) {
+    if (lua_type(L, 1) != LUA_TTABLE) {
         return luaL_error(L, "bad \"zone\" argument");
     }
 
-    lua_rawgeti(L, 1, 1);
-    zone = lua_touserdata(L, -1);
-    lua_pop(L, 1);
+    zone = ngx_http_lua_shdict_get_zone(L, 1);
     if (zone == NULL) {
         return luaL_error(L, "bad \"zone\" argument");
     }
@@ -1172,9 +1177,7 @@ ngx_http_lua_shdict_incr(lua_State *L)
         return luaL_error(L, "bad \"zone\" argument");
     }
 
-    lua_rawgeti(L, 1, 1);
-    zone = lua_touserdata(L, -1);
-    lua_pop(L, 1);
+    zone = ngx_http_lua_shdict_get_zone(L, 1);
     if (zone == NULL) {
         return luaL_error(L, "bad user data for the ngx_shm_zone_t pointer");
     }


### PR DESCRIPTION
@agentzh Oh, Sorry, there is a issue that `shm-zones-registration-capi` branch is base on `issue548`.
After I will fix. And the next capi of shm_zone registration is focus.

### need:
ngx_lua allocate and initialize shared memory that is need for users.

### needed:
User need to ensure all the shm zones are properly initialized before the Lua code in init_by_lua runs
that is needed by users.

like this:

```c++
    lmcf->shm_zones_inited++;

    if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts
        && lmcf->init_handler)
    {
        if (lmcf->init_handler(ctx->log, lmcf, lmcf->lua) != NGX_OK) {
            /* an error happened */
            return NGX_ERROR;
        }
    }

```

### So
1. define `ngx_http_lua_shared_memory_add` as need for user.
2. define `ngx_http_lua_shared_memory_init_` to avoid needed by user.
3. define `ngx_http_lua_shm_zone_ctx_t` as data for shm_zone,
and store `shm_zone` `data` `init function` of user.

### processes

add:
1. user call `ngx_http_lua_shared_memory_add`.
2. `ngx_http_lua_shared_memory_add` store `shm_zone` of user in `ngx_http_lua_shm_zone_ctx_t`.
3. `ngx_http_lua_shared_memory_add` set `ngx_http_lua_shared_memory_init` to `shm_zone` of ngx_lua.
4. `ngx_http_lua_shared_memory_add` set `ngx_http_lua_shm_zone_ctx_t` to `shm_zone` of ngx_lua.
5. user set `data` and `init` for `shm_zone` of self.

init:
1. ngx_core call `ngx_http_lua_shared_memory_init` to init shm_zone of ngx_lua.
2. `ngx_http_lua_shared_memory_init` call `user's init`.
3. `ngx_http_lua_shared_memory_init` ensure all the shm zones are properly initialized before the Lua code in init_by_lua runs.

Thinks!