### PR TITLE
ngx.shared.DICT add two feature: incr add an option argument initial value, replace add an option argument check_flags

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5626,17 +5626,22 @@ See also [ngx.shared.DICT](#ngxshareddict).
 
 ngx.shared.DICT.incr
 --------------------
-**syntax:** *newval, err = ngx.shared.DICT:incr(key, value)*
+**syntax:** *newval, err = ngx.shared.DICT:incr(key, value, init?)*
 
 **context:** *init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
 
 Increments the (numerical) value for `key` in the shm-based dictionary [ngx.shared.DICT](#ngxshareddict) by the step value `value`. Returns the new resulting number if the operation is successfully completed or `nil` and an error message otherwise.
 
-The key must already exist in the dictionary, otherwise it will return `nil` and `"not found"`.
+When the key is not exist in the dictionary and if `init` argument,
+
+1. is not specified, it will return `nil` and `"not found"`,
+1. is specified, it will create a new `key` with the new value: `value + init`.
+
+Like the [safe_add](#ngxshareddictsafe_add) method, it also never overrides the (least recently used) unexpired items in the store when running out of storage in the shared memory zone. In this case, it will immediately return `nil` and the string "no memory".
 
 If the original value is not a valid Lua number in the dictionary, it will return `nil` and `"not a number"`.
 
-The `value` argument can be any valid Lua numbers, like negative numbers or floating-point numbers.
+The `value` argument and `init` argument can be any valid Lua numbers, like negative numbers or floating-point numbers.
 
 This feature was first introduced in the `v0.3.1rc22` release.
 

--- a/README.markdown
+++ b/README.markdown
@@ -5594,11 +5594,13 @@ See also [ngx.shared.DICT](#ngxshareddict).
 
 ngx.shared.DICT.replace
 -----------------------
-**syntax:** *success, err, forcible = ngx.shared.DICT:replace(key, value, exptime?, flags?)*
+**syntax:** *success, err, forcible, curr_flags? = ngx.shared.DICT:replace(key, value, exptime?, flags?, check_flags?)*
 
 **context:** *init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
 
 Just like the [set](#ngxshareddictset) method, but only stores the key-value pair into the dictionary [ngx.shared.DICT](#ngxshareddict) if the key *does* exist.
+
+If current `user_flags` stored in the dictionary *does not* matched the `check_flags`, the `success` return value will be `false` and the `err` return value will be `"flags not matched"` and the `curr_flags` return value will be the current `user_flags` stored in the dictionary.
 
 If the `key` argument does *not* exist in the dictionary (or expired already), the `success` return value will be `false` and the `err` return value will be `"not found"`.
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -4685,11 +4685,13 @@ This feature was first introduced in the <code>v0.7.18</code> release.
 See also [[#ngx.shared.DICT|ngx.shared.DICT]].
 
 == ngx.shared.DICT.replace ==
-'''syntax:''' ''success, err, forcible = ngx.shared.DICT:replace(key, value, exptime?, flags?)''
+'''syntax:''' ''success, err, forcible, curr_flags? = ngx.shared.DICT:replace(key, value, exptime?, flags?, check_flags?)''
 
 '''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*''
 
 Just like the [[#ngx.shared.DICT.set|set]] method, but only stores the key-value pair into the dictionary [[#ngx.shared.DICT|ngx.shared.DICT]] if the key ''does'' exist.
+
+If current <code>user_flags</code> stored in the dictionary ''does not'' matched the <code>check_flags</code>, the <code>success</code> return value will be <code>false</code> and the <code>err</code> return value will be <code>"flags not matched"</code> and the <code>curr_flags</code> return value will be the current <code>user_flags</code> stored in the dictionary.
 
 If the <code>key</code> argument does ''not'' exist in the dictionary (or expired already), the <code>success</code> return value will be <code>false</code> and the <code>err</code> return value will be <code>"not found"</code>.
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -4711,17 +4711,22 @@ This feature was first introduced in the <code>v0.3.1rc22</code> release.
 See also [[#ngx.shared.DICT|ngx.shared.DICT]].
 
 == ngx.shared.DICT.incr ==
-'''syntax:''' ''newval, err = ngx.shared.DICT:incr(key, value)''
+'''syntax:''' ''newval, err = ngx.shared.DICT:incr(key, value, init?)''
 
 '''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*''
 
 Increments the (numerical) value for <code>key</code> in the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]] by the step value <code>value</code>. Returns the new resulting number if the operation is successfully completed or <code>nil</code> and an error message otherwise.
 
-The key must already exist in the dictionary, otherwise it will return <code>nil</code> and <code>"not found"</code>.
+When the key is not exist in the dictionary and if <code>init</code> argument,
+
+# is not specified, it will return <code>nil</code> and <code>"not found"</code>,
+# is specified, it will create a new <code>key</code> with the new value: <code>value + init</code>.
+
+Like the [[#ngx.shared.DICT.safe_add|safe_add]] method, it also never overrides the (least recently used) unexpired items in the store when running out of storage in the shared memory zone. In this case, it will immediately return <code>nil</code> and the string "no memory".
 
 If the original value is not a valid Lua number in the dictionary, it will return <code>nil</code> and <code>"not a number"</code>.
 
-The <code>value</code> argument can be any valid Lua numbers, like negative numbers or floating-point numbers.
+The <code>value</code> argument and <code>init</code> argument can be any valid Lua numbers, like negative numbers or floating-point numbers.
 
 This feature was first introduced in the <code>v0.3.1rc22</code> release.
 

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -1173,11 +1173,12 @@ ngx_http_lua_shdict_incr(lua_State *L)
     u_char                      *p;
     ngx_shm_zone_t              *zone;
     double                       value;
+    ngx_rbtree_node_t           *node;
 
     n = lua_gettop(L);
 
-    if (n != 3) {
-        return luaL_error(L, "expecting 3 arguments, but only seen %d", n);
+    if (n != 3 && n != 4) {
+        return luaL_error(L, "expecting 3 or 4 arguments, but only seen %d", n);
     }
 
     if (lua_type(L, 1) != LUA_TTABLE) {
@@ -1229,6 +1230,22 @@ ngx_http_lua_shdict_incr(lua_State *L)
     dd("shdict lookup returned %d", (int) rc);
 
     if (rc == NGX_DECLINED || rc == NGX_DONE) {
+        if (n == 4) {
+            num = value + luaL_checknumber(L, 4);
+
+            if (rc == NGX_DONE && sd->value_len == sizeof(double)) {
+                dd("go to allocated");
+
+                ngx_queue_remove(&sd->queue);
+                ngx_queue_insert_head(&ctx->sh->queue, &sd->queue);
+
+                goto allocated;
+            }
+
+            dd("go to insert");
+            goto insert;
+        }
+
         ngx_shmtx_unlock(&ctx->shpool->mutex);
 
         lua_pushnil(L);
@@ -1256,6 +1273,57 @@ ngx_http_lua_shdict_incr(lua_State *L)
     ngx_memcpy(&num, p, sizeof(double));
     num += value;
 
+    ngx_memcpy(p, (double *) &num, sizeof(double));
+
+    ngx_shmtx_unlock(&ctx->shpool->mutex);
+
+    lua_pushnumber(L, num);
+    lua_pushnil(L);
+    return 2;
+
+insert:
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+                   "lua shared dict incr: creating a new entry");
+
+    n = offsetof(ngx_rbtree_node_t, color)
+        + offsetof(ngx_http_lua_shdict_node_t, data)
+        + key.len
+        + sizeof(double);
+
+    node = ngx_slab_alloc_locked(ctx->shpool, n);
+
+    if (node == NULL) {
+        ngx_shmtx_unlock(&ctx->shpool->mutex);
+
+        lua_pushboolean(L, 0);
+        lua_pushliteral(L, "no memory");
+        return 2;
+    }
+
+    sd = (ngx_http_lua_shdict_node_t *) &node->color;
+
+    node->key = hash;
+
+    sd->key_len = (u_short) key.len;
+
+    sd->value_len = (uint32_t) sizeof(double);
+
+    ngx_rbtree_insert(&ctx->sh->rbtree, node);
+
+    ngx_queue_insert_head(&ctx->sh->queue, &sd->queue);
+
+allocated:
+
+    sd->user_flags = 0;
+
+    sd->expires = 0;
+
+    dd("setting value type to %d", LUA_TNUMBER);
+
+    sd->value_type = (uint8_t) LUA_TNUMBER;
+
+    p = ngx_copy(sd->data, key.data, key.len);
     ngx_memcpy(p, (double *) &num, sizeof(double));
 
     ngx_shmtx_unlock(&ctx->shpool->mutex);

--- a/t/043-shdict.t
+++ b/t/043-shdict.t
@@ -817,7 +817,7 @@ foo = hello
 
 
 
-=== TEST 31: incr key (key exists)
+=== TEST 31: replace key (key exists)
 --- http_config
     lua_shared_dict dogs 1m;
 --- config
@@ -951,7 +951,7 @@ foo = 10534
 
 
 
-=== TEST 36: replace key (key not exists)
+=== TEST 36: incr key (key not exists)
 --- http_config
     lua_shared_dict dogs 1m;
 --- config
@@ -974,7 +974,7 @@ foo = nil
 
 
 
-=== TEST 37: replace key (key expired)
+=== TEST 37: incr key (key expired)
 --- http_config
     lua_shared_dict dogs 1m;
 --- config
@@ -2396,3 +2396,169 @@ GET /test
 type: table
 --- no_error_log
 [error]
+
+
+
+=== TEST 91: incr key with init (key exists)
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local dogs = ngx.shared.dogs
+            dogs:set("foo", 32)
+            local res, err = dogs:incr("foo", 10502, 0)
+            ngx.say("incr: ", res, " ", err)
+            ngx.say("foo = ", dogs:get("foo"))
+        ';
+    }
+--- request
+GET /test
+--- response_body
+incr: 10534 nil
+foo = 10534
+--- no_error_log
+[error]
+
+
+
+=== TEST 92: incr key with init (key not exists)
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local dogs = ngx.shared.dogs
+            dogs:set("bah", 32)
+            local res, err = dogs:incr("foo", 2, 0)
+            ngx.say("incr: ", res, " ", err)
+            ngx.say("foo = ", dogs:get("foo"))
+        ';
+    }
+--- request
+GET /test
+--- response_body
+incr: 2 nil
+foo = 2
+--- no_error_log
+[error]
+
+
+
+=== TEST 93: incr key with init (key expired)
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local dogs = ngx.shared.dogs
+            dogs:set("bar", 3, 0.001)
+            dogs:set("baz", 2, 0.001)
+            dogs:set("foo", 32, 0.001)
+            ngx.location.capture("/sleep/0.002")
+            local res, err = dogs:incr("foo", 10502, 0)
+            ngx.say("incr: ", res, " ", err)
+            ngx.say("foo = ", dogs:get("foo"))
+        ';
+    }
+    location ~ ^/sleep/(.+) {
+        echo_sleep $1;
+    }
+--- request
+GET /test
+--- response_body
+incr: 10502 nil
+foo = 10502
+--- no_error_log
+[error]
+
+
+
+=== TEST 94: incr key with init (incr by 0)
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local dogs = ngx.shared.dogs
+            dogs:set("foo", 32)
+            local res, err = dogs:incr("foo", 0, 1)
+            ngx.say("incr: ", res, " ", err)
+            ngx.say("foo = ", dogs:get("foo"))
+        ';
+    }
+--- request
+GET /test
+--- response_body
+incr: 32 nil
+foo = 32
+--- no_error_log
+[error]
+
+
+
+=== TEST 95: incr key with init (incr by floating point number)
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local dogs = ngx.shared.dogs
+            local res, err = dogs:incr("foo", 0.14, 32)
+            ngx.say("incr: ", res, " ", err)
+            ngx.say("foo = ", dogs:get("foo"))
+        ';
+    }
+--- request
+GET /test
+--- response_body
+incr: 32.14 nil
+foo = 32.14
+--- no_error_log
+[error]
+
+
+
+=== TEST 96: incr key with init (incr by negative numbers)
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local dogs = ngx.shared.dogs
+            local res, err = dogs:incr("foo", -0.14, -31.72)
+            ngx.say("incr: ", res, " ", err)
+            ngx.say("foo = ", dogs:get("foo"))
+        ';
+    }
+--- request
+GET /test
+--- response_body
+incr: -31.86 nil
+foo = -31.86
+--- no_error_log
+[error]
+
+
+
+=== TEST 97: incr key (original value is not number)
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local dogs = ngx.shared.dogs
+            dogs:set("foo", true)
+            local res, err = dogs:incr("foo", -0.14, -31.72)
+            ngx.say("incr: ", res, " ", err)
+            ngx.say("foo = ", dogs:get("foo"))
+        ';
+    }
+--- request
+GET /test
+--- response_body
+incr: nil not a number
+foo = true
+--- no_error_log
+[error]
+

--- a/t/043-shdict.t
+++ b/t/043-shdict.t
@@ -2562,3 +2562,56 @@ foo = true
 --- no_error_log
 [error]
 
+
+
+=== TEST 98: replace key with check_flags (key exists)
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local dogs = ngx.shared.dogs
+            dogs:set("foo", 32, 0, 1)
+            local res, err, forcible, curr_flags = dogs:replace("foo", 10502, 0, 2, 1)
+            ngx.say("replace: ", res, " ", err, " ", forcible, " ", curr_flags)
+            ngx.say("foo = ", dogs:get("foo"))
+
+            local res, err, forcible, curr_flags = dogs:replace("foo", 105, 0, 2, 1)
+            ngx.say("replace: ", res, " ", err, " ", forcible, " ", curr_flags)
+            ngx.say("foo = ", dogs:get("foo"))
+
+        ';
+    }
+--- request
+GET /test
+--- response_body
+replace: true nil false nil
+foo = 105022
+replace: false flags not matched false 2
+foo = 105022
+--- no_error_log
+[error]
+
+
+
+=== TEST 99: replace key with check_flags (key not exists)
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local dogs = ngx.shared.dogs
+            dogs:set("bah", 32, 0, 1)
+            local res, err, forcible, curr_flags = dogs:replace("foo", 10502, 0, 2, 1)
+            ngx.say("replace: ", res, " ", err, " ", forcible, " ", curr_flags)
+            ngx.say("foo = ", dogs:get("foo"))
+        ';
+    }
+--- request
+GET /test
+--- response_body
+replace: false not found false nil
+foo = nil
+--- no_error_log
+[error]
+


### PR DESCRIPTION
1. incr add an option argument initial value
When the key is not exist in the dictionary and if init argument,
1) is not specified, it will return nil and "not found",
2) is specified, it will create a new key with the new value: value + init.

This is usefull when we used it as an counter.

2. replace add an option argument check_flags
Seems like check-and-set, replace will act only check_flags matched the current user_flags in the dictionary, and user_flags is used as an version.
This is usefull, cause we have a race-condition window between dict:get() and dict:set() across multiple nginx worker processes, and we can do like this example

I'm not sure if this api is good,  maybe a new api named cas_by_flags is better?

```lua
local value, flags = dict:get(key)
local success, err, forcible
while true do
    local newvalue = value + 1 -- something like this
    success, err, forcible, flags = dict:replace(key, newvalue, 0, new_flags, flags)
    if sucess then
        break
    elseif err == "not found" then
        -- turn to add
    elseif err == "flags not matched" then
         -- we just try again
    else
         -- something like no memory, just break
        break
    end
end