### PR TITLE
feature: add api in shdict: lpush, lpop, rpush, rpop, llen

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6316,7 +6316,7 @@ ngx.shared.DICT.lpush
 
 **context:** *init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
 
-Insert the specified (numerical or string) `value` at the head of the list named `key` in the shm-based dictionary [ngx.shared.DICT](#ngxshareddict). Returns the length of the list after the push operations.
+Inserts the specified (numerical or string) `value` at the head of the list named `key` in the shm-based dictionary [ngx.shared.DICT](#ngxshareddict). Returns the length of the list after the push operations.
 
 If `key` does not exist, it is created as empty list before performing the push operations. When key holds a value that is not a list, it will return `nil` and `"wrongtype operation"`.
 
@@ -6334,7 +6334,7 @@ ngx.shared.DICT.rpush
 
 **context:** *init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
 
-Similar to the [lpush](#ngxshareddictlpush) method, but insert the specified (numerical or string) `value` at the tail of the list named `key`.
+Similar to the [lpush](#ngxshareddictlpush) method, but inserts the specified (numerical or string) `value` at the tail of the list named `key`.
 
 This feature was first introduced in the `v0.*.*` release.
 

--- a/README.markdown
+++ b/README.markdown
@@ -3041,6 +3041,12 @@ Nginx API for Lua
 * [ngx.shared.DICT.replace](#ngxshareddictreplace)
 * [ngx.shared.DICT.delete](#ngxshareddictdelete)
 * [ngx.shared.DICT.incr](#ngxshareddictincr)
+* [ngx.shared.DICT.lpush](#ngxshareddictlpush)
+* [ngx.shared.DICT.rpush](#ngxshareddictrpush)
+* [ngx.shared.DICT.lpop](#ngxshareddictlpop)
+* [ngx.shared.DICT.rpop](#ngxshareddictrpop)
+* [ngx.shared.DICT.llen](#ngxshareddictllen)
+* [ngx.shared.DICT.expire](#ngxshareddictexpire)
 * [ngx.shared.DICT.flush_all](#ngxshareddictflush_all)
 * [ngx.shared.DICT.flush_expired](#ngxshareddictflush_expired)
 * [ngx.shared.DICT.get_keys](#ngxshareddictget_keys)
@@ -6035,6 +6041,12 @@ The resulting object `dict` has the following methods:
 * [replace](#ngxshareddictreplace)
 * [delete](#ngxshareddictdelete)
 * [incr](#ngxshareddictincr)
+* [lpush](#ngxshareddictlpush)
+* [rpush](#ngxshareddictrpush)
+* [lpop](#ngxshareddictlpop)
+* [rpop](#ngxshareddictrpop)
+* [llen](#ngxshareddictllen)
+* [expire](#ngxshareddictexpire)
 * [flush_all](#ngxshareddictflush_all)
 * [flush_expired](#ngxshareddictflush_expired)
 * [get_keys](#ngxshareddictget_keys)
@@ -6293,6 +6305,102 @@ The `value` argument and `init` argument can be any valid Lua numbers, like nega
 This method was first introduced in the `v0.3.1rc22` release.
 
 The optional `init` parameter was first added in the `v0.10.6` release.
+
+See also [ngx.shared.DICT](#ngxshareddict).
+
+[Back to TOC](#nginx-api-for-lua)
+
+ngx.shared.DICT.lpush
+---------------------
+**syntax:** *length, err = ngx.shared.DICT:lpush(key, value)*
+
+**context:** *init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
+
+Insert the specified (numerical or string) `value` at the head of the list named `key` in the shm-based dictionary [ngx.shared.DICT](#ngxshareddict). Returns the length of the list after the push operations.
+
+If `key` does not exist, it is created as empty list before performing the push operations. When key holds a value that is not a list, it will return `nil` and `"wrongtype operation"`.
+
+It never overrides the (least recently used) unexpired items in the store when running out of storage in the shared memory zone. In this case, it will immediately return `nil` and the string "no memory".
+
+This feature was first introduced in the `v0.*.*` release.
+
+See also [ngx.shared.DICT](#ngxshareddict).
+
+[Back to TOC](#nginx-api-for-lua)
+
+ngx.shared.DICT.rpush
+---------------------
+**syntax:** *length, err = ngx.shared.DICT:rpush(key, value)*
+
+**context:** *init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
+
+Similar to the [lpush](#ngxshareddictlpush) method, but insert the specified (numerical or string) `value` at the tail of the list named `key`.
+
+This feature was first introduced in the `v0.*.*` release.
+
+See also [ngx.shared.DICT](#ngxshareddict).
+
+[Back to TOC](#nginx-api-for-lua)
+
+ngx.shared.DICT.lpop
+--------------------
+**syntax:** *val, err = ngx.shared.DICT:lpop(key)*
+
+**context:** *init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
+
+Removes and returns the first element of the list named `key` in the shm-based dictionary [ngx.shared.DICT](#ngxshareddict).
+
+If `key` does not exist, it will return `nil`. When key holds a value that is not a list, it will return `nil` and `"wrongtype operation"`.
+
+This feature was first introduced in the `v0.*.*` release.
+
+See also [ngx.shared.DICT](#ngxshareddict).
+
+[Back to TOC](#nginx-api-for-lua)
+
+ngx.shared.DICT.rpop
+--------------------
+**syntax:** *val, err = ngx.shared.DICT:rpop(key)*
+
+**context:** *init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
+
+Removes and returns the last element of the list named `key` in the shm-based dictionary [ngx.shared.DICT](#ngxshareddict).
+
+If `key` does not exist, it will return `nil`. When key holds a value that is not a list, it will return `nil` and `"wrongtype operation"`.
+
+This feature was first introduced in the `v0.*.*` release.
+
+See also [ngx.shared.DICT](#ngxshareddict).
+
+[Back to TOC](#nginx-api-for-lua)
+
+ngx.shared.DICT.llen
+--------------------
+**syntax:** *len, err = ngx.shared.DICT:llen(key)*
+
+**context:** *init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
+
+Returns the length of the list named `key` in the shm-based dictionary [ngx.shared.DICT](#ngxshareddict).
+
+If key does not exist, it is interpreted as an empty list and 0 is returned. When key holds a value that is not a list, it will return `nil` and `"wrongtype operation"`.
+
+This feature was first introduced in the `v0.*.*` release.
+
+See also [ngx.shared.DICT](#ngxshareddict).
+
+[Back to TOC](#nginx-api-for-lua)
+
+ngx.shared.DICT.expire
+----------------------
+**syntax:** *ok, err = ngx.shared.DICT:expire(key, exptime)*
+
+**context:** *init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
+
+The `exptime` argument specifies expiration time (in seconds) for the inserted key-value pair. The time resolution is 0.001 seconds. If the exptime takes the value 0, then the item will never be expired.
+
+If key does not exist or has been expired, it will return `false` and `"not found"`. Otherwise it will return `true`.
+
+This feature was first introduced in the `v0.*.*` release.
 
 See also [ngx.shared.DICT](#ngxshareddict).
 

--- a/README.markdown
+++ b/README.markdown
@@ -3046,7 +3046,6 @@ Nginx API for Lua
 * [ngx.shared.DICT.lpop](#ngxshareddictlpop)
 * [ngx.shared.DICT.rpop](#ngxshareddictrpop)
 * [ngx.shared.DICT.llen](#ngxshareddictllen)
-* [ngx.shared.DICT.expire](#ngxshareddictexpire)
 * [ngx.shared.DICT.flush_all](#ngxshareddictflush_all)
 * [ngx.shared.DICT.flush_expired](#ngxshareddictflush_expired)
 * [ngx.shared.DICT.get_keys](#ngxshareddictget_keys)
@@ -6046,7 +6045,6 @@ The resulting object `dict` has the following methods:
 * [lpop](#ngxshareddictlpop)
 * [rpop](#ngxshareddictrpop)
 * [llen](#ngxshareddictllen)
-* [expire](#ngxshareddictexpire)
 * [flush_all](#ngxshareddictflush_all)
 * [flush_expired](#ngxshareddictflush_expired)
 * [get_keys](#ngxshareddictget_keys)
@@ -6383,22 +6381,6 @@ ngx.shared.DICT.llen
 Returns the length of the list named `key` in the shm-based dictionary [ngx.shared.DICT](#ngxshareddict).
 
 If key does not exist, it is interpreted as an empty list and 0 is returned. When the `key` already takes a value that is not a list, it will return `nil` and `"value not a list"`.
-
-This feature was first introduced in the `v0.*.*` release.
-
-See also [ngx.shared.DICT](#ngxshareddict).
-
-[Back to TOC](#nginx-api-for-lua)
-
-ngx.shared.DICT.expire
-----------------------
-**syntax:** *ok, err = ngx.shared.DICT:expire(key, exptime)*
-
-**context:** *init_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;*
-
-The `exptime` argument specifies a new expiration time (in seconds) for an existing key-value pair in the shm-based dictionary [ngx.shared.DICT](#ngxshareddict) specified by the `key` argument. The time resolution is 0.001 seconds. If the exptime takes the value 0, then the item will never expire.
-
-If key does not exist or has expired, it will return `false` and `"not found"`. Otherwise it will return `true`.
 
 This feature was first introduced in the `v0.*.*` release.
 

--- a/README.markdown
+++ b/README.markdown
@@ -6105,7 +6105,7 @@ ngx.shared.DICT.get
 
 **context:** *set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;*
 
-Retrieving the value in the dictionary [ngx.shared.DICT](#ngxshareddict) for the key `key`. If the key does not exist or has been expired, then `nil` will be returned.
+Retrieving the value in the dictionary [ngx.shared.DICT](#ngxshareddict) for the key `key`. If the key does not exist or has expired, then `nil` will be returned.
 
 In case of errors, `nil` and a string describing the error will be returned.
 
@@ -6314,11 +6314,11 @@ ngx.shared.DICT.lpush
 ---------------------
 **syntax:** *length, err = ngx.shared.DICT:lpush(key, value)*
 
-**context:** *init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
+**context:** *init_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;*
 
-Inserts the specified (numerical or string) `value` at the head of the list named `key` in the shm-based dictionary [ngx.shared.DICT](#ngxshareddict). Returns the length of the list after the push operations.
+Inserts the specified (numerical or string) `value` at the head of the list named `key` in the shm-based dictionary [ngx.shared.DICT](#ngxshareddict). Returns the number of elements in the list after the push operation.
 
-If `key` does not exist, it is created as empty list before performing the push operations. When key holds a value that is not a list, it will return `nil` and `"wrongtype operation"`.
+If `key` does not exist, it is created as an empty list before performing the push operations. When the `key` already takes a value that is not a list, it will return `nil` and `"value not a list"`.
 
 It never overrides the (least recently used) unexpired items in the store when running out of storage in the shared memory zone. In this case, it will immediately return `nil` and the string "no memory".
 
@@ -6332,7 +6332,7 @@ ngx.shared.DICT.rpush
 ---------------------
 **syntax:** *length, err = ngx.shared.DICT:rpush(key, value)*
 
-**context:** *init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
+**context:** *init_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;*
 
 Similar to the [lpush](#ngxshareddictlpush) method, but inserts the specified (numerical or string) `value` at the tail of the list named `key`.
 
@@ -6346,11 +6346,11 @@ ngx.shared.DICT.lpop
 --------------------
 **syntax:** *val, err = ngx.shared.DICT:lpop(key)*
 
-**context:** *init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
+**context:** *init_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;*
 
 Removes and returns the first element of the list named `key` in the shm-based dictionary [ngx.shared.DICT](#ngxshareddict).
 
-If `key` does not exist, it will return `nil`. When key holds a value that is not a list, it will return `nil` and `"wrongtype operation"`.
+If `key` does not exist, it will return `nil`. When the `key` already takes a value that is not a list, it will return `nil` and `"value not a list"`.
 
 This feature was first introduced in the `v0.*.*` release.
 
@@ -6362,11 +6362,11 @@ ngx.shared.DICT.rpop
 --------------------
 **syntax:** *val, err = ngx.shared.DICT:rpop(key)*
 
-**context:** *init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
+**context:** *init_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;*
 
 Removes and returns the last element of the list named `key` in the shm-based dictionary [ngx.shared.DICT](#ngxshareddict).
 
-If `key` does not exist, it will return `nil`. When key holds a value that is not a list, it will return `nil` and `"wrongtype operation"`.
+If `key` does not exist, it will return `nil`. When the `key` already takes a value that is not a list, it will return `nil` and `"value not a list"`.
 
 This feature was first introduced in the `v0.*.*` release.
 
@@ -6378,11 +6378,11 @@ ngx.shared.DICT.llen
 --------------------
 **syntax:** *len, err = ngx.shared.DICT:llen(key)*
 
-**context:** *init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
+**context:** *init_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;*
 
 Returns the length of the list named `key` in the shm-based dictionary [ngx.shared.DICT](#ngxshareddict).
 
-If key does not exist, it is interpreted as an empty list and 0 is returned. When key holds a value that is not a list, it will return `nil` and `"wrongtype operation"`.
+If key does not exist, it is interpreted as an empty list and 0 is returned. When the `key` already takes a value that is not a list, it will return `nil` and `"value not a list"`.
 
 This feature was first introduced in the `v0.*.*` release.
 
@@ -6394,11 +6394,11 @@ ngx.shared.DICT.expire
 ----------------------
 **syntax:** *ok, err = ngx.shared.DICT:expire(key, exptime)*
 
-**context:** *init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.**
+**context:** *init_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;*
 
-The `exptime` argument specifies expiration time (in seconds) for the inserted key-value pair. The time resolution is 0.001 seconds. If the exptime takes the value 0, then the item will never be expired.
+The `exptime` argument specifies a new expiration time (in seconds) for an existing key-value pair in the shm-based dictionary [ngx.shared.DICT](#ngxshareddict) specified by the `key` argument. The time resolution is 0.001 seconds. If the exptime takes the value 0, then the item will never expire.
 
-If key does not exist or has been expired, it will return `false` and `"not found"`. Otherwise it will return `true`.
+If key does not exist or has expired, it will return `false` and `"not found"`. Otherwise it will return `true`.
 
 This feature was first introduced in the `v0.*.*` release.
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -5058,7 +5058,6 @@ The resulting object <code>dict</code> has the following methods:
 * [[#ngx.shared.DICT.lpop|lpop]]
 * [[#ngx.shared.DICT.rpop|rpop]]
 * [[#ngx.shared.DICT.llen|llen]]
-* [[#ngx.shared.DICT.expire|expire]]
 * [[#ngx.shared.DICT.flush_all|flush_all]]
 * [[#ngx.shared.DICT.flush_expired|flush_expired]]
 * [[#ngx.shared.DICT.get_keys|get_keys]]
@@ -5347,19 +5346,6 @@ See also [[#ngx.shared.DICT|ngx.shared.DICT]].
 Returns the length of the list named <code>key</code> in the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]].
 
 If key does not exist, it is interpreted as an empty list and 0 is returned. When the <code>key</code> already takes a value that is not a list, it will return <code>nil</code> and <code>"value not a list"</code>.
-
-This feature was first introduced in the <code>v0.*.*</code> release.
-
-See also [[#ngx.shared.DICT|ngx.shared.DICT]].
-
-== ngx.shared.DICT.expire ==
-'''syntax:''' ''ok, err = ngx.shared.DICT:expire(key, exptime)''
-
-'''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*''
-
-The <code>exptime</code> argument specifies a new expiration time (in seconds) for an existing key-value pair in the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]] specified by the <code>key</code> argument. The time resolution is 0.001 seconds. If the exptime takes the value 0, then the item will never expire.
-
-If key does not exist or has expired, it will return <code>false</code> and <code>"not found"</code>. Otherwise it will return <code>true</code>.
 
 This feature was first introduced in the <code>v0.*.*</code> release.
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -5053,6 +5053,12 @@ The resulting object <code>dict</code> has the following methods:
 * [[#ngx.shared.DICT.replace|replace]]
 * [[#ngx.shared.DICT.delete|delete]]
 * [[#ngx.shared.DICT.incr|incr]]
+* [[#ngx.shared.DICT.lpush|lpush]]
+* [[#ngx.shared.DICT.rpush|rpush]]
+* [[#ngx.shared.DICT.lpop|lpop]]
+* [[#ngx.shared.DICT.rpop|rpop]]
+* [[#ngx.shared.DICT.llen|llen]]
+* [[#ngx.shared.DICT.expire|expire]]
 * [[#ngx.shared.DICT.flush_all|flush_all]]
 * [[#ngx.shared.DICT.flush_expired|flush_expired]]
 * [[#ngx.shared.DICT.get_keys|get_keys]]
@@ -5278,6 +5284,84 @@ The <code>value</code> argument and <code>init</code> argument can be any valid 
 This method was first introduced in the <code>v0.3.1rc22</code> release.
 
 The optional `init` parameter was first added in the <code>v0.10.6</code> release.
+
+See also [[#ngx.shared.DICT|ngx.shared.DICT]].
+
+== ngx.shared.DICT.lpush ==
+'''syntax:''' ''length, err = ngx.shared.DICT:lpush(key, value)''
+
+'''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*''
+
+Insert the specified (numerical or string) <code>value</code> at the head of the list named <code>key</code> in the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]]. Returns the length of the list after the push operations.
+
+If <code>key</code> does not exist, it is created as empty list before performing the push operations. When key holds a value that is not a list, it will return <code>nil</code> and <code>"wrongtype operation"</code>.
+
+It never overrides the (least recently used) unexpired items in the store when running out of storage in the shared memory zone. In this case, it will immediately return <code>nil</code> and the string "no memory".
+
+This feature was first introduced in the <code>v0.*.*</code> release.
+
+See also [[#ngx.shared.DICT|ngx.shared.DICT]].
+
+== ngx.shared.DICT.rpush ==
+'''syntax:''' ''length, err = ngx.shared.DICT:rpush(key, value)''
+
+'''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*''
+
+Similar to the [[#ngx.shared.DICT.lpush|lpush]] method, but insert the specified (numerical or string) <code>value</code> at the tail of the list named <code>key</code>.
+
+This feature was first introduced in the <code>v0.*.*</code> release.
+
+See also [[#ngx.shared.DICT|ngx.shared.DICT]].
+
+== ngx.shared.DICT.lpop ==
+'''syntax:''' ''val, err = ngx.shared.DICT:lpop(key)''
+
+'''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*''
+
+Removes and returns the first element of the list named <code>key</code> in the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]].
+
+If <code>key</code> does not exist, it will return <code>nil</code>. When key holds a value that is not a list, it will return <code>nil</code> and <code>"wrongtype operation"</code>.
+
+This feature was first introduced in the <code>v0.*.*</code> release.
+
+See also [[#ngx.shared.DICT|ngx.shared.DICT]].
+
+== ngx.shared.DICT.rpop ==
+'''syntax:''' ''val, err = ngx.shared.DICT:rpop(key)''
+
+'''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*''
+
+Removes and returns the last element of the list named <code>key</code> in the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]].
+
+If <code>key</code> does not exist, it will return <code>nil</code>. When key holds a value that is not a list, it will return <code>nil</code> and <code>"wrongtype operation"</code>.
+
+This feature was first introduced in the <code>v0.*.*</code> release.
+
+See also [[#ngx.shared.DICT|ngx.shared.DICT]].
+
+== ngx.shared.DICT.llen ==
+'''syntax:''' ''len, err = ngx.shared.DICT:llen(key)''
+
+'''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*''
+
+Returns the length of the list named <code>key</code> in the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]].
+
+If key does not exist, it is interpreted as an empty list and 0 is returned. When key holds a value that is not a list, it will return <code>nil</code> and <code>"wrongtype operation"</code>.
+
+This feature was first introduced in the <code>v0.*.*</code> release.
+
+See also [[#ngx.shared.DICT|ngx.shared.DICT]].
+
+== ngx.shared.DICT.expire ==
+'''syntax:''' ''ok, err = ngx.shared.DICT:expire(key, exptime)''
+
+'''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*''
+
+The <code>exptime</code> argument specifies expiration time (in seconds) for the inserted key-value pair. The time resolution is 0.001 seconds. If the exptime takes the value 0, then the item will never be expired.
+
+If key does not exist or has been expired, it will return <code>false</code> and <code>"not found"</code>. Otherwise it will return <code>true</code>.
+
+This feature was first introduced in the <code>v0.*.*</code> release.
 
 See also [[#ngx.shared.DICT|ngx.shared.DICT]].
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -5292,7 +5292,7 @@ See also [[#ngx.shared.DICT|ngx.shared.DICT]].
 
 '''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*''
 
-Insert the specified (numerical or string) <code>value</code> at the head of the list named <code>key</code> in the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]]. Returns the length of the list after the push operations.
+Inserts the specified (numerical or string) <code>value</code> at the head of the list named <code>key</code> in the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]]. Returns the length of the list after the push operations.
 
 If <code>key</code> does not exist, it is created as empty list before performing the push operations. When key holds a value that is not a list, it will return <code>nil</code> and <code>"wrongtype operation"</code>.
 
@@ -5307,7 +5307,7 @@ See also [[#ngx.shared.DICT|ngx.shared.DICT]].
 
 '''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*''
 
-Similar to the [[#ngx.shared.DICT.lpush|lpush]] method, but insert the specified (numerical or string) <code>value</code> at the tail of the list named <code>key</code>.
+Similar to the [[#ngx.shared.DICT.lpush|lpush]] method, but inserts the specified (numerical or string) <code>value</code> at the tail of the list named <code>key</code>.
 
 This feature was first introduced in the <code>v0.*.*</code> release.
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -5112,7 +5112,7 @@ This feature was first introduced in the <code>v0.3.1rc22</code> release.
 
 '''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
 
-Retrieving the value in the dictionary [[#ngx.shared.DICT|ngx.shared.DICT]] for the key <code>key</code>. If the key does not exist or has been expired, then <code>nil</code> will be returned.
+Retrieving the value in the dictionary [[#ngx.shared.DICT|ngx.shared.DICT]] for the key <code>key</code>. If the key does not exist or has expired, then <code>nil</code> will be returned.
 
 In case of errors, <code>nil</code> and a string describing the error will be returned.
 
@@ -5292,9 +5292,9 @@ See also [[#ngx.shared.DICT|ngx.shared.DICT]].
 
 '''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*''
 
-Inserts the specified (numerical or string) <code>value</code> at the head of the list named <code>key</code> in the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]]. Returns the length of the list after the push operations.
+Inserts the specified (numerical or string) <code>value</code> at the head of the list named <code>key</code> in the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]]. Returns the number of elements in the list after the push operation.
 
-If <code>key</code> does not exist, it is created as empty list before performing the push operations. When key holds a value that is not a list, it will return <code>nil</code> and <code>"wrongtype operation"</code>.
+If <code>key</code> does not exist, it is created as an empty list before performing the push operations. When the <code>key</code> already takes a value that is not a list, it will return <code>nil</code> and <code>"value not a list"</code>.
 
 It never overrides the (least recently used) unexpired items in the store when running out of storage in the shared memory zone. In this case, it will immediately return <code>nil</code> and the string "no memory".
 
@@ -5320,7 +5320,7 @@ See also [[#ngx.shared.DICT|ngx.shared.DICT]].
 
 Removes and returns the first element of the list named <code>key</code> in the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]].
 
-If <code>key</code> does not exist, it will return <code>nil</code>. When key holds a value that is not a list, it will return <code>nil</code> and <code>"wrongtype operation"</code>.
+If <code>key</code> does not exist, it will return <code>nil</code>. When the <code>key</code> already takes a value that is not a list, it will return <code>nil</code> and <code>"value not a list"</code>.
 
 This feature was first introduced in the <code>v0.*.*</code> release.
 
@@ -5333,7 +5333,7 @@ See also [[#ngx.shared.DICT|ngx.shared.DICT]].
 
 Removes and returns the last element of the list named <code>key</code> in the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]].
 
-If <code>key</code> does not exist, it will return <code>nil</code>. When key holds a value that is not a list, it will return <code>nil</code> and <code>"wrongtype operation"</code>.
+If <code>key</code> does not exist, it will return <code>nil</code>. When the <code>key</code> already takes a value that is not a list, it will return <code>nil</code> and <code>"value not a list"</code>.
 
 This feature was first introduced in the <code>v0.*.*</code> release.
 
@@ -5346,7 +5346,7 @@ See also [[#ngx.shared.DICT|ngx.shared.DICT]].
 
 Returns the length of the list named <code>key</code> in the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]].
 
-If key does not exist, it is interpreted as an empty list and 0 is returned. When key holds a value that is not a list, it will return <code>nil</code> and <code>"wrongtype operation"</code>.
+If key does not exist, it is interpreted as an empty list and 0 is returned. When the <code>key</code> already takes a value that is not a list, it will return <code>nil</code> and <code>"value not a list"</code>.
 
 This feature was first introduced in the <code>v0.*.*</code> release.
 
@@ -5357,9 +5357,9 @@ See also [[#ngx.shared.DICT|ngx.shared.DICT]].
 
 '''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*''
 
-The <code>exptime</code> argument specifies expiration time (in seconds) for the inserted key-value pair. The time resolution is 0.001 seconds. If the exptime takes the value 0, then the item will never be expired.
+The <code>exptime</code> argument specifies a new expiration time (in seconds) for an existing key-value pair in the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]] specified by the <code>key</code> argument. The time resolution is 0.001 seconds. If the exptime takes the value 0, then the item will never expire.
 
-If key does not exist or has been expired, it will return <code>false</code> and <code>"not found"</code>. Otherwise it will return <code>true</code>.
+If key does not exist or has expired, it will return <code>false</code> and <code>"not found"</code>. Otherwise it will return <code>true</code>.
 
 This feature was first introduced in the <code>v0.*.*</code> release.
 

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -2206,7 +2206,7 @@ ngx_http_lua_find_zone(u_char *name_data, size_t name_len)
         if (name->len == name_len
             && ngx_strncmp(name->data, name_data, name_len) == 0)
         {
-            return zone;
+            return &zone[i];
         }
     }
 

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -310,8 +310,8 @@ ngx_http_lua_shdict_expire(ngx_http_lua_shdict_ctx_t *ctx, ngx_uint_t n)
             list_queue = ngx_http_lua_shdict_get_list_head(sd, sd->key_len);
 
             for (lq = ngx_queue_head(list_queue);
-                lq != ngx_queue_sentinel(list_queue);
-                lq = ngx_queue_next(lq))
+                 lq != ngx_queue_sentinel(list_queue);
+                 lq = ngx_queue_next(lq))
             {
                 lnode = ngx_queue_data(lq, ngx_http_lua_shdict_list_node_t,
                                        queue);
@@ -552,6 +552,7 @@ ngx_http_lua_shdict_get_helper(lua_State *L, int get_stale)
     value.len = (size_t) sd->value_len;
 
     switch (value_type) {
+
     case LUA_TSTRING:
 
         lua_pushlstring(L, (char *) value.data, value.len);
@@ -754,8 +755,8 @@ ngx_http_lua_shdict_flush_expired(lua_State *L)
                 list_queue = ngx_http_lua_shdict_get_list_head(sd, sd->key_len);
 
                 for (lq = ngx_queue_head(list_queue);
-                    lq != ngx_queue_sentinel(list_queue);
-                    lq = ngx_queue_next(lq))
+                     lq != ngx_queue_sentinel(list_queue);
+                     lq = ngx_queue_next(lq))
                 {
                     lnode = ngx_queue_data(lq, ngx_http_lua_shdict_list_node_t,
                                            queue);
@@ -989,6 +990,7 @@ ngx_http_lua_shdict_set_helper(lua_State *L, int flags)
     value_type = lua_type(L, 3);
 
     switch (value_type) {
+
     case LUA_TSTRING:
         value.data = (u_char *) lua_tolstring(L, 3, &value.len);
         break;
@@ -1090,7 +1092,8 @@ ngx_http_lua_shdict_set_helper(lua_State *L, int flags)
 
 replace:
 
-        if (value.data && value.len == (size_t) sd->value_len
+        if (value.data
+            && value.len == (size_t) sd->value_len
             && sd->value_type != LUA_TTABLE)
         {
 
@@ -1141,8 +1144,8 @@ remove:
             queue = ngx_http_lua_shdict_get_list_head(sd, key.len);
 
             for (q = ngx_queue_head(queue);
-                q != ngx_queue_sentinel(queue);
-                q = ngx_queue_next(q))
+                 q != ngx_queue_sentinel(queue);
+                 q = ngx_queue_next(q))
             {
                 p = (u_char *) ngx_queue_data(q,
                                               ngx_http_lua_shdict_list_node_t,
@@ -1534,6 +1537,7 @@ ngx_http_lua_shared_dict_get(ngx_shm_zone_t *zone, u_char *key_data,
     len = (size_t) sd->value_len;
 
     switch (value->type) {
+
     case LUA_TSTRING:
 
         if (value->value.s.data == NULL || value->value.s.len == 0) {
@@ -1669,6 +1673,7 @@ ngx_http_lua_shdict_push_helper(lua_State *L, int flags)
     value_type = lua_type(L, 3);
 
     switch (value_type) {
+
     case LUA_TSTRING:
         value.data = (u_char *) lua_tolstring(L, 3, &value.len);
         break;
@@ -1729,8 +1734,8 @@ ngx_http_lua_shdict_push_helper(lua_State *L, int flags)
         queue = ngx_http_lua_shdict_get_list_head(sd, key.len);
 
         for (q = ngx_queue_head(queue);
-            q != ngx_queue_sentinel(queue);
-            q = ngx_queue_next(q))
+             q != ngx_queue_sentinel(queue);
+             q = ngx_queue_next(q))
         {
             /* TODO: reuse matched size list node */
             lnode = ngx_queue_data(q, ngx_http_lua_shdict_list_node_t, queue);
@@ -1821,11 +1826,12 @@ push_node:
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
                    "lua shared dict list: creating a new list node");
 
-    n = sizeof(ngx_http_lua_shdict_list_node_t)
+    n = offsetof(ngx_http_lua_shdict_list_node_t, data)
         + value.len;
 
-    lnode = ngx_slab_alloc_locked(ctx->shpool,
-                                  sizeof(ngx_http_lua_shdict_list_node_t));
+    dd("list node length: %d", n);
+
+    lnode = ngx_slab_alloc_locked(ctx->shpool, n);
 
     if (lnode == NULL) {
 
@@ -1892,7 +1898,6 @@ ngx_http_lua_shdict_rpop(lua_State *L)
 {
     return ngx_http_lua_shdict_pop_helper(L, NGX_HTTP_LUA_SHDICT_RIGHT);
 }
-
 
 
 static int
@@ -2008,6 +2013,7 @@ ngx_http_lua_shdict_pop_helper(lua_State *L, int flags)
     value.len = (size_t) lnode->value_len;
 
     switch (value_type) {
+
     case LUA_TSTRING:
 
         lua_pushlstring(L, (char *) value.data, value.len);
@@ -2319,6 +2325,7 @@ ngx_http_lua_ffi_shdict_store(ngx_shm_zone_t *zone, int op, u_char *key,
     hash = ngx_crc32_short(key, key_len);
 
     switch (value_type) {
+
     case LUA_TSTRING:
         /* do nothing */
         break;
@@ -2367,6 +2374,7 @@ ngx_http_lua_ffi_shdict_store(ngx_shm_zone_t *zone, int op, u_char *key,
             *errmsg = "not found";
             return NGX_DECLINED;
         }
+
         /* rc == NGX_OK */
 
         goto replace;
@@ -2401,7 +2409,8 @@ ngx_http_lua_ffi_shdict_store(ngx_shm_zone_t *zone, int op, u_char *key,
 
 replace:
 
-        if (str_value_buf && str_value_len == (size_t) sd->value_len
+        if (str_value_buf
+            && str_value_len == (size_t) sd->value_len
             && sd->value_type != LUA_TTABLE)
         {
 
@@ -2450,8 +2459,8 @@ remove:
             queue = ngx_http_lua_shdict_get_list_head(sd, key_len);
 
             for (q = ngx_queue_head(queue);
-                q != ngx_queue_sentinel(queue);
-                q = ngx_queue_next(q))
+                 q != ngx_queue_sentinel(queue);
+                 q = ngx_queue_next(q))
             {
                 p = (u_char *) ngx_queue_data(q,
                                               ngx_http_lua_shdict_list_node_t,
@@ -2628,6 +2637,7 @@ ngx_http_lua_ffi_shdict_get(ngx_shm_zone_t *zone, u_char *key,
     }
 
     switch (*value_type) {
+
     case LUA_TSTRING:
         *str_value_len = value.len;
         ngx_memcpy(*str_value_buf, value.data, value.len);

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -61,17 +61,20 @@ enum {
 };
 
 enum {
-    SHDICT_TNIL = 0,        // same as LUA_TNIL
-    SHDICT_TBOOLEAN = 1,    // same as LUA_TBOOLEAN
-    SHDICT_TNUMBER = 3,     // same as LUA_TNUMBER
-    SHDICT_TSTRING = 4,     // same as LUA_TSTRING
+    SHDICT_TNIL = 0,        /* same as LUA_TNIL */
+    SHDICT_TBOOLEAN = 1,    /* same as LUA_TBOOLEAN */
+    SHDICT_TNUMBER = 3,     /* same as LUA_TNUMBER */
+    SHDICT_TSTRING = 4,     /* same as LUA_TSTRING */
     SHDICT_TLIST = 5,
 };
 
 
-#define ngx_http_lua_shdict_get_list_head(sd, key_len)                      \
-    (ngx_queue_t *) ngx_align_ptr(((u_char *) &sd->data + key_len),         \
-                                  NGX_ALIGNMENT)
+static ngx_queue_t *
+ngx_http_lua_shdict_get_list_head(ngx_http_lua_shdict_node_t *sd, u_short len)
+{
+    return (ngx_queue_t *) ngx_align_ptr(((u_char *) &sd->data + len),
+                                         NGX_ALIGNMENT);
+}
 
 
 ngx_int_t

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -320,7 +320,6 @@ ngx_http_lua_shdict_expire(ngx_http_lua_shdict_ctx_t *ctx, ngx_uint_t n)
         }
 
         if (sd->value_type == SHDICT_TLIST) {
-
             list_queue = ngx_http_lua_shdict_get_list_head(sd, sd->key_len);
 
             for (lq = ngx_queue_head(list_queue);
@@ -765,7 +764,6 @@ ngx_http_lua_shdict_flush_expired(lua_State *L)
         if (sd->expires != 0 && sd->expires <= now) {
 
             if (sd->value_type == SHDICT_TLIST) {
-
                 list_queue = ngx_http_lua_shdict_get_list_head(sd, sd->key_len);
 
                 for (lq = ngx_queue_head(list_queue);
@@ -2156,6 +2154,7 @@ ngx_http_lua_shdict_llen(lua_State *L)
     dd("shdict lookup returned %d", (int) rc);
 
     if (rc == NGX_OK) {
+
         if (sd->value_type != SHDICT_TLIST) {
             ngx_shmtx_unlock(&ctx->shpool->mutex);
 
@@ -2471,7 +2470,6 @@ replace:
 remove:
 
         if (sd->value_type == SHDICT_TLIST) {
-
             queue = ngx_http_lua_shdict_get_list_head(sd, key_len);
 
             for (q = ngx_queue_head(queue);

--- a/src/ngx_http_lua_shdict.h
+++ b/src/ngx_http_lua_shdict.h
@@ -25,6 +25,14 @@ typedef struct {
 
 
 typedef struct {
+    uint8_t                      value_type;
+    uint32_t                     value_len;
+    ngx_queue_t                  queue;
+    u_char                       data[1];
+} ngx_http_lua_shdict_list_node_t;
+
+
+typedef struct {
     ngx_rbtree_t                  rbtree;
     ngx_rbtree_node_t             sentinel;
     ngx_queue_t                   queue;

--- a/src/ngx_http_lua_shdict.h
+++ b/src/ngx_http_lua_shdict.h
@@ -35,7 +35,7 @@ typedef struct {
 typedef struct {
     ngx_rbtree_t                  rbtree;
     ngx_rbtree_node_t             sentinel;
-    ngx_queue_t                   queue;
+    ngx_queue_t                   lru_queue;
 } ngx_http_lua_shdict_shctx_t;
 
 

--- a/src/ngx_http_lua_shdict.h
+++ b/src/ngx_http_lua_shdict.h
@@ -25,9 +25,9 @@ typedef struct {
 
 
 typedef struct {
-    uint8_t                      value_type;
-    uint32_t                     value_len;
     ngx_queue_t                  queue;
+    uint32_t                     value_len;
+    uint8_t                      value_type;
     u_char                       data[1];
 } ngx_http_lua_shdict_list_node_t;
 

--- a/t/062-count.t
+++ b/t/062-count.t
@@ -283,7 +283,7 @@ n = 4
 --- request
 GET /test
 --- response_body
-n = 19
+n = 18
 --- no_error_log
 [error]
 

--- a/t/062-count.t
+++ b/t/062-count.t
@@ -283,7 +283,7 @@ n = 4
 --- request
 GET /test
 --- response_body
-n = 13
+n = 19
 --- no_error_log
 [error]
 

--- a/t/133-shdict-list.t
+++ b/t/133-shdict-list.t
@@ -678,3 +678,39 @@ keys number: 0
 --- no_error_log
 [error]
 
+
+
+=== TEST 17: long list node
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            local long_str = string.rep("foo", 10)
+
+            for i = 1, 3 do
+                local len, err = dogs:lpush("list", long_str)
+                if not len then
+                    ngx.say("push err: ", err)
+                end
+            end
+
+            for i = 1, 3 do
+                local val, err = dogs:lpop("list")
+                if val then
+                    ngx.say(val)
+                end
+            end
+        }
+    }
+--- request
+GET /test
+--- response_body
+foofoofoofoofoofoofoofoofoofoo
+foofoofoofoofoofoofoofoofoofoo
+foofoofoofoofoofoofoofoofoofoo
+--- no_error_log
+[error]
+

--- a/t/133-shdict-list.t
+++ b/t/133-shdict-list.t
@@ -1,0 +1,680 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use Test::Nginx::Socket::Lua;
+
+#worker_connections(1014);
+#master_process_enabled(1);
+#log_level('warn');
+
+#repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 3 + 0);
+
+#no_diff();
+no_long_string();
+#master_on();
+#workers(2);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: lpush & lpop
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            local len, err = dogs:lpush("foo", "bar")
+            if len then
+                ngx.say("push success")
+            else
+                ngx.say("push err: ", err)
+            end
+
+            local val, err = dogs:llen("foo")
+            ngx.say(val, " ", err)
+
+            local val, err = dogs:lpop("foo")
+            ngx.say(val, " ", err)
+
+            local val, err = dogs:llen("foo")
+            ngx.say(val, " ", err)
+
+            local val, err = dogs:lpop("foo")
+            ngx.say(val, " ", err)
+        }
+    }
+--- request
+GET /test
+--- response_body
+push success
+1 nil
+bar nil
+0 nil
+nil nil
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: get operation on list type
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            local len, err = dogs:lpush("foo", "bar")
+            if len then
+                ngx.say("push success")
+            else
+                ngx.say("push err: ", err)
+            end
+
+            local val, err = dogs:get("foo")
+            ngx.say(val, " ", err)
+        }
+    }
+--- request
+GET /test
+--- response_body
+push success
+nil wrongtype operation
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: set operation on list type
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            local len, err = dogs:lpush("foo", "bar")
+            if len then
+                ngx.say("push success")
+            else
+                ngx.say("push err: ", err)
+            end
+
+            local ok, err = dogs:set("foo", "bar")
+            ngx.say(ok, " ", err)
+
+            local val, err = dogs:get("foo")
+            ngx.say(val, " ", err)
+        }
+    }
+--- request
+GET /test
+--- response_body
+push success
+true nil
+bar nil
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: replace operation on list type
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            local len, err = dogs:lpush("foo", "bar")
+            if len then
+                ngx.say("push success")
+            else
+                ngx.say("push err: ", err)
+            end
+
+            local ok, err = dogs:replace("foo", "bar")
+            ngx.say(ok, " ", err)
+
+            local val, err = dogs:get("foo")
+            ngx.say(val, " ", err)
+        }
+    }
+--- request
+GET /test
+--- response_body
+push success
+true nil
+bar nil
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: add operation on list type
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            local len, err = dogs:lpush("foo", "bar")
+            if len then
+                ngx.say("push success")
+            else
+                ngx.say("push err: ", err)
+            end
+
+            local ok, err = dogs:add("foo", "bar")
+            ngx.say(ok, " ", err)
+
+            local val, err = dogs:get("foo")
+            ngx.say(val, " ", err)
+        }
+    }
+--- request
+GET /test
+--- response_body
+push success
+false exists
+nil wrongtype operation
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: delete operation on list type
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            local len, err = dogs:lpush("foo", "bar")
+            if len then
+                ngx.say("push success")
+            else
+                ngx.say("push err: ", err)
+            end
+
+            local ok, err = dogs:delete("foo")
+            ngx.say(ok, " ", err)
+
+            local val, err = dogs:get("foo")
+            ngx.say(val, " ", err)
+        }
+    }
+--- request
+GET /test
+--- response_body
+push success
+true nil
+nil nil
+--- no_error_log
+[error]
+
+
+
+=== TEST 7: incr operation on list type
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            local len, err = dogs:lpush("foo", "bar")
+            if len then
+                ngx.say("push success")
+            else
+                ngx.say("push err: ", err)
+            end
+
+            local ok, err = dogs:incr("foo", 1)
+            ngx.say(ok, " ", err)
+
+            local val, err = dogs:get("foo")
+            ngx.say(val, " ", err)
+        }
+    }
+--- request
+GET /test
+--- response_body
+push success
+nil not a number
+nil wrongtype operation
+--- no_error_log
+[error]
+
+
+
+=== TEST 8: get_keys operation on list type
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            local len, err = dogs:lpush("foo", "bar")
+            if len then
+                ngx.say("push success")
+            else
+                ngx.say("push err: ", err)
+            end
+
+            local keys, err = dogs:get_keys()
+            ngx.say("key: ", keys[1])
+        }
+    }
+--- request
+GET /test
+--- response_body
+push success
+key: foo
+--- no_error_log
+[error]
+
+
+
+=== TEST 9: push operation on key-value type
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            local ok, err = dogs:set("foo", "bar")
+            if ok then
+                ngx.say("set success")
+            else
+                ngx.say("set err: ", err)
+            end
+
+            local len, err = dogs:lpush("foo", "bar")
+            ngx.say(len, " ", err)
+
+            local val, err = dogs:get("foo")
+            ngx.say(val, " ", err)
+        }
+    }
+--- request
+GET /test
+--- response_body
+set success
+nil wrongtype operation
+bar nil
+--- no_error_log
+[error]
+
+
+
+=== TEST 10: pop operation on key-value type
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            local ok, err = dogs:set("foo", "bar")
+            if ok then
+                ngx.say("set success")
+            else
+                ngx.say("set err: ", err)
+            end
+
+            local val, err = dogs:lpop("foo")
+            ngx.say(val, " ", err)
+
+            local val, err = dogs:get("foo")
+            ngx.say(val, " ", err)
+        }
+    }
+--- request
+GET /test
+--- response_body
+set success
+nil wrongtype operation
+bar nil
+--- no_error_log
+[error]
+
+
+
+=== TEST 11: llen operation on key-value type
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            local ok, err = dogs:set("foo", "bar")
+            if ok then
+                ngx.say("set success")
+            else
+                ngx.say("set err: ", err)
+            end
+
+            local val, err = dogs:llen("foo")
+            ngx.say(val, " ", err)
+
+            local val, err = dogs:get("foo")
+            ngx.say(val, " ", err)
+        }
+    }
+--- request
+GET /test
+--- response_body
+set success
+nil wrongtype operation
+bar nil
+--- no_error_log
+[error]
+
+
+
+=== TEST 12: lpush and lpop
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            for i = 1, 3 do
+                local len, err = dogs:lpush("foo", i)
+                if len ~= i then
+                    ngx.say("push err: ", err)
+                    break
+                end
+            end
+
+            for i = 1, 3 do
+                local val, err = dogs:lpop("foo")
+                if not val then
+                    ngx.say("pop err: ", err)
+                    break
+                else
+                    ngx.say(val)
+                end
+            end
+        }
+    }
+--- request
+GET /test
+--- response_body
+3
+2
+1
+--- no_error_log
+[error]
+
+
+
+=== TEST 13: lpush and rpop
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            for i = 1, 3 do
+                local len, err = dogs:lpush("foo", i)
+                if len ~= i then
+                    ngx.say("push err: ", err)
+                    break
+                end
+            end
+
+            for i = 1, 3 do
+                local val, err = dogs:rpop("foo")
+                if not val then
+                    ngx.say("pop err: ", err)
+                    break
+                else
+                    ngx.say(val)
+                end
+            end
+        }
+    }
+--- request
+GET /test
+--- response_body
+1
+2
+3
+--- no_error_log
+[error]
+
+
+
+=== TEST 14: rpush and lpop
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            for i = 1, 3 do
+                local len, err = dogs:rpush("foo", i)
+                if len ~= i then
+                    ngx.say("push err: ", err)
+                    break
+                end
+            end
+
+            for i = 1, 3 do
+                local val, err = dogs:lpop("foo")
+                if not val then
+                    ngx.say("pop err: ", err)
+                    break
+                else
+                    ngx.say(val)
+                end
+            end
+        }
+    }
+--- request
+GET /test
+--- response_body
+1
+2
+3
+--- no_error_log
+[error]
+
+
+
+=== TEST 15: list removed: expired
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            local max
+            for i = 1, 10000 do
+                local key = string.format("%05d", i)
+
+                local len , err = dogs:lpush(key, i)
+                if not len then
+                    max = i
+                    break
+                end
+
+                local ok = dogs:expire(key, 0.01)
+                if not ok then
+                    ngx.say("expire error")
+                end
+            end
+
+            local keys = dogs:get_keys(0)
+
+            ngx.say("max-1 matched keys length: ", max-1 == #keys)
+
+            ngx.sleep(0.01)
+
+            local keys = dogs:get_keys(0)
+
+            ngx.say("keys all expired, left number: ", #keys)
+
+            -- some reused, some removed
+            for i = 10000, 1, -1 do
+                local key = string.format("%05d", i)
+
+                local len, err = dogs:lpush(key, i)
+                if not len then
+                    ngx.say("loop again, max matched: ", 10001-i == max)
+                    break
+                end
+            end
+
+            dogs:flush_all()
+
+            dogs:flush_expired()
+
+            for i = 1, 10000 do
+                local key = string.format("%05d", i)
+
+                local len, err = dogs:lpush(key, i)
+                if not len then
+                    ngx.say("loop again, max matched: ", i == max)
+                    break
+                end
+            end
+        }
+    }
+--- request
+GET /test
+--- response_body
+max-1 matched keys length: true
+keys all expired, left number: 0
+loop again, max matched: true
+loop again, max matched: true
+--- no_error_log
+[error]
+
+
+
+=== TEST 16: list removed: forcibly
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            local max
+            for i = 1, 20000 do
+                local ok, err, forcible  = dogs:set(i, i)
+                if not ok or forcible then
+                    max = i
+                    break
+                end
+            end
+
+            local two = dogs:get(2)
+
+            ngx.say("two == number 2: ", two == 2)
+
+            dogs:flush_all()
+            dogs:flush_expired()
+
+            local keys = dogs:get_keys(0)
+
+            ngx.say("no one left: ", #keys)
+
+            for i = 1, 20000 do
+                local key = string.format("%05d", i)
+
+                local len, err = dogs:lpush(key, i)
+                if not len then
+                    break
+                end
+            end
+
+            for i = 1, max do
+                local ok, err = dogs:set(i, i)
+                if not ok then
+                    ngx.say("set err: ", err)
+                    break
+                end
+            end
+
+            local two = dogs:get(2)
+
+            ngx.say("two == number 2: ", two == 2)
+        }
+    }
+--- request
+GET /test
+--- response_body
+two == number 2: true
+no one left: 0
+two == number 2: true
+--- no_error_log
+[error]
+
+
+
+=== TEST 16: expire on all types
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+
+            local len, err = dogs:lpush("list", "foo")
+            if not len then
+                ngx.say("push err: ", err)
+            end
+
+            local ok, err = dogs:set("key", "bar")
+            if not ok then
+                ngx.say("set err: ", err)
+            end
+
+            local keys = dogs:get_keys(0)
+
+            ngx.say("keys number: ", #keys)
+
+            for i = 1, #keys do
+                local ok, err = dogs:expire(keys[i], 0.01)
+                if not ok then
+                    ngx.say("expire err: ", err)
+                end
+            end
+
+            local ok, err = dogs:expire("not-exits", 1)
+            if not ok then
+                ngx.say("expire on not-exists, err: ", err)
+            end
+
+            ngx.sleep(0.01)
+
+            local keys = dogs:get_keys(0)
+
+            ngx.say("keys number: ", #keys)
+        }
+    }
+--- request
+GET /test
+--- response_body
+keys number: 2
+expire on not-exists, err: not found
+keys number: 0
+--- no_error_log
+[error]
+

--- a/t/133-shdict-list.t
+++ b/t/133-shdict-list.t
@@ -82,7 +82,7 @@ nil nil
 GET /test
 --- response_body
 push success
-nil wrongtype operation
+nil value is a list
 --- no_error_log
 [error]
 
@@ -181,7 +181,7 @@ GET /test
 --- response_body
 push success
 false exists
-nil wrongtype operation
+nil value is a list
 --- no_error_log
 [error]
 
@@ -247,7 +247,7 @@ GET /test
 --- response_body
 push success
 nil not a number
-nil wrongtype operation
+nil value is a list
 --- no_error_log
 [error]
 
@@ -308,7 +308,7 @@ key: foo
 GET /test
 --- response_body
 set success
-nil wrongtype operation
+nil value not a list
 bar nil
 --- no_error_log
 [error]
@@ -341,7 +341,7 @@ bar nil
 GET /test
 --- response_body
 set success
-nil wrongtype operation
+nil value not a list
 bar nil
 --- no_error_log
 [error]
@@ -374,7 +374,7 @@ bar nil
 GET /test
 --- response_body
 set success
-nil wrongtype operation
+nil value not a list
 bar nil
 --- no_error_log
 [error]

--- a/t/133-shdict-list.t
+++ b/t/133-shdict-list.t
@@ -512,24 +512,18 @@ GET /test
                     max = i
                     break
                 end
-
-                local ok = dogs:expire(key, 0.01)
-                if not ok then
-                    ngx.say("expire error")
-                end
             end
 
             local keys = dogs:get_keys(0)
 
             ngx.say("max-1 matched keys length: ", max-1 == #keys)
 
-            ngx.sleep(0.01)
+            dogs:flush_all()
 
             local keys = dogs:get_keys(0)
 
             ngx.say("keys all expired, left number: ", #keys)
 
-            -- some reused, some removed
             for i = 10000, 1, -1 do
                 local key = string.format("%05d", i)
 
@@ -650,19 +644,7 @@ two == number 2: true
 
             ngx.say("keys number: ", #keys)
 
-            for i = 1, #keys do
-                local ok, err = dogs:expire(keys[i], 0.01)
-                if not ok then
-                    ngx.say("expire err: ", err)
-                end
-            end
-
-            local ok, err = dogs:expire("not-exits", 1)
-            if not ok then
-                ngx.say("expire on not-exists, err: ", err)
-            end
-
-            ngx.sleep(0.01)
+            dogs:flush_all()
 
             local keys = dogs:get_keys(0)
 
@@ -673,7 +655,6 @@ two == number 2: true
 GET /test
 --- response_body
 keys number: 2
-expire on not-exists, err: not found
 keys number: 0
 --- no_error_log
 [error]


### PR DESCRIPTION
I'm not sure if it is an good idea to get the list queue head in the way:
```
#define ngx_http_lua_shdict_get_list_head(sd, key_len)                      \
    (ngx_queue_t *) ngx_align_ptr(((u_char *) &sd->data + key_len),         \
                                  NGX_ALIGNMENT)
```

Anything not suitable, let me know, thanks :)