### PR TITLE
fixed a bug that nginx crashed when processing requests with no args

### DIFF
--- a/src/ngx_http_lua_args.c
+++ b/src/ngx_http_lua_args.c
@@ -113,6 +113,11 @@ ngx_http_lua_ngx_req_get_uri_args(lua_State *L)
 
     lua_createtable(L, 0, 4);
 
+    if (r->args.len == 0) {
+        lua_createtable(L, 0, 0);
+        return 1;
+    }
+
     /* we copy r->args over to buf to simplify
      * unescaping query arg keys and values */
 
@@ -196,6 +201,11 @@ ngx_http_lua_ngx_req_get_post_args(lua_State *L)
     }
 
     dd("post body length: %d", (int) len);
+
+    if (len == 0) {
+        lua_createtable(L, 0, 0);
+        return 1;
+    }
 
     buf = ngx_palloc(r->pool, len);
     if (buf == NULL) {


### PR DESCRIPTION
    If the length of r->variables is greater than 250, it is alloced by
ngx_palloc_large(), in specific, by malloc. And if r->uri.len equals to 0,
ngx_http_lua_ngx_req_get_uri_args() allocates a zero-length buffer in a
pool. We found that when we use jemalloc or tcmalloc, these two pointers
are probably the same. Therefore, free this buffer will destroy r->variables
by chance, and nginx crashes.