### PR TITLE
rebase ssl-cert-by-lua on version 0.9.19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,7 @@ src/uthread.[ch]
 src/timer.[ch]
 src/config.[ch]
 src/worker.[ch]
+src/sslcertby.[ch]
 src/lex.[ch]
 *.plist
 lua

--- a/config
+++ b/config
@@ -350,6 +350,7 @@ NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
                 $ngx_addon_dir/src/ngx_http_lua_timer.c \
                 $ngx_addon_dir/src/ngx_http_lua_config.c \
                 $ngx_addon_dir/src/ngx_http_lua_worker.c \
+                $ngx_addon_dir/src/ngx_http_lua_sslcertby.c \
                 $ngx_addon_dir/src/ngx_http_lua_lex.c \
                 "
 
@@ -404,6 +405,7 @@ NGX_ADDON_DEPS="$NGX_ADDON_DEPS \
                 $ngx_addon_dir/src/ngx_http_lua_timer.h \
                 $ngx_addon_dir/src/ngx_http_lua_config.h \
                 $ngx_addon_dir/src/ngx_http_lua_worker.h \
+                $ngx_addon_dir/src/ngx_http_lua_sslcertby.h \
                 $ngx_addon_dir/src/ngx_http_lua_lex.h \
                 "
 

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -94,6 +94,7 @@ typedef struct {
 #define NGX_HTTP_LUA_CONTEXT_BODY_FILTER    0x040
 #define NGX_HTTP_LUA_CONTEXT_TIMER          0x080
 #define NGX_HTTP_LUA_CONTEXT_INIT_WORKER    0x100
+#define NGX_HTTP_LUA_CONTEXT_SSL_CERT       0x200
 
 
 #ifndef NGX_LUA_NO_FFI_API
@@ -103,10 +104,13 @@ typedef struct {
 
 
 typedef struct ngx_http_lua_main_conf_s ngx_http_lua_main_conf_t;
+typedef struct ngx_http_lua_srv_conf_s ngx_http_lua_srv_conf_t;
 
 
-typedef ngx_int_t (*ngx_http_lua_conf_handler_pt)(ngx_log_t *log,
-        ngx_http_lua_main_conf_t *lmcf, lua_State *L);
+typedef ngx_int_t (*ngx_http_lua_main_conf_handler_pt)(ngx_log_t *log,
+    ngx_http_lua_main_conf_t *lmcf, lua_State *L);
+typedef ngx_int_t (*ngx_http_lua_srv_conf_handler_pt)(ngx_http_request_t *r,
+    ngx_http_lua_srv_conf_t *lmcf, lua_State *L);
 
 
 typedef struct {
@@ -145,11 +149,11 @@ struct ngx_http_lua_main_conf_s {
     ngx_flag_t           postponed_to_rewrite_phase_end;
     ngx_flag_t           postponed_to_access_phase_end;
 
-    ngx_http_lua_conf_handler_pt    init_handler;
-    ngx_str_t                       init_src;
+    ngx_http_lua_main_conf_handler_pt    init_handler;
+    ngx_str_t                            init_src;
 
-    ngx_http_lua_conf_handler_pt    init_worker_handler;
-    ngx_str_t                       init_worker_src;
+    ngx_http_lua_main_conf_handler_pt    init_worker_handler;
+    ngx_str_t                            init_worker_src;
 
     ngx_uint_t                      shm_zones_inited;
 
@@ -160,6 +164,15 @@ struct ngx_http_lua_main_conf_s {
     unsigned             requires_access:1;
     unsigned             requires_log:1;
     unsigned             requires_shm:1;
+};
+
+
+struct ngx_http_lua_srv_conf_s {
+#if (NGX_HTTP_SSL)
+    ngx_http_lua_srv_conf_handler_pt     ssl_cert_handler;
+    ngx_str_t                            ssl_cert_src;
+    u_char                              *ssl_cert_src_key;
+#endif
 };
 
 

--- a/src/ngx_http_lua_contentby.h
+++ b/src/ngx_http_lua_contentby.h
@@ -12,7 +12,7 @@
 #include "ngx_http_lua_common.h"
 
 
-ngx_int_t ngx_http_lua_content_by_chunk(lua_State *l, ngx_http_request_t *r);
+ngx_int_t ngx_http_lua_content_by_chunk(lua_State *L, ngx_http_request_t *r);
 void ngx_http_lua_content_wev_handler(ngx_http_request_t *r);
 ngx_int_t ngx_http_lua_content_handler_file(ngx_http_request_t *r);
 ngx_int_t ngx_http_lua_content_handler_inline(ngx_http_request_t *r);

--- a/src/ngx_http_lua_control.c
+++ b/src/ngx_http_lua_control.c
@@ -10,6 +10,7 @@
 #endif
 #include "ddebug.h"
 
+
 #include "ngx_http_lua_control.h"
 #include "ngx_http_lua_util.h"
 #include "ngx_http_lua_coroutine.h"
@@ -290,9 +291,9 @@ ngx_http_lua_ngx_redirect(lua_State *L)
 static int
 ngx_http_lua_ngx_exit(lua_State *L)
 {
+    ngx_int_t                    rc;
     ngx_http_request_t          *r;
     ngx_http_lua_ctx_t          *ctx;
-    ngx_int_t                    rc;
 
     if (lua_gettop(L) != 1) {
         return luaL_error(L, "expecting one argument");
@@ -312,9 +313,29 @@ ngx_http_lua_ngx_exit(lua_State *L)
                                | NGX_HTTP_LUA_CONTEXT_ACCESS
                                | NGX_HTTP_LUA_CONTEXT_CONTENT
                                | NGX_HTTP_LUA_CONTEXT_TIMER
-                               | NGX_HTTP_LUA_CONTEXT_HEADER_FILTER);
+                               | NGX_HTTP_LUA_CONTEXT_HEADER_FILTER
+                               | NGX_HTTP_LUA_CONTEXT_SSL_CERT);
 
     rc = (ngx_int_t) luaL_checkinteger(L, 1);
+
+    if (ctx->context == NGX_HTTP_LUA_CONTEXT_SSL_CERT) {
+
+#if (NGX_HTTP_SSL)
+
+        ctx->exit_code = rc;
+        ctx->exited = 1;
+
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "lua exit with code %i", rc);
+
+        return lua_yield(L, 0);
+
+#else
+
+        return luaL_error(L, "no SSL support");
+
+#endif
+    }
 
     if (ctx->no_abort
         && rc != NGX_ERROR
@@ -431,11 +452,31 @@ ngx_http_lua_ffi_exit(ngx_http_request_t *r, int status, u_char *err,
                                        | NGX_HTTP_LUA_CONTEXT_ACCESS
                                        | NGX_HTTP_LUA_CONTEXT_CONTENT
                                        | NGX_HTTP_LUA_CONTEXT_TIMER
-                                       | NGX_HTTP_LUA_CONTEXT_HEADER_FILTER,
+                                       | NGX_HTTP_LUA_CONTEXT_HEADER_FILTER
+                                       | NGX_HTTP_LUA_CONTEXT_SSL_CERT,
                                        err, errlen)
         != NGX_OK)
     {
         return NGX_ERROR;
+    }
+
+    if (ctx->context == NGX_HTTP_LUA_CONTEXT_SSL_CERT) {
+
+#if (NGX_HTTP_SSL)
+
+        ctx->exit_code = status;
+        ctx->exited = 1;
+
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "lua exit with code %d", status);
+
+        return NGX_OK;
+
+#else
+
+        return NGX_ERROR;
+
+#endif
     }
 
     if (ctx->no_abort
@@ -458,7 +499,7 @@ ngx_http_lua_ffi_exit(ngx_http_request_t *r, int status, u_char *err,
     {
         if (status != (ngx_int_t) r->headers_out.status) {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "attempt to "
-                          "set status %i via ngx.exit after sending out the "
+                          "set status %d via ngx.exit after sending out the "
                           "response status %ui", status,
                           r->headers_out.status);
         }

--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -24,6 +24,7 @@
 #include "ngx_http_lua_initby.h"
 #include "ngx_http_lua_initworkerby.h"
 #include "ngx_http_lua_shdict.h"
+#include "ngx_http_lua_sslcertby.h"
 #include "ngx_http_lua_lex.h"
 
 
@@ -1126,7 +1127,7 @@ ngx_http_lua_init_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
         return NGX_CONF_ERROR;
     }
 
-    lmcf->init_handler = (ngx_http_lua_conf_handler_pt) cmd->post;
+    lmcf->init_handler = (ngx_http_lua_main_conf_handler_pt) cmd->post;
 
     if (cmd->post == ngx_http_lua_init_by_file) {
         name = ngx_http_lua_rebase_path(cf->pool, value[1].data,
@@ -1186,7 +1187,7 @@ ngx_http_lua_init_worker_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
 
     value = cf->args->elts;
 
-    lmcf->init_worker_handler = (ngx_http_lua_conf_handler_pt) cmd->post;
+    lmcf->init_worker_handler = (ngx_http_lua_main_conf_handler_pt) cmd->post;
 
     if (cmd->post == ngx_http_lua_init_worker_by_file) {
         name = ngx_http_lua_rebase_path(cf->pool, value[1].data,

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -23,6 +23,8 @@
 #include "ngx_http_lua_initby.h"
 #include "ngx_http_lua_initworkerby.h"
 #include "ngx_http_lua_probe.h"
+#include "ngx_http_lua_sslcertby.h"
+#include <openssl/ssl.h>
 
 
 #if !defined(nginx_version) || nginx_version < 8054
@@ -32,7 +34,11 @@
 
 static void *ngx_http_lua_create_main_conf(ngx_conf_t *cf);
 static char *ngx_http_lua_init_main_conf(ngx_conf_t *cf, void *conf);
+static void *ngx_http_lua_create_srv_conf(ngx_conf_t *cf);
+static char *ngx_http_lua_merge_srv_conf(ngx_conf_t *cf, void *parent,
+    void *child);
 static void *ngx_http_lua_create_loc_conf(ngx_conf_t *cf);
+
 static char *ngx_http_lua_merge_loc_conf(ngx_conf_t *cf, void *parent,
     void *child);
 static ngx_int_t ngx_http_lua_init(ngx_conf_t *cf);
@@ -480,6 +486,24 @@ static ngx_command_t ngx_http_lua_cmds[] = {
       offsetof(ngx_http_lua_loc_conf_t, ssl_ciphers),
       NULL },
 
+#if (NGX_HTTP_SSL)
+
+    { ngx_string("ssl_certificate_by_lua"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_http_lua_ssl_cert_by_lua,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      0,
+      (void *) ngx_http_lua_ssl_cert_handler_inline },
+
+    { ngx_string("ssl_certificate_by_lua_file"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_http_lua_ssl_cert_by_lua,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      0,
+      (void *) ngx_http_lua_ssl_cert_handler_file },
+
+#endif  /* NGX_HTTP_SSL */
+
     { ngx_string("lua_ssl_verify_depth"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_num_slot,
@@ -514,8 +538,8 @@ ngx_http_module_t ngx_http_lua_module_ctx = {
     ngx_http_lua_create_main_conf,    /*  create main configuration */
     ngx_http_lua_init_main_conf,      /*  init main configuration */
 
-    NULL,                             /*  create server configuration */
-    NULL,                             /*  merge server configuration */
+    ngx_http_lua_create_srv_conf,     /*  create server configuration */
+    ngx_http_lua_merge_srv_conf,      /*  merge server configuration */
 
     ngx_http_lua_create_loc_conf,     /*  create location configuration */
     ngx_http_lua_merge_loc_conf       /*  merge location configuration */
@@ -750,6 +774,56 @@ ngx_http_lua_init_main_conf(ngx_conf_t *cf, void *conf)
     }
 
     lmcf->cycle = cf->cycle;
+
+    return NGX_CONF_OK;
+}
+
+
+static void *
+ngx_http_lua_create_srv_conf(ngx_conf_t *cf)
+{
+    ngx_http_lua_srv_conf_t     *lscf;
+
+    lscf = ngx_pcalloc(cf->pool, sizeof(ngx_http_lua_srv_conf_t));
+    if (lscf == NULL) {
+        return NULL;
+    }
+
+    /* set by ngx_pcalloc:
+     *      lscf->ssl_cert_handler = NULL;
+     *      lscf->ssl_cert_src = { 0, NULL };
+     *      lscf->ssl_cert_src_key = NULL;
+     */
+
+    return lscf;
+}
+
+
+static char *
+ngx_http_lua_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
+{
+    ngx_http_lua_srv_conf_t *prev = parent;
+    ngx_http_lua_srv_conf_t *conf = child;
+    ngx_http_ssl_srv_conf_t *sscf;
+
+    dd("merge srv conf");
+
+    if (conf->ssl_cert_src.len == 0) {
+        conf->ssl_cert_src = prev->ssl_cert_src;
+        conf->ssl_cert_handler = prev->ssl_cert_handler;
+    }
+
+    if (conf->ssl_cert_src.len) {
+        sscf = ngx_http_conf_get_module_srv_conf(cf, ngx_http_ssl_module);
+        if (sscf == NULL || sscf->ssl.ctx == NULL) {
+            ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                          "no ssl configured for the server");
+
+            return NGX_CONF_ERROR;
+        }
+
+        SSL_CTX_set_cert_cb(sscf->ssl.ctx, ngx_http_lua_ssl_cert_handler, NULL);
+    }
 
     return NGX_CONF_OK;
 }

--- a/src/ngx_http_lua_phase.c
+++ b/src/ngx_http_lua_phase.c
@@ -76,6 +76,10 @@ ngx_http_lua_ngx_get_phase(lua_State *L)
         lua_pushliteral(L, "timer");
         break;
 
+    case NGX_HTTP_LUA_CONTEXT_SSL_CERT:
+        lua_pushliteral(L, "ssl_cert");
+        break;
+
     default:
         return luaL_error(L, "unknown phase: %d", (int) ctx->context);
     }

--- a/src/ngx_http_lua_sleep.c
+++ b/src/ngx_http_lua_sleep.c
@@ -55,7 +55,8 @@ ngx_http_lua_ngx_sleep(lua_State *L)
     ngx_http_lua_check_context(L, ctx, NGX_HTTP_LUA_CONTEXT_REWRITE
                                | NGX_HTTP_LUA_CONTEXT_ACCESS
                                | NGX_HTTP_LUA_CONTEXT_CONTENT
-                               | NGX_HTTP_LUA_CONTEXT_TIMER);
+                               | NGX_HTTP_LUA_CONTEXT_TIMER
+                               | NGX_HTTP_LUA_CONTEXT_SSL_CERT);
 
     coctx = ctx->cur_co_ctx;
     if (coctx == NULL) {

--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -383,7 +383,8 @@ ngx_http_lua_socket_tcp(lua_State *L)
     ngx_http_lua_check_context(L, ctx, NGX_HTTP_LUA_CONTEXT_REWRITE
                                | NGX_HTTP_LUA_CONTEXT_ACCESS
                                | NGX_HTTP_LUA_CONTEXT_CONTENT
-                               | NGX_HTTP_LUA_CONTEXT_TIMER);
+                               | NGX_HTTP_LUA_CONTEXT_TIMER
+                               | NGX_HTTP_LUA_CONTEXT_SSL_CERT);
 
     lua_createtable(L, 3 /* narr */, 1 /* nrec */);
     lua_pushlightuserdata(L, &ngx_http_lua_tcp_socket_metatable_key);
@@ -440,7 +441,8 @@ ngx_http_lua_socket_tcp_connect(lua_State *L)
     ngx_http_lua_check_context(L, ctx, NGX_HTTP_LUA_CONTEXT_REWRITE
                                | NGX_HTTP_LUA_CONTEXT_ACCESS
                                | NGX_HTTP_LUA_CONTEXT_CONTENT
-                               | NGX_HTTP_LUA_CONTEXT_TIMER);
+                               | NGX_HTTP_LUA_CONTEXT_TIMER
+                               | NGX_HTTP_LUA_CONTEXT_SSL_CERT);
 
     luaL_checktype(L, 1, LUA_TTABLE);
 
@@ -1310,6 +1312,18 @@ ngx_http_lua_socket_tcp_sslhandshake(lua_State *L)
 
             if (n >= 4) {
                 u->ssl_verify = lua_toboolean(L, 4);
+
+                if (n >= 5) {
+                    if (lua_toboolean(L, 5)) {
+#ifdef TLSEXT_STATUSTYPE_ocsp
+                        SSL_set_tlsext_status_type(c->ssl->connection,
+                                                   TLSEXT_STATUSTYPE_ocsp);
+#else
+                        return luaL_error(L, "lack of status request support"
+                                             " in OpenSSL");
+#endif
+                    }
+                }
             }
         }
     }
@@ -1352,6 +1366,10 @@ new_ssl_name:
     }
 
     u->write_co_ctx = coctx;
+
+#if 0
+    SSL_set_tlsext_status_type(c->ssl->connection, TLSEXT_STATUSTYPE_ocsp);
+#endif
 
     rc = ngx_ssl_handshake(c);
 

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -49,6 +49,7 @@
 #include "ngx_http_lua_config.h"
 #include "ngx_http_lua_worker.h"
 #include "ngx_http_lua_socket_tcp.h"
+#include "ngx_http_lua_sslcertby.h"
 
 
 #if 1
@@ -111,7 +112,6 @@ static void ngx_http_lua_cleanup_zombie_child_uthreads(ngx_http_request_t *r,
     lua_State *L, ngx_http_lua_ctx_t *ctx, ngx_http_lua_co_ctx_t *coctx);
 static ngx_int_t ngx_http_lua_on_abort_resume(ngx_http_request_t *r);
 static void ngx_http_lua_close_fake_request(ngx_http_request_t *r);
-static void ngx_http_lua_free_fake_request(ngx_http_request_t *r);
 static ngx_int_t ngx_http_lua_flush_pending_output(ngx_http_request_t *r,
     ngx_http_lua_ctx_t *ctx);
 static ngx_int_t
@@ -2212,6 +2212,10 @@ ngx_http_lua_handle_exit(lua_State *L, ngx_http_request_t *r,
                    "lua thread aborting request with status %d",
                    ctx->exit_code);
 
+    if (r->connection->fd == -1) {  /* fake request */
+        return ctx->exit_code;
+    }
+
 #if 1
     if (!r->header_sent
         && !ctx->header_sent
@@ -3536,6 +3540,11 @@ void
 ngx_http_lua_finalize_fake_request(ngx_http_request_t *r, ngx_int_t rc)
 {
     ngx_connection_t          *c;
+#if (NGX_HTTP_SSL)
+    ngx_ssl_conn_t            *ssl_conn;
+
+    ngx_http_lua_ssl_cert_ctx_t     *cctx;
+#endif
 
     c = r->connection;
 
@@ -3549,6 +3558,23 @@ ngx_http_lua_finalize_fake_request(ngx_http_request_t *r, ngx_int_t rc)
     }
 
     if (rc == NGX_ERROR || rc >= NGX_HTTP_SPECIAL_RESPONSE) {
+
+#if (NGX_HTTP_SSL)
+
+        if (r->connection->ssl) {
+            ssl_conn = r->connection->ssl->connection;
+            if (ssl_conn) {
+                c = ngx_ssl_get_connection(ssl_conn);
+
+                if (c && c->ssl && c->ssl->lua_ctx) {
+                    cctx = c->ssl->lua_ctx;
+                    cctx->exit_code = 0;
+                }
+            }
+        }
+
+#endif
+
         ngx_http_lua_close_fake_request(r);
         return;
     }
@@ -3593,7 +3619,7 @@ ngx_http_lua_close_fake_request(ngx_http_request_t *r)
 }
 
 
-static void
+void
 ngx_http_lua_free_fake_request(ngx_http_request_t *r)
 {
     ngx_log_t                 *log;
@@ -3628,8 +3654,8 @@ ngx_http_lua_close_fake_connection(ngx_connection_t *c)
     ngx_pool_t          *pool;
     ngx_connection_t    *saved_c = NULL;
 
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0,
-                   "http lua close fake http connection");
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "http lua close fake http connection %p", c);
 
     c->destroyed = 1;
 
@@ -3819,6 +3845,8 @@ ngx_http_lua_create_fake_connection(ngx_pool_t *pool)
 
     c->error = 1;
 
+    dd("created fake connection: %p", c);
+
     return c;
 
 failed:
@@ -3904,6 +3932,8 @@ ngx_http_lua_create_fake_request(ngx_connection_t *c)
 
     r->http_state = NGX_HTTP_PROCESS_REQUEST_STATE;
     r->discard_body = 1;
+
+    dd("created fake request %p", r);
 
     return r;
 }

--- a/src/ngx_http_lua_util.h
+++ b/src/ngx_http_lua_util.h
@@ -84,6 +84,7 @@ extern char ngx_http_lua_headers_metatable_key;
      : (c) == NGX_HTTP_LUA_CONTEXT_HEADER_FILTER ? "header_filter_by_lua*"   \
      : (c) == NGX_HTTP_LUA_CONTEXT_TIMER ? "ngx.timer"                       \
      : (c) == NGX_HTTP_LUA_CONTEXT_INIT_WORKER ? "init_worker_by_lua*"       \
+     : (c) == NGX_HTTP_LUA_CONTEXT_SSL_CERT ? "ssl_certificate_by_lua*"      \
      : "(unknown)")
 
 
@@ -215,6 +216,8 @@ void ngx_http_lua_finalize_fake_request(ngx_http_request_t *r,
     ngx_int_t rc);
 
 void ngx_http_lua_close_fake_connection(ngx_connection_t *c);
+
+void ngx_http_lua_free_fake_request(ngx_http_request_t *r);
 
 void ngx_http_lua_release_ngx_ctx_table(ngx_log_t *log, lua_State *L,
     ngx_http_lua_ctx_t *ctx);

--- a/valgrind.suppress
+++ b/valgrind.suppress
@@ -111,6 +111,13 @@ fun:main
     fun:__libc_res_nsend
 }
 {
+    <insert_a_suppression_name_here>
+    Memcheck:Param
+    sendmsg(mmsg[0].msg_hdr)
+    fun:sendmmsg
+    fun:__libc_res_nsend
+}
+{
    <insert_a_suppression_name_here>
    Memcheck:Param
    sendmsg(msg.msg_iov[0])


### PR DESCRIPTION
This patch is the adaptation of  ssl-cert-by-lua to 0.9.19 based on your branch. There is no modification.