### PR TITLE
cache: added functions to load code without having an ngx_http_request_t

### DIFF
--- a/src/ngx_http_lua_cache.h
+++ b/src/ngx_http_lua_cache.h
@@ -15,7 +15,12 @@
 ngx_int_t ngx_http_lua_cache_loadbuffer(ngx_http_request_t *r, lua_State *L,
     const u_char *src, size_t src_len, const u_char *cache_key,
     const char *name);
+ngx_int_t ngx_http_lua_cache_loadbuffer2(ngx_log_t *log, lua_State *L,
+    const u_char *src, size_t src_len, const u_char *cache_key,
+    const char *name);
 ngx_int_t ngx_http_lua_cache_loadfile(ngx_http_request_t *r, lua_State *L,
+    const u_char *script, const u_char *cache_key);
+ngx_int_t ngx_http_lua_cache_loadfile2(ngx_log_t *log, lua_State *L,
     const u_char *script, const u_char *cache_key);
 
 


### PR DESCRIPTION
This patch adds the functions ngx_http_lua_cache_loadbuffer2() and
ngx_http_lua_cache_loadfile2() that take an ngx_log_t argument directly
instead of an ngx_http_request_t. These can be used in contexts where an
HTTP request is not available.

The existing ngx_http_lua_cache_loadbuffer() and ngx_http_lua_cache_loadfile()
functions have been updated to wrap the new functions (in theory the new
functions could simply replace the old ones, but all the callers would
need to be updated as well, and that's quite a big diff).