### PR TITLE
cache: make load functions take a log directly

### DIFF
--- a/src/ngx_http_lua_accessby.c
+++ b/src/ngx_http_lua_accessby.c
@@ -176,7 +176,8 @@ ngx_http_lua_access_handler_inline(ngx_http_request_t *r)
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
     /*  load Lua inline script (w/ cache) sp = 1 */
-    rc = ngx_http_lua_cache_loadbuffer(r, L, llcf->access_src.value.data,
+    rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
+                                       llcf->access_src.value.data,
                                        llcf->access_src.value.len,
                                        llcf->access_src_key,
                                        (const char *) llcf->access_chunkname);
@@ -215,7 +216,8 @@ ngx_http_lua_access_handler_file(ngx_http_request_t *r)
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
     /*  load Lua script file (w/ cache)        sp = 1 */
-    rc = ngx_http_lua_cache_loadfile(r, L, script_path, llcf->access_src_key);
+    rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
+                                     llcf->access_src_key);
     if (rc != NGX_OK) {
         if (rc < NGX_HTTP_SPECIAL_RESPONSE) {
             return NGX_HTTP_INTERNAL_SERVER_ERROR;

--- a/src/ngx_http_lua_bodyfilterby.c
+++ b/src/ngx_http_lua_bodyfilterby.c
@@ -160,7 +160,8 @@ ngx_http_lua_body_filter_inline(ngx_http_request_t *r, ngx_chain_t *in)
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
     /*  load Lua inline script (w/ cache) sp = 1 */
-    rc = ngx_http_lua_cache_loadbuffer(r, L, llcf->body_filter_src.value.data,
+    rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
+                                       llcf->body_filter_src.value.data,
                                        llcf->body_filter_src.value.len,
                                        llcf->body_filter_src_key,
                                        "=body_filter_by_lua");
@@ -208,7 +209,7 @@ ngx_http_lua_body_filter_file(ngx_http_request_t *r, ngx_chain_t *in)
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
     /*  load Lua script file (w/ cache)        sp = 1 */
-    rc = ngx_http_lua_cache_loadfile(r, L, script_path,
+    rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
                                      llcf->body_filter_src_key);
     if (rc != NGX_OK) {
         return NGX_ERROR;

--- a/src/ngx_http_lua_cache.c
+++ b/src/ngx_http_lua_cache.c
@@ -32,7 +32,7 @@
  *
  * */
 static ngx_int_t
-ngx_http_lua_cache_load_code(ngx_http_request_t *r, lua_State *L,
+ngx_http_lua_cache_load_code(ngx_log_t *log, lua_State *L,
     const char *key)
 {
     int          rc;
@@ -68,7 +68,7 @@ ngx_http_lua_cache_load_code(ngx_http_request_t *r, lua_State *L,
             err = (u_char *) "unknown error";
         }
 
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+        ngx_log_error(NGX_LOG_ERR, log, 0,
                       "lua: failed to run factory at key \"%s\": %s",
                       key, err);
         lua_pop(L, 2);
@@ -133,7 +133,7 @@ ngx_http_lua_cache_store_code(lua_State *L, const char *key)
 
 
 ngx_int_t
-ngx_http_lua_cache_loadbuffer(ngx_http_request_t *r, lua_State *L,
+ngx_http_lua_cache_loadbuffer(ngx_log_t *log, lua_State *L,
     const u_char *src, size_t src_len, const u_char *cache_key,
     const char *name)
 {
@@ -145,7 +145,7 @@ ngx_http_lua_cache_loadbuffer(ngx_http_request_t *r, lua_State *L,
 
     dd("XXX cache key: [%s]", cache_key);
 
-    rc = ngx_http_lua_cache_load_code(r, L, (char *) cache_key);
+    rc = ngx_http_lua_cache_load_code(log, L, (char *) cache_key);
     if (rc == NGX_OK) {
         /*  code chunk loaded from cache, sp++ */
         dd("Code cache hit! cache key='%s', stack top=%d, script='%.*s'",
@@ -194,7 +194,7 @@ ngx_http_lua_cache_loadbuffer(ngx_http_request_t *r, lua_State *L,
 
 error:
 
-    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+    ngx_log_error(NGX_LOG_ERR, log, 0,
                   "failed to load inlined Lua code: %s", err);
     lua_settop(L, n);
     return NGX_ERROR;
@@ -202,7 +202,7 @@ error:
 
 
 ngx_int_t
-ngx_http_lua_cache_loadfile(ngx_http_request_t *r, lua_State *L,
+ngx_http_lua_cache_loadfile(ngx_log_t *log, lua_State *L,
     const u_char *script, const u_char *cache_key)
 {
     int              n;
@@ -229,7 +229,7 @@ ngx_http_lua_cache_loadfile(ngx_http_request_t *r, lua_State *L,
 
     dd("XXX cache key for file: [%s]", cache_key);
 
-    rc = ngx_http_lua_cache_load_code(r, L, (char *) cache_key);
+    rc = ngx_http_lua_cache_load_code(log, L, (char *) cache_key);
     if (rc == NGX_OK) {
         /*  code chunk loaded from cache, sp++ */
         dd("Code cache hit! cache key='%s', stack top=%d, file path='%s'",
@@ -286,7 +286,7 @@ ngx_http_lua_cache_loadfile(ngx_http_request_t *r, lua_State *L,
 
 error:
 
-    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+    ngx_log_error(NGX_LOG_ERR, log, 0,
                   "failed to load external Lua file \"%s\": %s", script, err);
 
     lua_settop(L, n);

--- a/src/ngx_http_lua_cache.h
+++ b/src/ngx_http_lua_cache.h
@@ -12,10 +12,10 @@
 #include "ngx_http_lua_common.h"
 
 
-ngx_int_t ngx_http_lua_cache_loadbuffer(ngx_http_request_t *r, lua_State *L,
+ngx_int_t ngx_http_lua_cache_loadbuffer(ngx_log_t *log, lua_State *L,
     const u_char *src, size_t src_len, const u_char *cache_key,
     const char *name);
-ngx_int_t ngx_http_lua_cache_loadfile(ngx_http_request_t *r, lua_State *L,
+ngx_int_t ngx_http_lua_cache_loadfile(ngx_log_t *log, lua_State *L,
     const u_char *script, const u_char *cache_key);
 
 

--- a/src/ngx_http_lua_contentby.c
+++ b/src/ngx_http_lua_contentby.c
@@ -251,7 +251,7 @@ ngx_http_lua_content_handler_file(ngx_http_request_t *r)
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
     /*  load Lua script file (w/ cache)        sp = 1 */
-    rc = ngx_http_lua_cache_loadfile(r, L, script_path,
+    rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
                                      llcf->content_src_key);
     if (rc != NGX_OK) {
         if (rc < NGX_HTTP_SPECIAL_RESPONSE) {
@@ -280,7 +280,8 @@ ngx_http_lua_content_handler_inline(ngx_http_request_t *r)
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
     /*  load Lua inline script (w/ cache) sp = 1 */
-    rc = ngx_http_lua_cache_loadbuffer(r, L, llcf->content_src.value.data,
+    rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
+                                       llcf->content_src.value.data,
                                        llcf->content_src.value.len,
                                        llcf->content_src_key,
                                        (const char *)

--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -354,7 +354,8 @@ ngx_http_lua_filter_set_by_lua_inline(ngx_http_request_t *r, ngx_str_t *val,
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
     /*  load Lua inline script (w/ cache)        sp = 1 */
-    rc = ngx_http_lua_cache_loadbuffer(r, L, filter_data->script.data,
+    rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
+                                       filter_data->script.data,
                                        filter_data->script.len,
                                        filter_data->key, "=set_by_lua");
     if (rc != NGX_OK) {
@@ -407,7 +408,8 @@ ngx_http_lua_filter_set_by_lua_file(ngx_http_request_t *r, ngx_str_t *val,
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
     /*  load Lua script file (w/ cache)        sp = 1 */
-    rc = ngx_http_lua_cache_loadfile(r, L, script_path, filter_data->key);
+    rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
+                                     filter_data->key);
     if (rc != NGX_OK) {
         return NGX_ERROR;
     }

--- a/src/ngx_http_lua_headerfilterby.c
+++ b/src/ngx_http_lua_headerfilterby.c
@@ -168,7 +168,7 @@ ngx_http_lua_header_filter_inline(ngx_http_request_t *r)
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
     /*  load Lua inline script (w/ cache) sp = 1 */
-    rc = ngx_http_lua_cache_loadbuffer(r, L,
+    rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->header_filter_src.value.data,
                                        llcf->header_filter_src.value.len,
                                        llcf->header_filter_src_key,
@@ -211,7 +211,7 @@ ngx_http_lua_header_filter_file(ngx_http_request_t *r)
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
     /*  load Lua script file (w/ cache)        sp = 1 */
-    rc = ngx_http_lua_cache_loadfile(r, L, script_path,
+    rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
                                      llcf->header_filter_src_key);
     if (rc != NGX_OK) {
         return NGX_ERROR;

--- a/src/ngx_http_lua_logby.c
+++ b/src/ngx_http_lua_logby.c
@@ -113,7 +113,8 @@ ngx_http_lua_log_handler_inline(ngx_http_request_t *r)
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
     /*  load Lua inline script (w/ cache) sp = 1 */
-    rc = ngx_http_lua_cache_loadbuffer(r, L, llcf->log_src.value.data,
+    rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
+                                       llcf->log_src.value.data,
                                        llcf->log_src.value.len,
                                        llcf->log_src_key,
                                        (const char *) llcf->log_chunkname);
@@ -150,7 +151,8 @@ ngx_http_lua_log_handler_file(ngx_http_request_t *r)
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
     /*  load Lua script file (w/ cache)        sp = 1 */
-    rc = ngx_http_lua_cache_loadfile(r, L, script_path, llcf->log_src_key);
+    rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
+                                     llcf->log_src_key);
     if (rc != NGX_OK) {
         return NGX_ERROR;
     }

--- a/src/ngx_http_lua_rewriteby.c
+++ b/src/ngx_http_lua_rewriteby.c
@@ -176,7 +176,8 @@ ngx_http_lua_rewrite_handler_inline(ngx_http_request_t *r)
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
     /*  load Lua inline script (w/ cache) sp = 1 */
-    rc = ngx_http_lua_cache_loadbuffer(r, L, llcf->rewrite_src.value.data,
+    rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
+                                       llcf->rewrite_src.value.data,
                                        llcf->rewrite_src.value.len,
                                        llcf->rewrite_src_key,
                                        (const char *)
@@ -214,7 +215,8 @@ ngx_http_lua_rewrite_handler_file(ngx_http_request_t *r)
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
     /*  load Lua script file (w/ cache)        sp = 1 */
-    rc = ngx_http_lua_cache_loadfile(r, L, script_path, llcf->rewrite_src_key);
+    rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
+                                     llcf->rewrite_src_key);
     if (rc != NGX_OK) {
         if (rc < NGX_HTTP_SPECIAL_RESPONSE) {
             return NGX_HTTP_INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
This patch makes the functions ngx_http_lua_cache_loadbuffer() and
ngx_http_lua_cache_loadfile() take an ngx_log_t argument directly
instead of an ngx_http_request_t so that they can be used in contexts
where an HTTP request is not available.

---

This supersedes #618 which can probably be closed now (/cc @majek).