### PR TITLE
feature: allow tcpsock:setkeepalive() to receive nil args

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -4464,7 +4464,7 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
     if (spool == NULL) {
         /* create a new socket pool for the current peer key */
 
-        if (n == 3) {
+        if (n == 3 && !lua_isnil(L, 3)) {
             pool_size = luaL_checkinteger(L, 3);
 
         } else {
@@ -4567,7 +4567,7 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
         ngx_del_timer(c->write);
     }
 
-    if (n >= 2) {
+    if (n >= 2 && !lua_isnil(L, 2) ) {
         timeout = (ngx_msec_t) luaL_checkinteger(L, 2);
 
     } else {


### PR DESCRIPTION
`tcpsock:setkeepalive()` arguments are documented as being optional, yet they cannot be `nil`. This patch proposes to check if those arguments are `nil` before checking their type. If they are nil, then the configuration values are used as one would expect.

It comes handy when doing things like `sock:setkeepalive(var1, var2)` and if `var1` and `var2` are actually `nil`. It also allows one to do `sock:setkeepalive(nil, 25)`, though I hope this particular usage does not break the API.

It was motivated by an edge-case I encountered [here](https://github.com/thibaultCha/lua-cassandra/commit/759289d7404ff47a24779ee1c554861648e05adb#diff-ec126ebe12c61abf0bec8b3f0d0a3180R365) with this [travis failure](https://travis-ci.org/thibaultCha/lua-cassandra/jobs/96895510), in a scenario where a user of a lua-resty module can configure those options for the sockets used by that module.

---

Side note:

I would like to say I ran the tests but sadly I did not.
- I first followed the ngx_lua development instructions (I wanted to run all the tests with the full mysql/redis/memcached environment) but it seems [util/build2.sh](https://github.com/openresty/lua-nginx-module/blob/master/util/build2.sh) is outdated (some modules apparently got renamed, some paths are hard-coded, the Nginx version looks somewhat old).
- Fair enough, I decided to update it and slightly tweak it for my system, but so far drizzle has prevented me from finishing this. I have it compiled but `drizzle-nginx-module` does not seem to like any `LIBDRIZZLE_LIB` I am giving to it (granted this is totally outside the scope of this PR).
- I decided to simply download the latest OpenResty bundle and only run the `068-socket-keepalive.t` tests against it, without much success since the tests are failing, mainly due to the response size being checked:
```
# -received response of 156 bytes
# +received response of 160 bytes
```
I decided to ignore them (assumed it was a platform issue) and did not investigate. 

- I thought I'd make my changes to ngx_lua and compiled the bundle directly with it:
```
./configure --without-http_lua_module --add-module=../lua-nginx-module
```
And I added my test with an `--- ONLY` flag. However, the Nginx process cannot start when I compile OpenResty this way (with or without my changes):
```
t/068-socket-keepalive.t .. # I found ONLY: maybe you're debugging?
nginx: [error] failed to initialize Lua VM in /path/to/openresty-dev/lua-nginx-module/t/servroot/conf/nginx.conf:103
Bailout called.  Further testing stopped:  TEST 10b: sock:keepalive_timeout(nil) - Cannot start nginx using command "nginx -p /path/to/openresty-dev/lua-nginx-module/t/servroot/ -c /path/to/openresty-dev/lua-nginx-module/t/servroot/conf/nginx.conf > /dev/null".
```

Is there any recommended development installation (maybe more recent than `build2.sh`?) or have I done something wrong along the way? (I am on OS X btw). I am fine with using a VM if you think it would be easier. **Sorry for the long note!**