### PR TITLE
shdict check exptime param

### DIFF
--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -940,7 +940,7 @@ ngx_http_lua_shdict_set_helper(lua_State *L, int flags)
     if (n >= 4) {
         exptime = luaL_checknumber(L, 4);
         if (exptime < 0) {
-            exptime = 0;
+            return luaL_error(L, "bad \"exptime\" argument");
         }
     }
 

--- a/t/043-shdict.t
+++ b/t/043-shdict.t
@@ -2429,3 +2429,22 @@ nil
 nil
 --- no_error_log
 [error]
+
+
+
+=== TEST 92: invalid expire time
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local dogs = ngx.shared.dogs
+            dogs:set("foo", 32, -1)
+        ';
+    }
+--- request
+GET /test
+--- response_body_like: 500 Internal Server Error
+--- error_code: 500
+--- error_log
+bad "exptime" argument


### PR DESCRIPTION
throw a lua error when the `exptime` is less than 0 .