### PR TITLE
feature: implemented the balancer_by_lua_block and balancer_by_lua_file directives to allow NGINX load balancers written in Lua

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,7 @@ src/timer.[ch]
 src/config.[ch]
 src/worker.[ch]
 src/lex.[ch]
+src/balancer.[ch]
 *.plist
 lua
 ttimer

--- a/config
+++ b/config
@@ -352,6 +352,7 @@ NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
                 $ngx_addon_dir/src/ngx_http_lua_config.c \
                 $ngx_addon_dir/src/ngx_http_lua_worker.c \
                 $ngx_addon_dir/src/ngx_http_lua_lex.c \
+                $ngx_addon_dir/src/ngx_http_lua_balancer.c \
                 "
 
 NGX_ADDON_DEPS="$NGX_ADDON_DEPS \
@@ -407,6 +408,7 @@ NGX_ADDON_DEPS="$NGX_ADDON_DEPS \
                 $ngx_addon_dir/src/ngx_http_lua_config.h \
                 $ngx_addon_dir/src/ngx_http_lua_worker.h \
                 $ngx_addon_dir/src/ngx_http_lua_lex.h \
+                $ngx_addon_dir/src/ngx_http_lua_balancer.h \
                 "
 
 CFLAGS="$CFLAGS -DNDK_SET_VAR"

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -1853,6 +1853,76 @@ When a relative path like <code>foo/bar.lua</code> is given, they will be turned
 
 This directive was first introduced in the <code>v0.5.0rc31</code> release.
 
+== balancer_by_lua_block ==
+
+'''syntax:''' ''balancer_by_lua_block { lua-script }''
+
+'''context:''' ''upstream''
+
+'''phase:''' ''content''
+
+This directive runs Lua code as an upstream balancer for any upstream entities defined
+by the <code>upstream {}</code> configuration block.
+
+For instance,
+
+<geshi lang="nginx">
+    upstream foo {
+        server 127.0.0.1;
+        balancer_by_lua_block {
+            -- use Lua to do something interesting here
+            -- as a dynamic balancer
+        }
+    }
+
+    server {
+        location / {
+            proxy_pass http://foo;
+        }
+    }
+</geshi>
+
+The resulting Lua load balancer can work with any existing nginx upstream modules
+like [http://nginx.org/en/docs/http/ngx_http_proxy_module.html ngx_proxy] and
+[http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html ngx_fastcgi].
+
+Also, the Lua load balancer can work with the standard upstream connection pool mechanism,
+i.e., the standard [http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive keepalive] directive.
+Just ensure that the [http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive keepalive] directive
+is used *after* this <code>balancer_by_lua_block</code> directive in a single <code>upstream {}</code> configuration block.
+
+The Lua load balancer can totally ignore the list of servers defined in the <code>upstream {}</code> block
+and select peer from a completely dynamic server list (even changing per request) via the
+[https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/balancer.md ngx.balancer] module
+from the [https://github.com/openresty/lua-resty-core lua-resty-core] library.
+
+The Lua code handler registered by this directive might get called more than once in a single
+downstream request when the nginx upstream mechanism retries the request on conditions
+specified by directives like the [http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream proxy_next_upstream]
+directive.
+
+This Lua code execution context does not support yielding, so Lua APIs that may yield
+(like cosockets and "light threads") are disabled in this context. One can usually work
+around this limitation by doing such operations in an earlier phase handler (like
+[[#access_by_lua|access_by_lua*]]) and passing along the result into this context
+via the [[#ngx.ctx|ngx.ctx]] table.
+
+This directive was first introduced in the <code>v0.10.0</code> release.
+
+== balancer_by_lua_file ==
+
+'''syntax:''' ''balancer_by_lua_file <path-to-lua-script-file>''
+
+'''context:''' ''upstream''
+
+'''phase:''' ''content''
+
+Equivalent to [[#balancer_by_lua_block|balancer_by_lua_block]], except that the file specified by <code><path-to-lua-script-file></code> contains the Lua code, or, as from the <code>v0.5.0rc32</code> release, the [[#Lua/LuaJIT bytecode support|Lua/LuaJIT bytecode]] to be executed.
+
+When a relative path like <code>foo/bar.lua</code> is given, they will be turned into the absolute path relative to the <code>server prefix</code> path determined by the <code>-p PATH</code> command-line option while starting the Nginx server.
+
+This directive was first introduced in the <code>v0.10.0</code> release.
+
 == lua_need_request_body ==
 
 '''syntax:''' ''lua_need_request_body <on|off>''
@@ -2427,7 +2497,7 @@ These constants are usually used by the [[#ngx.log|ngx.log]] method.
 == print ==
 '''syntax:''' ''print(...)''
 
-'''context:''' ''init_by_lua*, init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*, ngx.timer.*''
+'''context:''' ''init_by_lua*, init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*, ngx.timer.*, ngx.balancer_by_lua*''
 
 Writes argument values into the nginx <code>error.log</code> file with the <code>ngx.NOTICE</code> log level.
 
@@ -2442,7 +2512,7 @@ Lua <code>nil</code> arguments are accepted and result in literal <code>"nil"</c
 There is a hard coded <code>2048</code> byte limitation on error message lengths in the Nginx core. This limit includes trailing newlines and leading time stamps. If the message size exceeds this limit, Nginx will truncate the message text accordingly. This limit can be manually modified by editing the <code>NGX_MAX_ERROR_STR</code> macro definition in the <code>src/core/ngx_log.h</code> file in the Nginx source tree.
 
 == ngx.ctx ==
-'''context:''' ''init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*, ngx.timer.*''
+'''context:''' ''init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*, ngx.timer.*, balancer_by_lua*''
 
 This table can be used to store per-request Lua context data and has a life time identical to the current request (as with the Nginx variables). 
 
@@ -2998,7 +3068,7 @@ For reading ''request'' headers, use the [[#ngx.req.get_headers|ngx.req.get_head
 == ngx.resp.get_headers ==
 '''syntax:''' ''headers = ngx.resp.get_headers(max_headers?, raw?)''
 
-'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*''
+'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*, balancer_by_lua*''
 
 Returns a Lua table holding all the current response headers for the current request.
 
@@ -3097,7 +3167,7 @@ This method was first introduced in the <code>v0.7.17</code> release.
 == ngx.req.get_method ==
 '''syntax:''' ''method_name = ngx.req.get_method()''
 
-'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*''
+'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, balancer_by_lua*''
 
 Retrieves the current request's request method name. Strings like <code>"GET"</code> and <code>"POST"</code> are returned instead of numerical [[#HTTP method constants|method constants]].
 
@@ -3240,7 +3310,7 @@ See also [[#ngx.req.set_uri|ngx.req.set_uri]].
 == ngx.req.get_uri_args ==
 '''syntax:''' ''args = ngx.req.get_uri_args(max_args?)''
 
-'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*''
+'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*, balancer_by_lua*''
 
 Returns a Lua table holding all the current request URL query arguments.
 
@@ -3919,7 +3989,7 @@ Just as [[#ngx.print|ngx.print]] but also emit a trailing newline.
 == ngx.log ==
 '''syntax:''' ''ngx.log(log_level, ...)''
 
-'''context:''' ''init_by_lua*, init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*''
+'''context:''' ''init_by_lua*, init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*''
 
 Log arguments concatenated to error.log with the given logging level.
 
@@ -3949,7 +4019,7 @@ Since <code>v0.8.3</code> this function returns <code>1</code> on success, or re
 == ngx.exit ==
 '''syntax:''' ''ngx.exit(status)''
 
-'''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, ngx.timer.*''
+'''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, ngx.timer.*, balancer_by_lua*''
 
 When <code>status >= 200</code> (i.e., <code>ngx.HTTP_OK</code> and above), it will interrupt the execution of the current request and return status code to nginx.
 
@@ -6095,6 +6165,22 @@ the
 
 Please refer to the [https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/semaphore.md documentation]
 for this <code>ngx.semaphore</code> Lua module in [https://github.com/openresty/lua-resty-core lua-resty-core]
+for more details.
+
+This feature requires at least ngx_lua <code>v0.10.0</code>.
+
+== ngx.balancer ==
+'''syntax:''' ''local balancer = require "ngx.balancer"''
+
+This is a Lua module that provides a Lua API to allow defining completely dynamic load balancers
+in pure Lua.
+
+This Lua module does not ship with this ngx_lua module itself rather it is shipped with
+the
+[https://github.com/openresty/lua-resty-core lua-resty-core] library.
+
+Please refer to the [https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/balancer.md documentation]
+for this <code>ngx.balancer</code> Lua module in [https://github.com/openresty/lua-resty-core lua-resty-core]
 for more details.
 
 This feature requires at least ngx_lua <code>v0.10.0</code>.

--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -1,0 +1,603 @@
+
+/*
+ * Copyright (C) Yichun Zhang (agentzh)
+ */
+
+
+#ifndef DDEBUG
+#define DDEBUG 0
+#endif
+#include "ddebug.h"
+
+
+#include "ngx_http_lua_cache.h"
+#include "ngx_http_lua_balancer.h"
+#include "ngx_http_lua_util.h"
+#include "ngx_http_lua_directive.h"
+
+
+struct ngx_http_lua_balancer_peer_data_s {
+    /* the round robin data must be first */
+    ngx_http_upstream_rr_peer_data_t    rrp;
+
+    ngx_http_lua_srv_conf_t            *conf;
+    ngx_http_request_t                 *request;
+
+    ngx_event_get_peer_pt               get_rr_peer;
+
+    ngx_uint_t                          more_tries;
+    ngx_uint_t                          total_tries;
+
+    struct sockaddr                    *sockaddr;
+    socklen_t                           socklen;
+
+    ngx_str_t                           host;
+    in_port_t                           port;
+
+    int                                 last_peer_state;
+};
+
+
+static ngx_int_t ngx_http_lua_balancer_init(ngx_conf_t *cf,
+    ngx_http_upstream_srv_conf_t *us);
+static ngx_int_t ngx_http_lua_balancer_init_peer(ngx_http_request_t *r,
+    ngx_http_upstream_srv_conf_t *us);
+static ngx_int_t ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc,
+    void *data);
+static ngx_int_t ngx_http_lua_balancer_by_chunk(lua_State *L,
+    ngx_http_request_t *r);
+void ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+    ngx_uint_t state);
+
+
+ngx_int_t
+ngx_http_lua_balancer_handler_file(ngx_http_request_t *r,
+    ngx_http_lua_srv_conf_t *lscf, lua_State *L)
+{
+    ngx_int_t           rc;
+
+    rc = ngx_http_lua_cache_loadfile(r->connection->log, L,
+                                     lscf->balancer.src.data,
+                                     lscf->balancer.src_key);
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    /*  make sure we have a valid code chunk */
+    ngx_http_lua_assert(lua_isfunction(L, -1));
+
+    return ngx_http_lua_balancer_by_chunk(L, r);
+}
+
+
+ngx_int_t
+ngx_http_lua_balancer_handler_inline(ngx_http_request_t *r,
+    ngx_http_lua_srv_conf_t *lscf, lua_State *L)
+{
+    ngx_int_t           rc;
+
+    rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
+                                       lscf->balancer.src.data,
+                                       lscf->balancer.src.len,
+                                       lscf->balancer.src_key,
+                                       "=balancer_by_lua");
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    /*  make sure we have a valid code chunk */
+    ngx_http_lua_assert(lua_isfunction(L, -1));
+
+    return ngx_http_lua_balancer_by_chunk(L, r);
+}
+
+
+char *
+ngx_http_lua_balancer_by_lua_block(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf)
+{
+    char        *rv;
+    ngx_conf_t   save;
+
+    save = *cf;
+    cf->handler = ngx_http_lua_balancer_by_lua;
+    cf->handler_conf = conf;
+
+    rv = ngx_http_lua_conf_lua_block_parse(cf, cmd);
+
+    *cf = save;
+
+    return rv;
+}
+
+
+char *
+ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf)
+{
+    u_char                      *p;
+    u_char                      *name;
+    ngx_str_t                   *value;
+    ngx_http_lua_srv_conf_t     *lscf = conf;
+
+    ngx_http_upstream_srv_conf_t      *uscf;
+
+    dd("enter");
+
+    /*  must specifiy a content handler */
+    if (cmd->post == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    if (lscf->balancer.handler) {
+        return "is duplicate";
+    }
+
+    value = cf->args->elts;
+
+    lscf->balancer.handler = (ngx_http_lua_srv_conf_handler_pt) cmd->post;
+
+    if (cmd->post == ngx_http_lua_balancer_handler_file) {
+        /* Lua code in an external file */
+
+        name = ngx_http_lua_rebase_path(cf->pool, value[1].data,
+                                        value[1].len);
+        if (name == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        lscf->balancer.src.data = name;
+        lscf->balancer.src.len = ngx_strlen(name);
+
+        p = ngx_palloc(cf->pool, NGX_HTTP_LUA_FILE_KEY_LEN + 1);
+        if (p == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        lscf->balancer.src_key = p;
+
+        p = ngx_copy(p, NGX_HTTP_LUA_FILE_TAG, NGX_HTTP_LUA_FILE_TAG_LEN);
+        p = ngx_http_lua_digest_hex(p, value[1].data, value[1].len);
+        *p = '\0';
+
+    } else {
+        /* inlined Lua code */
+
+        lscf->balancer.src = value[1];
+
+        p = ngx_palloc(cf->pool, NGX_HTTP_LUA_INLINE_KEY_LEN + 1);
+        if (p == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        lscf->balancer.src_key = p;
+
+        p = ngx_copy(p, NGX_HTTP_LUA_INLINE_TAG, NGX_HTTP_LUA_INLINE_TAG_LEN);
+        p = ngx_http_lua_digest_hex(p, value[1].data, value[1].len);
+        *p = '\0';
+    }
+
+    uscf = ngx_http_conf_get_module_srv_conf(cf, ngx_http_upstream_module);
+
+    if (uscf->peer.init_upstream) {
+        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                           "load balancing method redefined");
+    }
+
+    uscf->peer.init_upstream = ngx_http_lua_balancer_init;
+
+    uscf->flags = NGX_HTTP_UPSTREAM_CREATE
+                  |NGX_HTTP_UPSTREAM_WEIGHT
+                  |NGX_HTTP_UPSTREAM_MAX_FAILS
+                  |NGX_HTTP_UPSTREAM_FAIL_TIMEOUT
+                  |NGX_HTTP_UPSTREAM_DOWN;
+
+    return NGX_CONF_OK;
+}
+
+
+static ngx_int_t
+ngx_http_lua_balancer_init(ngx_conf_t *cf,
+    ngx_http_upstream_srv_conf_t *us)
+{
+    if (ngx_http_upstream_init_round_robin(cf, us) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    /* this callback is called upon individual requests */
+    us->peer.init = ngx_http_lua_balancer_init_peer;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_lua_balancer_init_peer(ngx_http_request_t *r,
+    ngx_http_upstream_srv_conf_t *us)
+{
+    ngx_http_lua_srv_conf_t            *bcf;
+    ngx_http_lua_balancer_peer_data_t  *bp;
+
+    bp = ngx_pcalloc(r->pool, sizeof(ngx_http_lua_balancer_peer_data_t));
+    if (bp == NULL) {
+        return NGX_ERROR;
+    }
+
+    r->upstream->peer.data = &bp->rrp;
+
+    if (ngx_http_upstream_init_round_robin_peer(r, us) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    r->upstream->peer.get = ngx_http_lua_balancer_get_peer;
+    r->upstream->peer.free = ngx_http_lua_balancer_free_peer;
+
+    bcf = ngx_http_conf_upstream_srv_conf(us, ngx_http_lua_module);
+
+    bp->conf = bcf;
+    bp->get_rr_peer = ngx_http_upstream_get_round_robin_peer;
+    bp->request = r;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
+{
+    lua_State                          *L;
+    ngx_int_t                           rc;
+    ngx_http_request_t                 *r;
+    ngx_http_lua_ctx_t                 *ctx;
+    ngx_http_lua_srv_conf_t            *lscf;
+    ngx_http_lua_main_conf_t           *lmcf;
+    ngx_http_lua_balancer_peer_data_t  *bp = data;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "lua balancer peer, try: %ui", pc->tries);
+
+    lscf = bp->conf;
+
+    r = bp->request;
+
+    ngx_http_lua_assert(lscf->balancer.handler && r);
+
+    L = ngx_http_lua_get_lua_vm(r, NULL);
+
+    bp->sockaddr = NULL;
+    bp->socklen = 0;
+    bp->more_tries = 0;
+    bp->total_tries++;
+
+    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
+
+    /* balancer_by_lua does not support yielding and
+     * there cannot be any conflicts among concurrent requests,
+     * thus it is safe to store the peer data in the main conf.
+     */
+    lmcf->balancer_peer_data = bp;
+
+    rc = lscf->balancer.handler(r, lscf, L);
+
+    if (rc == NGX_ERROR) {
+        return NGX_ERROR;
+    }
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+
+    if (ctx->exited && ctx->exit_code != NGX_OK) {
+        rc = ctx->exit_code;
+        if (rc == NGX_ERROR || rc == NGX_BUSY || rc == NGX_DECLINED) {
+            return rc;
+        }
+
+        if (rc > NGX_OK) {
+            return NGX_ERROR;
+        }
+    }
+
+    if (bp->sockaddr && bp->socklen) {
+        pc->sockaddr = bp->sockaddr;
+        pc->socklen = bp->socklen;
+        pc->name = &bp->host;
+        bp->rrp.peers->single = 0;
+
+        if (bp->more_tries) {
+            r->upstream->peer.tries += bp->more_tries;
+        }
+
+        dd("tries: %d", (int) r->upstream->peer.tries);
+
+        return NGX_OK;
+    }
+
+    return bp->get_rr_peer(pc, &bp->rrp);
+}
+
+
+static ngx_int_t
+ngx_http_lua_balancer_by_chunk(lua_State *L, ngx_http_request_t *r)
+{
+    u_char                  *err_msg;
+    size_t                   len;
+    ngx_int_t                rc;
+    ngx_http_lua_ctx_t      *ctx;
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+
+    if (ctx == NULL) {
+        ctx = ngx_http_lua_create_ctx(r);
+        if (ctx == NULL) {
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
+
+    } else {
+        dd("reset ctx");
+        ngx_http_lua_reset_ctx(r, L, ctx);
+    }
+
+    ctx->context = NGX_HTTP_LUA_CONTEXT_BALANCER;
+
+    /* init nginx context in Lua VM */
+    ngx_http_lua_set_req(L, r);
+    ngx_http_lua_create_new_globals_table(L, 0 /* narr */, 1 /* nrec */);
+
+    /*  {{{ make new env inheriting main thread's globals table */
+    lua_createtable(L, 0, 1 /* nrec */);   /* the metatable for the new env */
+    ngx_http_lua_get_globals_table(L);
+    lua_setfield(L, -2, "__index");
+    lua_setmetatable(L, -2);    /*  setmetatable({}, {__index = _G}) */
+    /*  }}} */
+
+    lua_setfenv(L, -2);    /*  set new running env for the code closure */
+
+    lua_pushcfunction(L, ngx_http_lua_traceback);
+    lua_insert(L, 1);  /* put it under chunk and args */
+
+    /*  protected call user code */
+    rc = lua_pcall(L, 0, 1, 1);
+
+    lua_remove(L, 1);  /* remove traceback function */
+
+    dd("rc == %d", (int) rc);
+
+    if (rc != 0) {
+        /*  error occured when running loaded code */
+        err_msg = (u_char *) lua_tolstring(L, -1, &len);
+
+        if (err_msg == NULL) {
+            err_msg = (u_char *) "unknown reason";
+            len = sizeof("unknown reason") - 1;
+        }
+
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "failed to run balancer_by_lua*: %*s", len, err_msg);
+
+        lua_settop(L, 0); /*  clear remaining elems on stack */
+
+        return NGX_ERROR;
+    }
+
+    lua_settop(L, 0); /*  clear remaining elems on stack */
+    return rc;
+}
+
+
+void
+ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+    ngx_uint_t state)
+{
+    ngx_http_lua_balancer_peer_data_t  *bp = data;
+
+    if (bp->sockaddr && bp->socklen) {
+        bp->last_peer_state = (int) state;
+
+        if (pc->tries) {
+            pc->tries--;
+        }
+
+        return;
+    }
+
+    /* fallback */
+
+    ngx_http_upstream_free_round_robin_peer(pc, data, state);
+}
+
+
+#ifndef NGX_LUA_NO_FFI_API
+
+int
+ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
+    const u_char *addr, size_t addr_len, int port, char **err)
+{
+    ngx_url_t              url;
+    ngx_http_lua_ctx_t    *ctx;
+    ngx_http_upstream_t   *u;
+
+    ngx_http_lua_main_conf_t           *lmcf;
+    ngx_http_lua_balancer_peer_data_t  *bp;
+
+    if (r == NULL) {
+        *err = "no request found";
+        return NGX_ERROR;
+    }
+
+    u = r->upstream;
+
+    if (u == NULL) {
+        *err = "no upstream found";
+        return NGX_ERROR;
+    }
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+    if (ctx == NULL) {
+        *err = "no ctx found";
+        return NGX_ERROR;
+    }
+
+    if ((ctx->context & NGX_HTTP_LUA_CONTEXT_BALANCER) == 0) {
+        *err = "API disabled in the current context";
+        return NGX_ERROR;
+    }
+
+    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
+
+    /* we cannot read r->upstream->peer.data here directly because
+     * it could be overridden by other modules like
+     * ngx_http_upstream_keepalive_module.
+     */
+    bp = lmcf->balancer_peer_data;
+    if (bp == NULL) {
+        *err = "no upstream peer data found";
+        return NGX_ERROR;
+    }
+
+    ngx_memzero(&url, sizeof(ngx_url_t));
+
+    url.url.data = ngx_palloc(r->pool, addr_len);
+    if (url.url.data == NULL) {
+        *err = "no memory";
+        return NGX_ERROR;
+    }
+
+    ngx_memcpy(url.url.data, addr, addr_len);
+
+    url.url.len = addr_len;
+    url.default_port = port;
+    url.uri_part = 0;
+    url.no_resolve = 1;
+
+    if (ngx_parse_url(r->pool, &url) != NGX_OK) {
+        if (url.err) {
+            *err = url.err;
+        }
+
+        return NGX_ERROR;
+    }
+
+    if (url.addrs && url.addrs[0].sockaddr) {
+        bp->sockaddr = url.addrs[0].sockaddr;
+        bp->socklen = url.addrs[0].socklen;
+        bp->host = url.addrs[0].name;
+
+    } else {
+        *err = "no host allowed";
+        return NGX_ERROR;
+    }
+
+    return NGX_OK;
+}
+
+
+int
+ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
+    int count, char **err)
+{
+    ngx_uint_t             max_tries;
+    ngx_http_lua_ctx_t    *ctx;
+    ngx_http_upstream_t   *u;
+
+    ngx_http_lua_main_conf_t           *lmcf;
+    ngx_http_lua_balancer_peer_data_t  *bp;
+
+    if (r == NULL) {
+        *err = "no request found";
+        return NGX_ERROR;
+    }
+
+    u = r->upstream;
+
+    if (u == NULL) {
+        *err = "no upstream found";
+        return NGX_ERROR;
+    }
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+    if (ctx == NULL) {
+        *err = "no ctx found";
+        return NGX_ERROR;
+    }
+
+    if ((ctx->context & NGX_HTTP_LUA_CONTEXT_BALANCER) == 0) {
+        *err = "API disabled in the current context";
+        return NGX_ERROR;
+    }
+
+    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
+
+    bp = lmcf->balancer_peer_data;
+    if (bp == NULL) {
+        *err = "no upstream peer data found";
+        return NGX_ERROR;
+    }
+
+    max_tries = r->upstream->conf->next_upstream_tries;
+
+    if (bp->total_tries + count > max_tries) {
+        count = max_tries - bp->total_tries;
+        *err = "reduced tries due to limit";
+
+    } else {
+        *err = NULL;
+    }
+
+    bp->more_tries = count;
+    return NGX_OK;
+}
+
+
+int
+ngx_http_lua_ffi_balancer_get_last_failure(ngx_http_request_t *r,
+    int *status, char **err)
+{
+    ngx_http_lua_ctx_t         *ctx;
+    ngx_http_upstream_t        *u;
+    ngx_http_upstream_state_t  *state;
+
+    ngx_http_lua_balancer_peer_data_t  *bp;
+    ngx_http_lua_main_conf_t           *lmcf;
+
+    if (r == NULL) {
+        *err = "no request found";
+        return NGX_ERROR;
+    }
+
+    u = r->upstream;
+
+    if (u == NULL) {
+        *err = "no upstream found";
+        return NGX_ERROR;
+    }
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+    if (ctx == NULL) {
+        *err = "no ctx found";
+        return NGX_ERROR;
+    }
+
+    if ((ctx->context & NGX_HTTP_LUA_CONTEXT_BALANCER) == 0) {
+        *err = "API disabled in the current context";
+        return NGX_ERROR;
+    }
+
+    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
+
+    bp = lmcf->balancer_peer_data;
+    if (bp == NULL) {
+        *err = "no upstream peer data found";
+        return NGX_ERROR;
+    }
+
+    if (r->upstream_states && r->upstream_states->nelts > 1) {
+        state = r->upstream_states->elts;
+        *status = (int) state[r->upstream_states->nelts - 2].status;
+
+    } else {
+        *status = 0;
+    }
+
+    return bp->last_peer_state;
+}
+
+#endif  /* NGX_LUA_NO_FFI_API */

--- a/src/ngx_http_lua_balancer.h
+++ b/src/ngx_http_lua_balancer.h
@@ -1,0 +1,27 @@
+
+/*
+ * Copyright (C) Yichun Zhang (agentzh)
+ */
+
+
+#ifndef _NGX_HTTP_LUA_BALANCER_H_INCLUDED_
+#define _NGX_HTTP_LUA_BALANCER_H_INCLUDED_
+
+
+#include "ngx_http_lua_common.h"
+
+
+ngx_int_t ngx_http_lua_balancer_handler_inline(ngx_http_request_t *r,
+    ngx_http_lua_srv_conf_t *lscf, lua_State *L);
+
+ngx_int_t ngx_http_lua_balancer_handler_file(ngx_http_request_t *r,
+    ngx_http_lua_srv_conf_t *lscf, lua_State *L);
+
+char *ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+
+char *ngx_http_lua_balancer_by_lua_block(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+
+
+#endif /* _NGX_HTTP_LUA_BALANCER_H_INCLUDED_ */

--- a/src/ngx_http_lua_control.c
+++ b/src/ngx_http_lua_control.c
@@ -315,7 +315,8 @@ ngx_http_lua_ngx_exit(lua_State *L)
                                | NGX_HTTP_LUA_CONTEXT_ACCESS
                                | NGX_HTTP_LUA_CONTEXT_CONTENT
                                | NGX_HTTP_LUA_CONTEXT_TIMER
-                               | NGX_HTTP_LUA_CONTEXT_HEADER_FILTER);
+                               | NGX_HTTP_LUA_CONTEXT_HEADER_FILTER
+                               | NGX_HTTP_LUA_CONTEXT_BALANCER);
 
     rc = (ngx_int_t) luaL_checkinteger(L, 1);
 
@@ -351,7 +352,9 @@ ngx_http_lua_ngx_exit(lua_State *L)
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "lua exit with code %i", ctx->exit_code);
 
-    if (ctx->context & NGX_HTTP_LUA_CONTEXT_HEADER_FILTER) {
+    if (ctx->context & (NGX_HTTP_LUA_CONTEXT_HEADER_FILTER
+                        | NGX_HTTP_LUA_CONTEXT_BALANCER))
+    {
         return 0;
     }
 

--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -40,8 +40,6 @@ static ngx_int_t ngx_http_lua_set_by_lua_init(ngx_http_request_t *r);
 
 static u_char *ngx_http_lua_gen_chunk_name(ngx_conf_t *cf, const char *tag,
     size_t tag_len);
-static char *ngx_http_lua_conf_lua_block_parse(ngx_conf_t *cf,
-    ngx_command_t *cmd);
 static ngx_int_t ngx_http_lua_conf_read_lua_token(ngx_conf_t *cf,
     ngx_http_lua_block_parser_ctx_t *ctx);
 static u_char *ngx_http_lua_strlstrn(u_char *s1, u_char *last, u_char *s2,
@@ -1286,7 +1284,7 @@ found:
 
 
 /* a specialized version of the standard ngx_conf_parse() function */
-static char *
+char *
 ngx_http_lua_conf_lua_block_parse(ngx_conf_t *cf, ngx_command_t *cmd)
 {
     ngx_http_lua_block_parser_ctx_t     ctx;

--- a/src/ngx_http_lua_directive.h
+++ b/src/ngx_http_lua_directive.h
@@ -68,6 +68,9 @@ ngx_int_t ngx_http_lua_filter_set_by_lua_file(ngx_http_request_t *r,
 char *ngx_http_lua_rewrite_no_postpone(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 
+char *ngx_http_lua_conf_lua_block_parse(ngx_conf_t *cf,
+    ngx_command_t *cmd);
+
 
 #endif /* _NGX_HTTP_LUA_DIRECTIVE_H_INCLUDED_ */
 

--- a/src/ngx_http_lua_util.h
+++ b/src/ngx_http_lua_util.h
@@ -85,6 +85,7 @@ extern char ngx_http_lua_headers_metatable_key;
      : (c) == NGX_HTTP_LUA_CONTEXT_BODY_FILTER ? "body_filter_by_lua*"       \
      : (c) == NGX_HTTP_LUA_CONTEXT_TIMER ? "ngx.timer"                       \
      : (c) == NGX_HTTP_LUA_CONTEXT_INIT_WORKER ? "init_worker_by_lua*"       \
+     : (c) == NGX_HTTP_LUA_CONTEXT_BALANCER ? "balancer_by_lua*"             \
      : "(unknown)")
 
 

--- a/t/138-balancer.t
+++ b/t/138-balancer.t
@@ -1,0 +1,278 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua;
+
+#worker_connections(1014);
+#master_on();
+#workers(2);
+#log_level('warn');
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 4 + 7);
+
+#no_diff();
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: simple logging
+--- http_config
+    upstream backend {
+        server 0.0.0.1;
+        balancer_by_lua_block {
+            print("hello from balancer by lua!")
+        }
+    }
+--- config
+    location = /t {
+        proxy_pass http://backend;
+    }
+--- request
+    GET /t
+--- response_body_like: 502 Bad Gateway
+--- error_code: 502
+--- error_log eval
+[
+'[lua] balancer_by_lua:2: hello from balancer by lua! while connecting to upstream,',
+qr{\[crit\] .*? connect\(\) to 0\.0\.0\.1:80 failed .*?, upstream: "http://0\.0\.0\.1:80/t"},
+]
+--- no_error_log
+[warn]
+
+
+
+=== TEST 2: exit 403
+--- http_config
+    upstream backend {
+        server 0.0.0.1;
+        balancer_by_lua_block {
+            print("hello from balancer by lua!")
+            ngx.exit(403)
+        }
+    }
+--- config
+    location = /t {
+        proxy_pass http://backend;
+    }
+--- request
+    GET /t
+--- response_body_like: 500 Internal Server Error
+--- error_code: 500
+--- error_log
+[lua] balancer_by_lua:2: hello from balancer by lua! while connecting to upstream,
+--- no_error_log eval
+[
+'[warn]',
+qr{\[crit\] .*? connect\(\) to 0\.0\.0\.1:80 failed .*?, upstream: "http://0\.0\.0\.1:80/t"},
+]
+
+
+
+=== TEST 3: exit OK
+--- http_config
+    upstream backend {
+        server 0.0.0.1;
+        balancer_by_lua_block {
+            print("hello from balancer by lua!")
+            ngx.exit(ngx.OK)
+        }
+    }
+--- config
+    location = /t {
+        proxy_pass http://backend;
+    }
+--- request
+    GET /t
+--- response_body_like: 502 Bad Gateway
+--- error_code: 502
+--- error_log eval
+[
+'[lua] balancer_by_lua:2: hello from balancer by lua! while connecting to upstream,',
+qr{\[crit\] .*? connect\(\) to 0\.0\.0\.1:80 failed .*?, upstream: "http://0\.0\.0\.1:80/t"},
+]
+--- no_error_log
+[warn]
+
+
+
+=== TEST 4: ngx.var works
+--- http_config
+    upstream backend {
+        server 0.0.0.1;
+        balancer_by_lua_block {
+            print("1: variable foo = ", ngx.var.foo)
+            ngx.var.foo = tonumber(ngx.var.foo) + 1
+            print("2: variable foo = ", ngx.var.foo)
+        }
+    }
+--- config
+    location = /t {
+        set $foo 32;
+        proxy_pass http://backend;
+    }
+--- request
+    GET /t
+--- response_body_like: 502 Bad Gateway
+--- error_code: 502
+--- error_log eval
+[
+"1: variable foo = 32",
+"2: variable foo = 33",
+qr/\[crit\] .* connect\(\) .*? failed/,
+]
+--- no_error_log
+[warn]
+
+
+
+=== TEST 5: ngx.req.get_headers works
+--- http_config
+    upstream backend {
+        server 0.0.0.1;
+        balancer_by_lua_block {
+            print("header foo: ", ngx.req.get_headers()["foo"])
+        }
+    }
+--- config
+    location = /t {
+        proxy_pass http://backend;
+    }
+--- request
+    GET /t
+--- more_headers
+Foo: bar
+--- response_body_like: 502 Bad Gateway
+--- error_code: 502
+--- error_log eval
+[
+"header foo: bar",
+qr/\[crit\] .* connect\(\) .*? failed/,
+]
+--- no_error_log
+[warn]
+
+
+
+=== TEST 6: ngx.req.get_uri_args() works
+--- http_config
+    upstream backend {
+        server 0.0.0.1;
+        balancer_by_lua_block {
+            print("arg foo: ", ngx.req.get_uri_args()["foo"])
+        }
+    }
+--- config
+    location = /t {
+        proxy_pass http://backend;
+    }
+--- request
+    GET /t?baz=blah&foo=bar
+--- more_headers
+Foo: bar
+--- response_body_like: 502 Bad Gateway
+--- error_code: 502
+--- error_log eval
+["arg foo: bar",
+qr/\[crit\] .* connect\(\) .*? failed/,
+]
+--- no_error_log
+[warn]
+
+
+
+=== TEST 7: ngx.req.get_method() works
+--- http_config
+    upstream backend {
+        server 0.0.0.1;
+        balancer_by_lua_block {
+            print("method: ", ngx.req.get_method())
+        }
+    }
+--- config
+    location = /t {
+        proxy_pass http://backend;
+    }
+--- request
+    GET /t
+--- more_headers
+Foo: bar
+--- response_body_like: 502 Bad Gateway
+--- error_code: 502
+--- error_log eval
+[
+"method: GET",
+qr/\[crit\] .* connect\(\) .*? failed/,
+]
+--- no_error_log
+[warn]
+
+
+
+=== TEST 8: simple logging (by_lua_file)
+--- http_config
+    upstream backend {
+        server 0.0.0.1;
+        balancer_by_lua_file html/a.lua;
+    }
+--- config
+    location = /t {
+        proxy_pass http://backend;
+    }
+--- user_files
+>>> a.lua
+print("hello from balancer by lua!")
+--- request
+    GET /t
+--- response_body_like: 502 Bad Gateway
+--- error_code: 502
+--- error_log eval
+[
+'[lua] a.lua:1: hello from balancer by lua! while connecting to upstream,',
+qr{\[crit\] .*? connect\(\) to 0\.0\.0\.1:80 failed .*?, upstream: "http://0\.0\.0\.1:80/t"},
+]
+--- no_error_log
+[warn]
+
+
+
+=== TEST 9: cosockets are disabled
+--- http_config
+    upstream backend {
+        server 0.0.0.1;
+        balancer_by_lua_block {
+            local sock, err = ngx.socket.tcp()
+        }
+    }
+--- config
+    location = /t {
+        proxy_pass http://backend;
+    }
+--- request
+    GET /t
+--- response_body_like: 500 Internal Server Error
+--- error_code: 500
+--- error_log eval
+qr/\[error\] .*? failed to run balancer_by_lua\*: balancer_by_lua:2: API disabled in the context of balancer_by_lua\*/
+
+
+
+=== TEST 10: ngx.sleep is disabled
+--- http_config
+    upstream backend {
+        server 0.0.0.1;
+        balancer_by_lua_block {
+            ngx.sleep(0.1)
+        }
+    }
+--- config
+    location = /t {
+        proxy_pass http://backend;
+    }
+--- request
+    GET /t
+--- response_body_like: 500 Internal Server Error
+--- error_code: 500
+--- error_log eval
+qr/\[error\] .*? failed to run balancer_by_lua\*: balancer_by_lua:2: API disabled in the context of balancer_by_lua\*/


### PR DESCRIPTION
This PR is coupled by the following PR for lua-resty-core:

https://github.com/openresty/lua-resty-core/pull/8