### PR TITLE
$TEST_NGINX_HTML_DIR is too long name for unix socket

### DIFF
--- a/t/014-bugs.t
+++ b/t/014-bugs.t
@@ -978,7 +978,7 @@ ok
     proxy_ssl_session_reuse off;
 
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         ssl_certificate ../html/test.crt;
         ssl_certificate_key ../html/test.key;
 
@@ -988,7 +988,7 @@ ok
     }
 
     upstream local {
-        server unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        server unix:nginx.sock;
     }
 
 --- config

--- a/t/023-rewrite/socket-keepalive.t
+++ b/t/023-rewrite/socket-keepalive.t
@@ -817,7 +817,7 @@ lua tcp socket keepalive timeout: unlimited
 "
     lua_package_path '$::HtmlDir/?.lua;./?.lua';
     server {
-        listen unix:$::HtmlDir/nginx.sock;
+        listen unix:nginx.sock;
         default_type 'text/plain';
 
         server_tokens off;
@@ -832,7 +832,7 @@ lua tcp socket keepalive timeout: unlimited
         set $port $TEST_NGINX_MEMCACHED_PORT;
         rewrite_by_lua '
             local test = require "test"
-            local path = "$TEST_NGINX_HTML_DIR/nginx.sock";
+            local path = "nginx.sock";
             local port = ngx.var.port
             test.go(path, port)
             test.go(path, port)

--- a/t/023-rewrite/unix-socket.t
+++ b/t/023-rewrite/unix-socket.t
@@ -86,7 +86,7 @@ failed to connect: failed to parse host name "/tmp/test-nginx.sock": invalid hos
 === TEST 3: sanity
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        listen unix:nginx.sock;
         default_type 'text/plain';
 
         server_tokens off;
@@ -99,7 +99,7 @@ failed to connect: failed to parse host name "/tmp/test-nginx.sock": invalid hos
     location /test {
         rewrite_by_lua '
             local sock = ngx.socket.tcp()
-            local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+            local ok, err = sock:connect("unix:nginx.sock")
             if not ok then
                 ngx.say("failed to connect: ", err)
                 return

--- a/t/059-unix-socket.t
+++ b/t/059-unix-socket.t
@@ -71,7 +71,7 @@ failed to connect: failed to parse host name "/tmp/test-nginx.sock": invalid hos
 === TEST 3: sanity
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        listen unix:nginx.sock;
         default_type 'text/plain';
 
         server_tokens off;
@@ -84,7 +84,7 @@ failed to connect: failed to parse host name "/tmp/test-nginx.sock": invalid hos
     location /test {
         content_by_lua '
             local sock = ngx.socket.tcp()
-            local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+            local ok, err = sock:connect("unix:nginx.sock")
             if not ok then
                 ngx.say("failed to connect: ", err)
                 return

--- a/t/068-socket-keepalive.t
+++ b/t/068-socket-keepalive.t
@@ -781,7 +781,7 @@ qr/lua tcp socket connection pool size: 30\b/]
 "
     lua_package_path '$::HtmlDir/?.lua;./?.lua';
     server {
-        listen unix:$::HtmlDir/nginx.sock;
+        listen unix:nginx.sock;
         default_type 'text/plain';
 
         server_tokens off;
@@ -796,7 +796,7 @@ qr/lua tcp socket connection pool size: 30\b/]
         set $port $TEST_NGINX_MEMCACHED_PORT;
         content_by_lua '
             local test = require "test"
-            local path = "$TEST_NGINX_HTML_DIR/nginx.sock";
+            local path = "nginx.sock";
             local port = ngx.var.port
             test.go(path, port)
             test.go(path, port)
@@ -1064,7 +1064,7 @@ lua tcp socket get keepalive peer: using connection
 "
     lua_package_path '$::HtmlDir/?.lua;./?.lua';
     server {
-        listen unix:$::HtmlDir/nginx.sock;
+        listen unix:nginx.sock;
         default_type 'text/plain';
 
         server_tokens off;
@@ -1079,7 +1079,7 @@ lua tcp socket get keepalive peer: using connection
         set $port $TEST_NGINX_MEMCACHED_PORT;
         content_by_lua '
             local test = require "test"
-            local path = "$TEST_NGINX_HTML_DIR/nginx.sock";
+            local path = "nginx.sock";
             test.go(path, "A")
             test.go(path, "B")
         ';
@@ -1124,7 +1124,7 @@ lua tcp socket keepalive create connection pool for key "B"
 "
     lua_package_path '$::HtmlDir/?.lua;./?.lua';
     server {
-        listen unix:$::HtmlDir/nginx.sock;
+        listen unix:nginx.sock;
         default_type 'text/plain';
 
         server_tokens off;
@@ -1135,7 +1135,7 @@ lua tcp socket keepalive create connection pool for key "B"
         set $port $TEST_NGINX_MEMCACHED_PORT;
         content_by_lua '
             local test = require "test"
-            local path = "$TEST_NGINX_HTML_DIR/nginx.sock";
+            local path = "nginx.sock";
             test.go(path, "A")
             test.go(path, "A")
         ';

--- a/t/129-ssl-socket.t
+++ b/t/129-ssl-socket.t
@@ -1633,7 +1633,7 @@ attempt to call method 'sslhandshake' (a nil value)
 === TEST 21: unix domain ssl cosocket (no verify)
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate ../html/test.crt;
         ssl_certificate_key ../html/test.key;
@@ -1656,7 +1656,7 @@ attempt to call method 'sslhandshake' (a nil value)
             do
                 local sock = ngx.socket.tcp()
                 sock:settimeout(3000)
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -1736,7 +1736,7 @@ SSL reused session
 === TEST 22: unix domain ssl cosocket (verify)
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate ../html/test.crt;
         ssl_certificate_key ../html/test.key;
@@ -1761,7 +1761,7 @@ SSL reused session
             do
                 local sock = ngx.socket.tcp()
                 sock:settimeout(3000)
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -1842,7 +1842,7 @@ SSL reused session
 === TEST 23: unix domain ssl cosocket (no ssl on server)
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        listen unix:nginx.sock;
         server_name   test.com;
 
         server_tokens off;
@@ -1865,7 +1865,7 @@ SSL reused session
 
                 sock:settimeout(2000)
 
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -1932,7 +1932,7 @@ SSL reused session
 === TEST 24: lua_ssl_crl
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate ../html/test.crt;
         ssl_certificate_key ../html/test.key;
@@ -1960,7 +1960,7 @@ SSL reused session
 
                 sock:settimeout(3000)
 
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -2169,7 +2169,7 @@ SSL reused session
 === TEST 27: unix domain ssl cosocket (no gen session)
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate ../html/test.crt;
         ssl_certificate_key ../html/test.key;
@@ -2192,7 +2192,7 @@ SSL reused session
             do
                 local sock = ngx.socket.tcp()
                 sock:settimeout(3000)
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -2240,7 +2240,7 @@ SSL reused session
 === TEST 28: unix domain ssl cosocket (gen session, true)
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate ../html/test.crt;
         ssl_certificate_key ../html/test.key;
@@ -2263,7 +2263,7 @@ SSL reused session
             do
                 local sock = ngx.socket.tcp()
                 sock:settimeout(3000)
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -2314,7 +2314,7 @@ SSL reused session
 === TEST 29: unix domain ssl cosocket (keepalive)
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate ../html/test.crt;
         ssl_certificate_key ../html/test.key;
@@ -2337,7 +2337,7 @@ SSL reused session
             local sock = ngx.socket.tcp()
             sock:settimeout(3000)
             for i = 1, 2 do
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -2391,7 +2391,7 @@ SSL reused session
 === TEST 30: unix domain ssl cosocket (verify cert but no host name check, passed)
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate ../html/test.crt;
         ssl_certificate_key ../html/test.key;
@@ -2416,7 +2416,7 @@ SSL reused session
             do
                 local sock = ngx.socket.tcp()
                 sock:settimeout(3000)
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -2496,7 +2496,7 @@ SSL reused session
 === TEST 31: unix domain ssl cosocket (verify cert but no host name check, NOT passed)
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate ../html/test.crt;
         ssl_certificate_key ../html/test.key;
@@ -2521,7 +2521,7 @@ SSL reused session
             do
                 local sock = ngx.socket.tcp()
                 sock:settimeout(3000)
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return

--- a/t/139-ssl-cert-by.t
+++ b/t/139-ssl-cert-by.t
@@ -22,7 +22,7 @@ __DATA__
 === TEST 1: simple logging
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate_by_lua_block { print("ssl cert by lua is running!") }
         ssl_certificate ../../cert/test.crt;
@@ -46,7 +46,7 @@ __DATA__
 
                 sock:settimeout(2000)
 
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -116,7 +116,7 @@ ssl_certificate_by_lua:1: ssl cert by lua is running!
 === TEST 2: sleep
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate_by_lua_block {
             local begin = ngx.now()
@@ -144,7 +144,7 @@ ssl_certificate_by_lua:1: ssl cert by lua is running!
 
                 sock:settimeout(2000)
 
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -216,7 +216,7 @@ qr/elapsed in ssl cert by lua: 0.(?:09|1[01])\d+,/,
 === TEST 3: timer
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate_by_lua_block {
             local function f()
@@ -249,7 +249,7 @@ qr/elapsed in ssl cert by lua: 0.(?:09|1[01])\d+,/,
 
                 sock:settimeout(2000)
 
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -319,7 +319,7 @@ my timer run!
 === TEST 4: cosocket
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate_by_lua_block {
             local sock = ngx.socket.tcp()
@@ -367,7 +367,7 @@ my timer run!
 
                 sock:settimeout(2000)
 
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -857,7 +857,7 @@ should never reached here
 === TEST 11: get phase
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate_by_lua_block {print("get_phase: ", ngx.get_phase())}
         ssl_certificate ../../cert/test.crt;
@@ -881,7 +881,7 @@ should never reached here
 
                 sock:settimeout(2000)
 
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -920,7 +920,7 @@ get_phase: ssl_cert
 === TEST 12: connection aborted prematurely
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate_by_lua_block {
             ngx.sleep(0.3)
@@ -944,7 +944,7 @@ get_phase: ssl_cert
 
                 sock:settimeout(150)
 
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -985,7 +985,7 @@ ssl-cert-by-lua: after sleeping
 === TEST 13: subrequests disabled
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate_by_lua_block {ngx.location.capture("/foo")}
         ssl_certificate ../../cert/test.crt;
@@ -1002,7 +1002,7 @@ ssl-cert-by-lua: after sleeping
 
                 sock:settimeout(2000)
 
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -1043,7 +1043,7 @@ qr/\[crit\] .*?cert cb error/,
 === TEST 14: simple logging (by_lua_file)
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate_by_lua_file html/a.lua;
         ssl_certificate ../../cert/test.crt;
@@ -1072,7 +1072,7 @@ print("ssl cert by lua is running!")
 
                 sock:settimeout(2000)
 
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -1142,7 +1142,7 @@ a.lua:1: ssl cert by lua is running!
 === TEST 15: coroutine API
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate_by_lua_block {
             local cc, cr, cy = coroutine.create, coroutine.resume, coroutine.yield
@@ -1183,7 +1183,7 @@ a.lua:1: ssl cert by lua is running!
 
                 sock:settimeout(2000)
 
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -1261,7 +1261,7 @@ lua ssl server name: "test.com"
 === TEST 16: simple user thread wait with yielding
 --- http_config
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen unix:nginx.sock ssl;
         server_name   test.com;
         ssl_certificate_by_lua_block {
             function f()
@@ -1307,7 +1307,7 @@ lua ssl server name: "test.com"
 
                 sock:settimeout(2000)
 
-                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                local ok, err = sock:connect("unix:nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return


### PR DESCRIPTION
From Linux unix(7): "On Linux sun_path is 108 bytes in size"

I have longer directory names when running different builds of nginx and
these tests fail because of that.
