### PR TITLE
skip t/139-ssl-cert-by.t if too old OpenSSL

### DIFF
--- a/t/139-ssl-cert-by.t
+++ b/t/139-ssl-cert-by.t
@@ -4,7 +4,15 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(3);
 
-plan tests => repeat_each() * (blocks() * 6 + 10);
+# All these tests need to have new openssl
+my $NginxBinary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
+my $openssl_version = eval { `$NginxBinary -V 2>&1` };
+
+if ($openssl_version =~ m/built with OpenSSL (0|1\.0\.(?:0|1[^\d]|2[a-d]).*)/) {
+    plan(skip_all => "too old OpenSSL, need 1.0.2e, was $1");
+} else {
+    plan tests => repeat_each() * (blocks() * 6 + 10);
+}
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 $ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;


### PR DESCRIPTION
At RHEL-7 default openssl version is

OpenSSL 1.0.1e-fips 11 Feb 2013

and certby tests fails because of that. Because test bails out, testing stops there and I can't even get report.

This patch is only tested with RHEL-7 so it might will not work with other openssl installations.