### PR TITLE
fix 132-lua-blocks error_log rx

### DIFF
--- a/t/132-lua-blocks.t
+++ b/t/132-lua-blocks.t
@@ -310,7 +310,7 @@ hello, world
 [error]
 --- must_die
 --- error_log eval
-qr/\[emerg\] .*? Lua code block missing the closing long bracket "]]" in .*?\bnginx\.conf:41/
+qr/\[emerg\].*? Lua code block missing the closing long bracket "]]" in .*?\bnginx\.conf:41/
 
 
 
@@ -329,7 +329,7 @@ hello, world
 [error]
 --- must_die
 --- error_log eval
-qr/\[emerg\] .*? Lua code block missing the closing long bracket "]==]" in .*?\bnginx\.conf:41/
+qr/\[emerg\].*? Lua code block missing the closing long bracket "]==]" in .*?\bnginx\.conf:41/
 
 
 
@@ -348,7 +348,7 @@ hello, world
 [error]
 --- must_die
 --- error_log eval
-qr/\[emerg\] .*? Lua code block missing the closing long bracket "]]" in .*?\bnginx\.conf:41/
+qr/\[emerg\].*? Lua code block missing the closing long bracket "]]" in .*?\bnginx\.conf:41/
 
 
 
@@ -367,7 +367,7 @@ hello, world
 [error]
 --- must_die
 --- error_log eval
-qr/\[emerg\] .*? Lua code block missing the closing long bracket "]=]" in .*?\bnginx\.conf:41/
+qr/\[emerg\].*? Lua code block missing the closing long bracket "]=]" in .*?\bnginx\.conf:41/
 
 
 
@@ -417,7 +417,7 @@ GET /t
 --- no_error_log
 [error]
 --- error_log eval
-qr{\[emerg\] .*? unexpected lua closing long-bracket in .*?/nginx\.conf:41}
+qr{\[emerg\].*? unexpected lua closing long-bracket in .*?/nginx\.conf:41}
 --- must_die
 
 


### PR DESCRIPTION
line is in my env:

nginx: [emerg] Lua code block missing the closing long bracket "]]" in /build/nginx/nginx-1.9.9/ngx_lua/t/servroot/conf/nginx.conf:49

so '\] .*? Lua' does not match single space and line number is off