### PR TITLE
ngx.re APIs now returns false instead of nil

### DIFF
--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -698,7 +698,6 @@ phases.
 * cosocket: pool-based backend concurrency level control: implement automatic <code>connect</code> queueing when the backend concurrency exceeds its connection pool limit.
 * cosocket: review and merge aviramc's [https://github.com/openresty/lua-nginx-module/pull/290 patch] for adding the <code>bsdrecv</code> method.
 * add new API function <code>ngx.resp.add_header</code> to emulate the standard <code>add_header</code> config directive.
-* [[#ngx.re.match|ngx.re]] API: use <code>false</code> instead of <code>nil</code> in the resulting match table to indicate non-existent submatch captures, such that we can avoid "holes" in the array table.
 * review and apply Jader H. Silva's patch for <code>ngx.re.split()</code>.
 * review and apply vadim-pavlov's patch for [[#ngx.location.capture|ngx.location.capture]]'s <code>extra_headers</code> option
 * use <code>ngx_hash_t</code> to optimize the built-in header look-up process for [[#ngx.req.set_header|ngx.req.set_header]], [[#ngx.header.HEADER|ngx.header.HEADER]], and etc.
@@ -4593,15 +4592,15 @@ and are returned in the same Lua table as key-value pairs as the numbered captur
     -- m["remaining"] == "234"
 </geshi>
 
-Unmatched subpatterns will have <code>nil</code> values in their <code>captures</code> table fields.
+Unmatched subpatterns will have <code>false</code> values in their <code>captures</code> table fields.
 
 <geshi lang="lua">
     local m, err = ngx.re.match("hello, world", "(world)|(hello)|(?<named>howdy)")
     -- m[0] == "hello"
-    -- m[1] == nil
+    -- m[1] == false
     -- m[2] == "hello"
-    -- m[3] == nil
-    -- m["named"] == nil
+    -- m[3] == false
+    -- m["named"] == false
 </geshi>
 
 Specify <code>options</code> to control how the match operation will be performed. The following option characters are supported:

--- a/src/ngx_http_lua_regex.c
+++ b/src/ngx_http_lua_regex.c
@@ -592,14 +592,14 @@ exec:
     }
 
     if (res_tb_idx == 0) {
-        lua_createtable(L, rc /* narr */, 0 /* nrec */);
+        lua_createtable(L, re_comp.captures /* narr */, name_count /* nrec */);
         res_tb_idx = lua_gettop(L);
     }
 
-    for (i = 0, n = 0; i < rc; i++, n += 2) {
+    for (i = 0, n = 0; i < re_comp.captures + 1; i++, n += 2) {
         dd("capture %d: %d %d", i, cap[n], cap[n + 1]);
-        if (cap[n] < 0) {
-            lua_pushnil(L);
+        if (i >= rc || cap[n] < 0) {
+            lua_pushboolean(L, 0);
 
         } else {
             lua_pushlstring(L, (char *) &subj.data[cap[n]],

--- a/t/034-match.t
+++ b/t/034-match.t
@@ -409,7 +409,7 @@ error: .*?unknown flag "H" \(flags "Hm"\)
     GET /re
 --- response_body
 hello
-nil
+false
 hello
 
 
@@ -814,7 +814,7 @@ hello-1234
 
 
 
-=== TEST 38: named captures are nil
+=== TEST 38: named captures are false
 --- config
     location /re {
         content_by_lua '
@@ -834,10 +834,10 @@ hello-1234
     GET /re
 --- response_body
 hello
-nil
+false
 hello
-nil
-nil
+false
+false
 
 
 
@@ -901,15 +901,15 @@ matched: 章
             -- Note the D here
             local m = ngx.re.match(target, regex, 'D')
 
-            ngx.say(type(m.group1))
-            ngx.say(type(m.group2))
+            ngx.say(m.group1[1])
+            ngx.say(m.group2[1])
         ";
     }
 --- request
 GET /t
 --- response_body
-nil
-nil
+false
+false
 --- no_error_log
 [error]
 
@@ -1148,3 +1148,23 @@ failed to match
 1234
 --- SKIP
 
+
+
+=== TEST 49: trailing captures are false
+--- config
+    location /re {
+        content_by_lua '
+            local m = ngx.re.match("hello", "(hello)(.+)?")
+            if m then
+                ngx.say(m[0])
+                ngx.say(m[1])
+                ngx.say(m[2])
+            end
+        ';
+    }
+--- request
+    GET /re
+--- response_body
+hello
+hello
+false


### PR DESCRIPTION
Previously, `ngx.re.match` and `ngx.re.find` returned nil when the
subjcet did not match the pattern. This caused issues when results are
stored into a table (holes, wrong length, ...).

This commit fixes this behavior:

* `ngx.re.match` returns `false`
* `ngx.re.find` returns `false, false`

The behavior in case of actual errors is not changed (`nil` is
returned).

About `ngx.re.find`, I noticed that when the subject didn't match the pattern, a single nil was returned and when  it did match but the requested group didn't, two `nil`s were returned. Not sure if it was on purpose or not, but now it returns two `false` in both cases.