### PR TITLE
feature: ngx.log accepts tables with __tostring metafield

### DIFF
--- a/src/ngx_http_lua_log.c
+++ b/src/ngx_http_lua_log.c
@@ -160,6 +160,16 @@ log_wrapper(ngx_log_t *log, const char *ident, ngx_uint_t level,
 
                 break;
 
+            case LUA_TTABLE:
+                if (!luaL_callmeta(L, i, "__tostring")) {
+                    return luaL_argerror(L, i, "expected table to have "
+                                         "__tostring metamethod");
+                }
+
+                lua_tolstring(L, -1, &len);
+                size += len;
+                break;
+
             case LUA_TLIGHTUSERDATA:
                 if (lua_touserdata(L, i) == NULL) {
                     size += sizeof("null") - 1;
@@ -225,6 +235,12 @@ log_wrapper(ngx_log_t *log, const char *ident, ngx_uint_t level,
                     *p++ = 'e';
                 }
 
+                break;
+
+            case LUA_TTABLE:
+                luaL_callmeta(L, i, "__tostring");
+                q = (u_char *) lua_tolstring(L, -1, &len);
+                p = ngx_copy(p, q, len);
                 break;
 
             case LUA_TLIGHTUSERDATA:

--- a/t/009-log.t
+++ b/t/009-log.t
@@ -265,7 +265,96 @@ qr/\[error\] \S+: \S+ \[lua\] set_by_lua:2: truefalsenil,/
 
 
 
-=== TEST 14: print() in header filter
+=== TEST 14: test table with metamethod
+--- config
+    location /log {
+        content_by_lua_block {
+            ngx.say("before log")
+            local t = setmetatable({v = "value"}, {
+                __tostring = function(self)
+                    return "tostring "..self.v
+                end
+            })
+            ngx.log(ngx.ERR, t)
+            ngx.say("after log")
+        }
+    }
+--- request
+GET /log
+--- response_body
+before log
+after log
+--- error_log eval
+qr/\[error\] \S+: \S+ \[lua\] content_by_lua\(nginx\.conf:\d+\):8: tostring value,/
+
+
+
+=== TEST 15: test table without metamethod
+--- config
+    location /log {
+        content_by_lua_block {
+            ngx.log(ngx.ERR, {})
+            ngx.say("done")
+        }
+    }
+--- request
+GET /log
+--- response_body_like: 500 Internal Server Error
+--- error_code: 500
+--- error_log
+bad argument #1 to 'log' (expected table to have __tostring metamethod)
+
+
+
+=== TEST 16: test tables mixed with other types
+--- config
+    location /log {
+        content_by_lua_block {
+            ngx.say("before log")
+            local t = setmetatable({v = "value"}, {
+                __tostring = function(self)
+                    return "tostring: "..self.v
+                end
+            })
+            ngx.log(ngx.ERR, t, " hello ", t)
+            ngx.say("after log")
+        }
+    }
+--- request
+GET /log
+--- response_body
+before log
+after log
+--- error_log eval
+qr/\[error\] \S+: \S+ \[lua\] content_by_lua\(nginx\.conf:\d+\):8: tostring: value hello tostring: value,/
+
+
+
+=== TEST 17: test print with tables
+--- config
+    location /log {
+        content_by_lua_block {
+            ngx.say("before log")
+            local t = setmetatable({v = "value"}, {
+                __tostring = function(self)
+                    return "tostring: "..self.v
+                end
+            })
+            print(t, " hello ", t)
+            ngx.say("after log")
+        }
+    }
+--- request
+GET /log
+--- response_body
+before log
+after log
+--- error_log eval
+qr/\[notice\] \S+: \S+ \[lua\] content_by_lua\(nginx\.conf:\d+\):8: tostring: value hello tostring: value,/
+
+
+
+=== TEST 18: print() in header filter
 --- config
     location /log {
         header_filter_by_lua '
@@ -285,7 +374,7 @@ hi
 
 
 
-=== TEST 15: ngx.log() in header filter
+=== TEST 19: ngx.log in header filter
 --- config
     location /log {
         header_filter_by_lua '
@@ -305,7 +394,7 @@ qr/\[error\] .*? \[lua\] header_filter_by_lua:2: howdy, lua!/
 
 
 
-=== TEST 16: ngx.log() big data
+=== TEST 20: ngx.log big data
 --- config
     location /log {
         content_by_lua '
@@ -321,7 +410,7 @@ GET /log
 
 
 
-=== TEST 17: ngx.log in Lua function calls & inlined lua
+=== TEST 21: ngx.log in Lua function calls & inlined lua
 --- config
     location /log {
         content_by_lua '
@@ -346,7 +435,7 @@ qr/\[error\] \S+: \S+ \[lua\] content_by_lua\(nginx\.conf:\d+\):7: bar\(\): hell
 
 
 
-=== TEST 18: ngx.log in Lua function tail-calls & inlined lua
+=== TEST 22: ngx.log in Lua function tail-calls & inlined lua
 --- config
     location /log {
         content_by_lua '
@@ -376,7 +465,7 @@ qr/\[error\] \S+: \S+ \[lua\] content_by_lua\(nginx\.conf:\d+\):8:(?: foo\(\):)?
 
 
 
-=== TEST 19: ngx.log in Lua files
+=== TEST 23: ngx.log in Lua files
 --- config
     location /log {
         content_by_lua_file 'html/test.lua';
@@ -403,7 +492,7 @@ qr/\[error\] \S+: \S+ \[lua\] test.lua:6: bar\(\): hello, log12343.14159/
 
 
 
-=== TEST 20: ngx.log with bad levels (ngx.ERROR, -1)
+=== TEST 24: ngx.log with bad levels (ngx.ERROR, -1)
 --- config
     location /log {
         content_by_lua '
@@ -420,7 +509,7 @@ bad log level: -1
 
 
 
-=== TEST 21: ngx.log with bad levels (9)
+=== TEST 25: ngx.log with bad levels (9)
 --- config
     location /log {
         content_by_lua '
@@ -437,7 +526,7 @@ bad log level: 9
 
 
 
-=== TEST 22: \0 in the log message
+=== TEST 26: \0 in the log message
 --- config
     location = /t {
         content_by_lua '


### PR DESCRIPTION
> Extend `ngx.log()` to allow table arguments when those have a `__tostring`
metafield. If they do not, ngx.log will raise an error (similar to
previous behavior when a table was given to ngx.log).

> When a table with `__tostring` metafield is given, the metamethod will
be called through `luaL_callmeta()`.

#### Use case
While implementing [lua-cassandra](https://github.com/thibaultCha/lua-cassandra), I found myself in the need to return more complex errors than regular strings. Those errors allow one to take particular actions depending on the fields it contains (error code and a given Cassandra peer for example). For those errors to be nicely printed to the user, I implemented a `__tostring` metafield but quickly found out that I needed to do:

```lua
ngx.log(ngx.ERR, tostring(err))
```

This change was primarily motived by this use case. Secondly, it is worth noting that in plain Lua,

```lua
print(t)
```

Will call the `__tostring` metamethod of `t` if any, so this behavior mimics Lua's `print`.

#### Caveats
- Yes, tables are more expensive for Lua to maintain, but in some cases, they are more descriptive than plain strings. Errors are not the only use case in which you would want to log tables either. I think it's a good thing if we get closer to `print`'s behavior.
- What I am more concerned about: currently, the metamethod is called twice (once for the length, once for the actual string). Just like `lua_tolstring()` is called twice for strings too. If the `__tostring` is expensive, we are wasting some time here.

Finally, I did not check if ngx's `print` (overriding ngx.log at NOTICE level) will also benefit from this, nor added a test for it. If this change is considered, I will add such a test.