### PR TITLE
Unmatched capture are set to false in capture table

### DIFF
--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -698,7 +698,6 @@ phases.
 * cosocket: pool-based backend concurrency level control: implement automatic <code>connect</code> queueing when the backend concurrency exceeds its connection pool limit.
 * cosocket: review and merge aviramc's [https://github.com/openresty/lua-nginx-module/pull/290 patch] for adding the <code>bsdrecv</code> method.
 * add new API function <code>ngx.resp.add_header</code> to emulate the standard <code>add_header</code> config directive.
-* [[#ngx.re.match|ngx.re]] API: use <code>false</code> instead of <code>nil</code> in the resulting match table to indicate non-existent submatch captures, such that we can avoid "holes" in the array table.
 * review and apply Jader H. Silva's patch for <code>ngx.re.split()</code>.
 * review and apply vadim-pavlov's patch for [[#ngx.location.capture|ngx.location.capture]]'s <code>extra_headers</code> option
 * use <code>ngx_hash_t</code> to optimize the built-in header look-up process for [[#ngx.req.set_header|ngx.req.set_header]], [[#ngx.header.HEADER|ngx.header.HEADER]], and etc.
@@ -4593,15 +4592,15 @@ and are returned in the same Lua table as key-value pairs as the numbered captur
     -- m["remaining"] == "234"
 </geshi>
 
-Unmatched subpatterns will have <code>nil</code> values in their <code>captures</code> table fields.
+Unmatched subpatterns will have <code>false</code> values in their <code>captures</code> table fields.
 
 <geshi lang="lua">
     local m, err = ngx.re.match("hello, world", "(world)|(hello)|(?<named>howdy)")
     -- m[0] == "hello"
-    -- m[1] == nil
+    -- m[1] == false
     -- m[2] == "hello"
-    -- m[3] == nil
-    -- m["named"] == nil
+    -- m[3] == false
+    -- m["named"] == false
 </geshi>
 
 Specify <code>options</code> to control how the match operation will be performed. The following option characters are supported:

--- a/src/ngx_http_lua_regex.c
+++ b/src/ngx_http_lua_regex.c
@@ -2071,6 +2071,11 @@ ngx_http_lua_re_collect_named_captures(lua_State *L, int res_tb_idx,
         }
 
         if (flags & NGX_LUA_RE_MODE_DUPNAMES) {
+            /* unmatched groups are not stored in tables in DUPNAMES mode */
+            if (!lua_toboolean(L, -1)) {
+                lua_pop(L, 1);
+                continue;
+            }
 
             lua_getfield(L, -2, name); /* big_tb cap small_tb */
 

--- a/src/ngx_http_lua_regex.c
+++ b/src/ngx_http_lua_regex.c
@@ -592,14 +592,14 @@ exec:
     }
 
     if (res_tb_idx == 0) {
-        lua_createtable(L, rc /* narr */, 0 /* nrec */);
+        lua_createtable(L, re_comp.captures /* narr */, name_count /* nrec */);
         res_tb_idx = lua_gettop(L);
     }
 
-    for (i = 0, n = 0; i < rc; i++, n += 2) {
+    for (i = 0, n = 0; i < re_comp.captures + 1; i++, n += 2) {
         dd("capture %d: %d %d", i, cap[n], cap[n + 1]);
-        if (cap[n] < 0) {
-            lua_pushnil(L);
+        if (i >= rc || cap[n] < 0) {
+            lua_pushboolean(L, 0);
 
         } else {
             lua_pushlstring(L, (char *) &subj.data[cap[n]],
@@ -1116,12 +1116,12 @@ ngx_http_lua_ngx_re_gmatch_iterator(lua_State *L)
 
     dd("rc = %d", (int) rc);
 
-    lua_createtable(L, rc /* narr */, 0 /* nrec */);
+    lua_createtable(L, ctx->ncaptures + 1 /* narr */, name_count /* nrec */);
 
-    for (i = 0, n = 0; i < rc; i++, n += 2) {
+    for (i = 0, n = 0; i < ctx->ncaptures + 1; i++, n += 2) {
         dd("capture %d: %d %d", i, cap[n], cap[n + 1]);
-        if (cap[n] < 0) {
-            lua_pushnil(L);
+        if (i >= rc || cap[n] < 0) {
+            lua_pushboolean(L, 0);
 
         } else {
             lua_pushlstring(L, (char *) &subj.data[cap[n]],

--- a/t/034-match.t
+++ b/t/034-match.t
@@ -409,7 +409,7 @@ error: .*?unknown flag "H" \(flags "Hm"\)
     GET /re
 --- response_body
 hello
-nil
+false
 hello
 
 
@@ -814,7 +814,7 @@ hello-1234
 
 
 
-=== TEST 38: named captures are nil
+=== TEST 38: named captures are false
 --- config
     location /re {
         content_by_lua '
@@ -834,10 +834,10 @@ hello-1234
     GET /re
 --- response_body
 hello
-nil
+false
 hello
-nil
-nil
+false
+false
 
 
 
@@ -901,15 +901,15 @@ matched: 章
             -- Note the D here
             local m = ngx.re.match(target, regex, 'D')
 
-            ngx.say(type(m.group1))
-            ngx.say(type(m.group2))
+            ngx.say(m.group1[1])
+            ngx.say(m.group2[1])
         ";
     }
 --- request
 GET /t
 --- response_body
-nil
-nil
+false
+false
 --- no_error_log
 [error]
 
@@ -1147,4 +1147,25 @@ failed to match
 --- response_body
 1234
 --- SKIP
+
+
+
+=== TEST 49: trailing captures are false
+--- config
+    location /re {
+        content_by_lua '
+            local m = ngx.re.match("hello", "(hello)(.+)?")
+            if m then
+                ngx.say(m[0])
+                ngx.say(m[1])
+                ngx.say(m[2])
+            end
+        ';
+    }
+--- request
+    GET /re
+--- response_body
+hello
+hello
+false
 

--- a/t/034-match.t
+++ b/t/034-match.t
@@ -901,15 +901,15 @@ matched: 章
             -- Note the D here
             local m = ngx.re.match(target, regex, 'D')
 
-            ngx.say(m.group1[1])
-            ngx.say(m.group2[1])
+            ngx.say(type(m.group1))
+            ngx.say(type(m.group2))
         ";
     }
 --- request
 GET /t
 --- response_body
-false
-false
+nil
+nil
 --- no_error_log
 [error]
 

--- a/t/035-gmatch.t
+++ b/t/035-gmatch.t
@@ -582,13 +582,13 @@ matched: []
 --- response_body
 1234
 1234
-nil
+false
 1234
-nil
+false
 abcd
-nil
+false
 abcd
-nil
+false
 abcd
 
 

--- a/t/038-match-o.t
+++ b/t/038-match-o.t
@@ -384,7 +384,7 @@ error: pcre_compile() failed: missing ) in "(abc"
     GET /re
 --- response_body
 hello
-nil
+false
 hello
 
 
@@ -716,7 +716,7 @@ hello-1234
 
 
 
-=== TEST 33: named captures are nil
+=== TEST 33: named captures are false
 --- config
     location /re {
         content_by_lua '
@@ -736,8 +736,8 @@ hello-1234
     GET /re
 --- response_body
 hello
-nil
+false
 hello
-nil
-nil
+false
+false
 


### PR DESCRIPTION
Now unmatched capture groups in `ngx.re.match` and `ngx.re.gmatch` are
set to `false` rather than nil. This prevents to create table with
holes that don't play nice with `ipairs` or `#` operators.

For consistency, unmatched trailing captures (for instance in
`ngx.re.match("hello", "(hello)(.+)?")`) as well as named captures are
also set to `false`.

An interesting side effect of this patch concerns the duplicate pattern option (the `D` flag): the unmatched capture will also receive a `false` value, for instance:
```lua
local regex = '^(?<g>foo)?(?<g>bar)?$'
ngx.re.match('foobar', regex, 'D') -- { [0]='foobar', [1]='foo', [2]='bar', g={ 'foo', 'bar' } }
ngx.re.match('foo', regex, 'D')    -- { [0]='foobar', [1]='foo', [2]=false, g={ 'foo', false } }
ngx.re.match('bar', regex, 'D')    -- { [0]='foobar', [1]=false, [2]='bar', g={ false, 'bar' } }
ngx.re.match('', regex, 'D')       -- { [0]='foobar', [1]=false, [2]=false, g={ false, false } }
```
I have mixed feelings about this behavior: on one hand it is consistent with the other cases, but on the other hand I can't think of any valid uses case and it might create a lot of useless tables. So I am open to any feedback about that.