### PR TITLE
style fix: variable name align with the previous line

### DIFF
--- a/src/ngx_http_lua_req_body.c
+++ b/src/ngx_http_lua_req_body.c
@@ -619,9 +619,9 @@ ngx_http_lua_ngx_req_append_body(lua_State *L)
     ngx_http_request_t          *r;
     int                          n;
     ngx_http_request_body_t     *rb;
-    ngx_str_t                   body;
-    size_t                      size, rest;
-    size_t                      offset = 0;
+    ngx_str_t                    body;
+    size_t                       size, rest;
+    size_t                       offset = 0;
 
     n = lua_gettop(L);
 
@@ -683,10 +683,10 @@ ngx_http_lua_ngx_req_body_finish(lua_State *L)
     int                          n;
     ngx_http_request_body_t     *rb;
     ngx_buf_t                   *b;
-    size_t                      size;
-    ngx_str_t                   value;
-    ngx_str_t                   key;
-    ngx_int_t                   rc;
+    size_t                       size;
+    ngx_str_t                    value;
+    ngx_str_t                    key;
+    ngx_int_t                    rc;
 
     n = lua_gettop(L);
 

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -140,7 +140,7 @@ void
 ngx_http_lua_shdict_rbtree_insert_value(ngx_rbtree_node_t *temp,
     ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel)
 {
-    ngx_rbtree_node_t          **p;
+    ngx_rbtree_node_t           **p;
     ngx_http_lua_shdict_node_t   *sdn, *sdnt;
 
     for ( ;; ) {


### PR DESCRIPTION
checked by ngx-style: https://github.com/openresty/nginx-devel-utils/pull/6