### PR TITLE
doc: fix log_by_lua, runs before nginx access log and after

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2115,7 +2115,7 @@ log_by_lua
 **WARNING** Since the `v0.9.17` release, use of this directive is *discouraged*;
 use the new [log_by_lua_block](#log_by_lua_block) directive instead.
 
-Runs the Lua source code inlined as the `<lua-script-str>` at the `log` request processing phase. This does not replace the current access logs, but runs after.
+Runs the Lua source code inlined as the `<lua-script-str>` at the `log` request processing phase. This does not replace the current access logs, but runs before.
 
 Note that the following API functions are currently disabled within this context:
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -1757,7 +1757,7 @@ This directive was first introduced in the <code>v0.5.0rc32</code> release.
 '''WARNING''' Since the <code>v0.9.17</code> release, use of this directive is ''discouraged'';
 use the new [[#log_by_lua_block|log_by_lua_block]] directive instead.
 
-Runs the Lua source code inlined as the <code><lua-script-str></code> at the <code>log</code> request processing phase. This does not replace the current access logs, but runs after.
+Runs the Lua source code inlined as the <code><lua-script-str></code> at the <code>log</code> request processing phase. This does not replace the current access logs, but runs before.
 
 Note that the following API functions are currently disabled within this context:
 


### PR DESCRIPTION
According to #254 and commit e549fc2df0c03648a4553c8310c90c61db46aa42 log_by_lua runs before classic nginx access logs. This was missed in the docs.