### PR TITLE
Nginx 1.9.11 ngx_udp_connection_t => ngx_resolver_connection_t

### DIFF
--- a/src/ngx_http_lua_socket_udp.c
+++ b/src/ngx_http_lua_socket_udp.c
@@ -54,7 +54,7 @@ static void ngx_http_lua_socket_udp_read_handler(ngx_http_request_t *r,
     ngx_http_lua_socket_udp_upstream_t *u);
 static void ngx_http_lua_socket_udp_handle_success(ngx_http_request_t *r,
     ngx_http_lua_socket_udp_upstream_t *u);
-static ngx_int_t ngx_http_lua_udp_connect(ngx_udp_connection_t *uc);
+static ngx_int_t ngx_http_lua_udp_connect(ngx_resolver_connection_t *uc);
 static int ngx_http_lua_socket_udp_close(lua_State *L);
 static ngx_int_t ngx_http_lua_socket_udp_resume(ngx_http_request_t *r);
 static void ngx_http_lua_udp_resolve_cleanup(void *data);
@@ -170,7 +170,7 @@ ngx_http_lua_socket_udp_setpeername(lua_State *L)
     ngx_url_t                    url;
     ngx_int_t                    rc;
     ngx_http_lua_loc_conf_t     *llcf;
-    ngx_udp_connection_t        *uc;
+    ngx_resolver_connection_t   *uc;
     int                          timeout;
     ngx_http_lua_co_ctx_t       *coctx;
 
@@ -246,7 +246,7 @@ ngx_http_lua_socket_udp_setpeername(lua_State *L)
             return 2;
         }
 
-        if (u->udp_connection.connection) {
+        if (u->udp_connection.udp) {
             ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                            "lua udp socket reconnect without shutting down");
 
@@ -642,7 +642,7 @@ ngx_http_lua_socket_resolve_retval_handler(ngx_http_request_t *r,
 {
     ngx_http_lua_ctx_t              *ctx;
     ngx_http_lua_co_ctx_t           *coctx;
-    ngx_udp_connection_t            *uc;
+    ngx_resolver_connection_t       *uc;
     ngx_connection_t                *c;
     ngx_http_cleanup_t              *cln;
     ngx_http_upstream_resolved_t    *ur;
@@ -699,7 +699,7 @@ ngx_http_lua_socket_resolve_retval_handler(ngx_http_request_t *r,
 
     /* rc == NGX_OK */
 
-    c = uc->connection;
+    c = uc->udp;
 
     c->data = u;
 
@@ -806,13 +806,13 @@ ngx_http_lua_socket_udp_send(lua_State *L)
     u = lua_touserdata(L, -1);
     lua_pop(L, 1);
 
-    if (u == NULL || u->udp_connection.connection == NULL) {
+    if (u == NULL || u->udp_connection.udp == NULL) {
         llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
 
         if (llcf->log_socket_errors) {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                           "attempt to send data on a closed socket: u:%p, c:%p",
-                          u, u ? u->udp_connection.connection : NULL);
+                          u, u ? u->udp_connection.udp : NULL);
         }
 
         lua_pushnil(L);
@@ -881,7 +881,7 @@ ngx_http_lua_socket_udp_send(lua_State *L)
 
     dd("sending query %.*s", (int) query.len, query.data);
 
-    n = ngx_send(u->udp_connection.connection, query.data, query.len);
+    n = ngx_send(u->udp_connection.udp, query.data, query.len);
 
     dd("ngx_send returns %d (query len %d)", (int) n, (int) query.len);
 
@@ -937,13 +937,13 @@ ngx_http_lua_socket_udp_receive(lua_State *L)
     u = lua_touserdata(L, -1);
     lua_pop(L, 1);
 
-    if (u == NULL || u->udp_connection.connection == NULL) {
+    if (u == NULL || u->udp_connection.udp == NULL) {
         llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
 
         if (llcf->log_socket_errors) {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                           "attempt to receive data on a closed socket: u:%p, "
-                          "c:%p", u, u ? u->udp_connection.connection : NULL);
+                          "c:%p", u, u ? u->udp_connection.udp : NULL);
         }
 
         lua_pushnil(L);
@@ -1094,12 +1094,12 @@ ngx_http_lua_socket_udp_finalize(ngx_http_request_t *r,
         u->resolved->ctx = NULL;
     }
 
-    if (u->udp_connection.connection) {
+    if (u->udp_connection.udp) {
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                        "lua close socket connection");
 
-        ngx_close_connection(u->udp_connection.connection);
-        u->udp_connection.connection = NULL;
+        ngx_close_connection(u->udp_connection.udp);
+        u->udp_connection.udp = NULL;
     }
 
     if (u->waiting) {
@@ -1145,13 +1145,13 @@ ngx_http_lua_socket_udp_read(ngx_http_request_t *r,
     ngx_event_t                 *rev;
     ssize_t                      n;
 
-    c = u->udp_connection.connection;
+    c = u->udp_connection.udp;
     rev = c->read;
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
                    "lua udp socket read data: waiting: %d", (int) u->waiting);
 
-    n = ngx_udp_recv(u->udp_connection.connection,
+    n = ngx_udp_recv(u->udp_connection.udp,
                      ngx_http_lua_socket_udp_buffer, u->recv_buf_size);
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
@@ -1198,7 +1198,7 @@ ngx_http_lua_socket_udp_read_handler(ngx_http_request_t *r,
     ngx_connection_t            *c;
     ngx_http_lua_loc_conf_t     *llcf;
 
-    c = u->udp_connection.connection;
+    c = u->udp_connection.udp;
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "lua udp socket read handler");
@@ -1348,7 +1348,7 @@ ngx_http_lua_socket_udp_handle_success(ngx_http_request_t *r,
 
 
 static ngx_int_t
-ngx_http_lua_udp_connect(ngx_udp_connection_t *uc)
+ngx_http_lua_udp_connect(ngx_resolver_connection_t *uc)
 {
     int                rc;
     ngx_int_t          event;
@@ -1398,7 +1398,7 @@ ngx_http_lua_udp_connect(ngx_udp_connection_t *uc)
     rev->log = &uc->log;
     wev->log = &uc->log;
 
-    uc->connection = c;
+    uc->udp = c;
 
     c->number = ngx_atomic_fetch_add(ngx_connection_counter, 1);
 
@@ -1414,7 +1414,7 @@ ngx_http_lua_udp_connect(ngx_udp_connection_t *uc)
         ngx_log_debug0(NGX_LOG_DEBUG_EVENT, &uc->log, 0, "datagram unix "
                        "domain socket autobind");
 
-        if (bind(uc->connection->fd, &addr, sizeof(sa_family_t)) != 0) {
+        if (bind(uc->udp->fd, &addr, sizeof(sa_family_t)) != 0) {
             ngx_log_error(NGX_LOG_CRIT, &uc->log, ngx_socket_errno,
                           "bind() failed");
 
@@ -1485,7 +1485,7 @@ ngx_http_lua_socket_udp_close(lua_State *L)
     u = lua_touserdata(L, -1);
     lua_pop(L, 1);
 
-    if (u == NULL || u->udp_connection.connection == NULL) {
+    if (u == NULL || u->udp_connection.udp == NULL) {
         lua_pushnil(L);
         lua_pushliteral(L, "closed");
         return 2;

--- a/src/ngx_http_lua_socket_udp.h
+++ b/src/ngx_http_lua_socket_udp.h
@@ -31,7 +31,7 @@ struct ngx_http_lua_socket_udp_upstream_s {
     ngx_http_lua_loc_conf_t         *conf;
     ngx_http_cleanup_pt             *cleanup;
     ngx_http_request_t              *request;
-    ngx_udp_connection_t             udp_connection;
+    ngx_resolver_connection_t        udp_connection;
 
     ngx_msec_t                       read_timeout;
 


### PR DESCRIPTION
Hi,

In Nginx 1.9.11, the ```ngx_udp_connection_t``` structure has been renamed to ```ngx_resolver_connection_t``` in ```src/core/ngx_resolver.h``` of Nginx core. (https://github.com/nginx/nginx/commit/1945fff7bfee1eef23933faa0ccfbe05445dcfe1).

Consequently, compilation fails in ```lua-nginx-module/src/ngx_http_lua_socket_udp.h``` and ```lua-nginx-module/src/ngx_http_lua_socket_udp.c``` due to references of ```ngx_udp_connection_t```. The compilation failure is as follows:

```
modules/lua-nginx-module/src/ngx_http_lua_util.c
In file included from modules/lua-nginx-module/src/ngx_http_lua_util.c:38:0:
modules/lua-nginx-module/src/ngx_http_lua_socket_udp.h:34:5: error: unknown type name ‘ngx_udp_connection_t’
     ngx_udp_connection_t             udp_connection;
```

I've attached a simple patch that corrects the issue and allows Nginx 1.9.11 to compile.

----
UPDATE: See #668 for others reporting this issue.