### PR TITLE
Small documentation fix to sample code

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6320,7 +6320,7 @@ Timeout for the reading operation is controlled by the [lua_socket_read_timeout]
  sock:settimeout(1000)  -- one second timeout
  local data, err = sock:receive()
  if not data then
-     ngx.say("failed to read a packet: ", data)
+     ngx.say("failed to read a packet: ", err)
      return
  end
  ngx.say("successfully read a packet: ", data)


### PR DESCRIPTION
Was playing with `sock:receive` and realised the sample code was outputting the wrong variable.