### PR TITLE
docs(readme) add get_phase() result for ssl_cert context

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6845,6 +6845,8 @@ Retrieves the current running phase name. Possible return values are
 	for the context of [init_by_lua](#init_by_lua) or [init_by_lua_file](#init_by_lua_file).
 * `init_worker`
 	for the context of [init_worker_by_lua](#init_worker_by_lua) or [init_worker_by_lua_file](#init_worker_by_lua_file).
+* `ssl_cert`
+	for the context of [ssl_certificate_by_lua](#ssl_certificate_by_lua) or [ssl_certificate_by_lua_file](#ssl_certificate_by_lua_file).
 * `set`
 	for the context of [set_by_lua](#set_by_lua) or [set_by_lua_file](#set_by_lua_file).
 * `rewrite`

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -5765,6 +5765,8 @@ Retrieves the current running phase name. Possible return values are
 : for the context of [[#init_by_lua|init_by_lua]] or [[#init_by_lua_file|init_by_lua_file]].
 * <code>init_worker</code>
 : for the context of [[#init_worker_by_lua|init_worker_by_lua]] or [[#init_worker_by_lua_file|init_worker_by_lua_file]].
+* <code>ssl_cert</code>
+: for the context of [[#ssl_certificate_by_lua|ssl_certificate_by_lua]] or [[#ssl_certificate_by_lua_file|ssl_certificate_by_lua_file]].
 * <code>set</code>
 : for the context of [[#set_by_lua|set_by_lua]] or [[#set_by_lua_file|set_by_lua_file]].
 * <code>rewrite</code>


### PR DESCRIPTION
I believe the result of `ngx.get_phase()` in the SSL context was missing.