### PR TITLE
prevents potential "unused variable" error

### DIFF
--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -493,7 +493,10 @@ int
 ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
     int count, char **err)
 {
+#if (nginx_version >= 1007005)
     ngx_uint_t             max_tries;
+#endif
+
     ngx_http_lua_ctx_t    *ctx;
     ngx_http_upstream_t   *u;
 


### PR DESCRIPTION
Compiling an older version of nginx (`1.6.3` at least) results in an "unused variable error" when using default `CC_OPTS` (`-Wall -Wpointer-arith -Wno-unused-parameter -Werror` for me and for example on Travis CI):

```shell
.../ngx_http_lua_balancer.c:496:28: error: unused variable ‘max_tries’ [-Werror=unused-variable]
     ngx_uint_t             max_tries;
                            ^
cc1: all warnings being treated as errors
```

While passing "-Wno-unused-variables" to the compiler is an option this patch removes that workaround.

I'm not that happy with the looks of the `#if`-block so if you like to move or reformat it I will happily adjust the patch.