### PR TITLE
ngx.req.get_post_args: return error message instead of raising an exception

### DIFF
--- a/src/ngx_http_lua_args.c
+++ b/src/ngx_http_lua_args.c
@@ -111,8 +111,6 @@ ngx_http_lua_ngx_req_get_uri_args(lua_State *L)
 
     ngx_http_lua_check_fake_request(L, r);
 
-    lua_createtable(L, 0, 4);
-
     if (r->args.len == 0) {
         lua_createtable(L, 0, 0);
         return 1;
@@ -125,6 +123,8 @@ ngx_http_lua_ngx_req_get_uri_args(lua_State *L)
     if (buf == NULL) {
         return luaL_error(L, "no memory");
     }
+
+    lua_createtable(L, 0, 4);
 
     ngx_memcpy(buf, r->args.data, r->args.len);
 
@@ -183,12 +183,13 @@ ngx_http_lua_ngx_req_get_post_args(lua_State *L)
     }
 
     if (r->request_body->temp_file) {
-        return luaL_error(L, "requesty body in temp file not supported");
+        lua_pushnil(L);
+        lua_pushliteral(L, "requesty body in temp file not supported");
+        return 2;
     }
 
-    lua_createtable(L, 0, 4);
-
     if (r->request_body->bufs == NULL) {
+        lua_createtable(L, 0, 0);
         return 1;
     }
 
@@ -211,6 +212,8 @@ ngx_http_lua_ngx_req_get_post_args(lua_State *L)
     if (buf == NULL) {
         return luaL_error(L, "no memory");
     }
+
+    lua_createtable(L, 0, 4);
 
     p = buf;
     for (cl = r->request_body->bufs; cl; cl = cl->next) {

--- a/t/031-post-args.t
+++ b/t/031-post-args.t
@@ -323,3 +323,34 @@ for my $k (@k) {
 CORE::join("", @k);
 --- timeout: 4
 
+
+
+
+=== TEST 10: request body in temp file
+--- config
+    location /lua {
+        lua_need_request_body on;
+        client_body_in_file_only clean;
+        content_by_lua '
+            local args, err = ngx.req.get_post_args()
+
+            if not args then
+                ngx.say(err)
+            else
+                local keys = {}
+                for key, val in pairs(args) do
+                    table.insert(keys, key)
+                end
+
+                table.sort(keys)
+                for i, key in ipairs(keys) do
+                    ngx.say(key, " = ", args[key])
+                end
+            end
+        ';
+    }
+--- request
+POST /lua
+a=3&b=4&c
+--- response_body
+requesty body in temp file not supported


### PR DESCRIPTION
return error message instead of raising an exception when request body is in temp file.