### PR TITLE
Clear errors in pem_to_der functions

### DIFF
--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -842,12 +842,14 @@ ngx_http_lua_ffi_cert_pem_to_der(const u_char *pem, size_t pem_len, u_char *der,
     bio = BIO_new_mem_buf((char *) pem, (int) pem_len);
     if (bio == NULL) {
         *err = "BIO_new_mem_buf() failed";
+        ERR_clear_error();
         return NGX_ERROR;
     }
 
     x509 = PEM_read_bio_X509_AUX(bio, NULL, NULL, NULL);
     if (x509 == NULL) {
         *err = "PEM_read_bio_X509_AUX() failed";
+        ERR_clear_error();
         return NGX_ERROR;
     }
 
@@ -856,6 +858,7 @@ ngx_http_lua_ffi_cert_pem_to_der(const u_char *pem, size_t pem_len, u_char *der,
         *err = "i2d_X509() failed";
         X509_free(x509);
         BIO_free(bio);
+        ERR_clear_error();
         return NGX_ERROR;
     }
 
@@ -881,6 +884,7 @@ ngx_http_lua_ffi_cert_pem_to_der(const u_char *pem, size_t pem_len, u_char *der,
 
             *err = "PEM_read_bio_X509() failed";
             BIO_free(bio);
+            ERR_clear_error();
             return NGX_ERROR;
         }
 
@@ -889,6 +893,7 @@ ngx_http_lua_ffi_cert_pem_to_der(const u_char *pem, size_t pem_len, u_char *der,
             *err = "i2d_X509() failed";
             X509_free(x509);
             BIO_free(bio);
+            ERR_clear_error();
             return NGX_ERROR;
         }
 
@@ -914,6 +919,7 @@ ngx_http_lua_ffi_priv_key_pem_to_der(const u_char *pem, size_t pem_len,
     in = BIO_new_mem_buf((char *) pem, (int) pem_len);
     if (in == NULL) {
         *err = "BIO_new_mem_buf() failed";
+        ERR_clear_error();
         return NGX_ERROR;
     }
 
@@ -921,6 +927,7 @@ ngx_http_lua_ffi_priv_key_pem_to_der(const u_char *pem, size_t pem_len,
     if (pkey == NULL) {
         BIO_free(in);
         *err = "PEM_read_bio_PrivateKey failed";
+        ERR_clear_error();
         return NGX_ERROR;
     }
 
@@ -930,6 +937,7 @@ ngx_http_lua_ffi_priv_key_pem_to_der(const u_char *pem, size_t pem_len,
     if (len < 0) {
         EVP_PKEY_free(pkey);
         *err = "i2d_PrivateKey failed";
+        ERR_clear_error();
         return NGX_ERROR;
     }
 

--- a/t/140-ssl-c-api.t
+++ b/t/140-ssl-c-api.t
@@ -11,7 +11,7 @@ my $openssl_version = eval { `$NginxBinary -V 2>&1` };
 if ($openssl_version =~ m/built with OpenSSL (0|1\.0\.(?:0|1[^\d]|2[a-d]).*)/) {
     plan(skip_all => "too old OpenSSL, need 1.0.2e, was $1");
 } else {
-    plan tests => repeat_each() * (blocks() * 5);
+    plan tests => repeat_each() * ((blocks() * 5)+1);
 }
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
@@ -360,4 +360,139 @@ lua ssl server name: "test.com"
 
 --- no_error_log
 [error]
+[alert]
+
+
+=== TEST 3: Handshake continue when cert_pem_to_der errors
+--- http_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+
+        ssl_certificate_by_lua_block {
+            collectgarbage()
+
+            local ffi = require "ffi"
+
+            ffi.cdef[[
+                int ngx_http_lua_ffi_cert_pem_to_der(const unsigned char *pem,
+                    size_t pem_len, unsigned char *der, char **err);
+
+                int ngx_http_lua_ffi_priv_key_pem_to_der(const unsigned char *pem,
+                    size_t pem_len, unsigned char *der, char **err);
+            ]]
+
+            local errmsg = ffi.new("char *[1]")
+
+            local r = getfenv(0).__ngx_req
+            if not r then
+                ngx.log(ngx.ERR, "no request found")
+                return
+            end
+
+            local cert = "garbage data"
+
+            local out = ffi.new("char [?]", #cert)
+
+            local rc = ffi.C.ngx_http_lua_ffi_cert_pem_to_der(cert, #cert, out, errmsg)
+            if rc < 1 then
+                ngx.log(ngx.ERR, "failed to parse PEM cert: ",
+                        ffi.string(errmsg[0]))
+            end
+
+            local pkey = "garbage key data"
+
+            out = ffi.new("char [?]", #pkey)
+
+            local rc = ffi.C.ngx_http_lua_ffi_priv_key_pem_to_der(pkey, #pkey, out, errmsg)
+            if rc < 1 then
+                ngx.log(ngx.ERR, "failed to parse PEM priv key: ",
+                        ffi.string(errmsg[0]))
+            end
+        }
+
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block { ngx.status = 201 ngx.say("foo") ngx.exit(201) }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /foo HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to recieve response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+sent http request: 56 bytes.
+received: HTTP/1.1 201 Created
+received: Server: nginx
+received: Content-Type: text/plain
+received: Content-Length: 4
+received: Connection: close
+received: 
+received: foo
+close: 1 nil
+
+--- error_log
+lua ssl server name: "test.com"
+failed to parse PEM cert: PEM_read_bio_X509_AUX()
+failed to parse PEM priv key: PEM_read_bio_PrivateKey failed
+
+--- no_error_log
 [alert]


### PR DESCRIPTION
Calls OpenSSL's [ERR_clear_error](https://www.openssl.org/docs/manmaster/crypto/ERR_clear_error.html) when an error occurs in pem_to_der conversion functions

Related: openresty/lua-resty-core#28