### PR TITLE
Fix conf sample syntax error in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -129,7 +129,7 @@ Synopsis
                  ngx.say("status: ", res.status)
                  ngx.say("body:")
                  ngx.print(res.body)
-             end';
+             end
          }
      }
 


### PR DESCRIPTION
The sample with incorrect ending of if block will cause 500 error.