### PR TITLE
bugfix: ngx.req.append_body may go to endless loop

### DIFF
--- a/src/ngx_http_lua_req_body.c
+++ b/src/ngx_http_lua_req_body.c
@@ -565,6 +565,10 @@ ngx_http_lua_ngx_req_init_body(lua_State *L)
         if (size > (size_t) r->headers_in.content_length_n) {
             size = (size_t) r->headers_in.content_length_n;
         }
+
+        if (size == 0) {
+            r->request_body_in_file_only = 1;
+        }
     }
 
     rb = r->request_body;
@@ -622,6 +626,8 @@ ngx_http_lua_ngx_req_append_body(lua_State *L)
     ngx_str_t                    body;
     size_t                       size, rest;
     size_t                       offset = 0;
+    ngx_chain_t                  chain;
+    ngx_buf_t                    buf;
 
     n = lua_gettop(L);
 
@@ -643,6 +649,24 @@ ngx_http_lua_ngx_req_append_body(lua_State *L)
         || r->request_body->bufs == NULL)
     {
         return luaL_error(L, "request_body not initalized");
+    }
+
+    if (r->request_body_in_file_only) {
+        buf.start = body.data;
+        buf.pos = buf.start;
+        buf.last = buf.start + body.len;
+        buf.end = buf.last;
+        buf.temporary = 1;
+
+        chain.buf = &buf;
+        chain.next = NULL;
+
+        if (ngx_http_lua_write_request_body(r, &chain) != NGX_OK) {
+            return luaL_error(L, "fail to write file");
+        }
+
+        r->headers_in.content_length_n += body.len;
+        return 0;
     }
 
     rb = r->request_body;

--- a/t/044-req-body.t
+++ b/t/044-req-body.t
@@ -1630,3 +1630,74 @@ request body:hello, world
 --- no_error_log
 [error]
 [alert]
+
+
+
+=== TEST 50: init & append & finish (content_length = 0)
+--- config
+    location /t {
+        content_by_lua '
+            local old_http_content_length = ngx.var.http_content_length
+
+            ngx.req.read_body()
+            ngx.req.init_body()
+            ngx.req.append_body("he")
+            ngx.req.append_body("llo")
+            ngx.req.finish_body()
+
+            ngx.say("old content length: ", old_http_content_length)
+
+            local data = ngx.req.get_body_data()
+            local data_file = ngx.req.get_body_file()
+
+            if not data and data_file then
+                ngx.say("no data in buf, go to data file")
+            end
+
+            ngx.say("content length: ", ngx.var.http_content_length)
+        ';
+    }
+--- request
+    GET /t
+--- more_headers
+Content-Length: 0
+--- response_body
+old content length: 0
+no data in buf, go to data file
+content length: 5
+--- no_error_log
+[error]
+[alert]
+
+
+
+=== TEST 51: init & append & finish (client_body_buffer_size = 0)
+--- http_config
+    client_body_buffer_size 0;
+--- config
+    location /t {
+        content_by_lua '
+            ngx.req.read_body()
+            ngx.req.init_body()
+            ngx.req.append_body("he")
+            ngx.req.append_body("llo")
+            ngx.req.finish_body()
+
+            local data = ngx.req.get_body_data()
+            local data_file = ngx.req.get_body_file()
+
+            if not data and data_file then
+                ngx.say("no data in buf, go to data file")
+            end
+
+            ngx.say("content length: ", ngx.var.http_content_length)
+        ';
+    }
+--- request
+    GET /t
+--- response_body
+no data in buf, go to data file
+content length: 5
+--- no_error_log
+[error]
+[alert]


### PR DESCRIPTION
when ngx.req.init_body have not specified the buffer_size and
(client_body_buffer_size = 0 or Content Length = 0)

And now we honor the `client_body_in_file_only` in `ngx.req.append_body` too, I'm not sure if this is ok, if yes, then I should add some test case too.