### PR TITLE
cppcheck fixes (I think we could add cppcheck as a CI step)

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -1181,7 +1181,7 @@ ngx_http_lua_socket_tcp_sslhandshake(lua_State *L)
     /* Lua function arguments: self [,session] [,host] [,verify] */
 
     n = lua_gettop(L);
-    if (n < 1 && n > 4) {
+    if (n < 1 || n > 4) {
         return luaL_error(L, "ngx.socket connect: expecting 1 ~ 4 "
                           "arguments (including the object), but seen %d", n);
     }

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -907,16 +907,16 @@ ngx_http_lua_request_cleanup(ngx_http_lua_ctx_t *ctx, int forcible)
     ngx_http_request_t          *r;
     ngx_http_lua_main_conf_t    *lmcf;
 
-    r = ctx->request;
-
-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                   "lua request cleanup: forcible=%d", forcible);
-
     /*  force coroutine handling the request quit */
     if (ctx == NULL) {
         dd("ctx is NULL");
         return;
     }
+
+    r = ctx->request;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "lua request cleanup: forcible=%d", forcible);
 
     if (ctx->cleanup) {
         *ctx->cleanup = NULL;


### PR DESCRIPTION
[src/ngx_http_lua_socket_tcp.c:1184]: (warning) Logical conjunction always evaluates to false: n < 1 && n > 4.
[src/ngx_http_lua_util.c:916]: (warning) Either the condition 'ctx==0' is redundant or there is possible null pointer dereference: ctx.