### PR TITLE
skip ipv6 if not supported

### DIFF
--- a/t/058-tcp-socket.t
+++ b/t/058-tcp-socket.t
@@ -1,5 +1,6 @@
 # vim:set ft= ts=4 sw=4 et fdm=marker:
 
+
 use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
@@ -3298,6 +3299,7 @@ failed to receive a line: closed []
 close: 1 nil
 --- no_error_log
 [error]
+--- skip_eval: 3: system("ping6 -c 1 ::1 >/dev/null 2>&1") ne 0
 
 
 


### PR DESCRIPTION
travis ci does not support ipv6, the best we can do, skip it