### PR TITLE
bugfix: ignore unexpected closing long-brackets in '*_by_lua_block' directives

### DIFF
--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -1417,20 +1417,8 @@ ngx_http_lua_conf_lua_block_parse(ngx_conf_t *cf, ngx_command_t *cmd)
             break;
 
         case FOUND_LBRACKET_STR:
-
-            break;
-
         case FOUND_LBRACKET_CMT:
-
-            break;
-
         case FOUND_RIGHT_LBRACKET:
-            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                               "unexpected lua closing long-bracket");
-            goto failed;
-
-            break;
-
         case FOUND_COMMENT_LINE:
         case FOUND_DOUBLE_QUOTED:
         case FOUND_SINGLE_QUOTED:

--- a/t/132-lua-blocks.t
+++ b/t/132-lua-blocks.t
@@ -10,7 +10,7 @@ use Test::Nginx::Socket::Lua;
 repeat_each(2);
 #repeat_each(1);
 
-plan tests => repeat_each() * (blocks() * 3 + 4);
+plan tests => repeat_each() * (blocks() * 3 + 3);
 
 #no_diff();
 no_long_string();
@@ -405,7 +405,7 @@ hello, world!
 
 
 
-=== TEST 16: content_by_lua_block (unexpected closing long brackets)
+=== TEST 16: content_by_lua_block unexpected closing long brackets must FAIL
 --- config
     location = /t {
         content_by_lua_block {
@@ -414,15 +414,30 @@ hello, world!
     }
 --- request
 GET /t
+--- error_code: 500
+--- error_log eval
+qr{\[error\] .*? unexpected symbol near ']'}
+
+
+
+=== TEST 17: content_by_lua_block unexpected closing long brackets ignored (GitHub #748)
+--- config
+    location = /t {
+        content_by_lua_block {
+            local t1, t2 = {"hello world"}, {1}
+            ngx.say(t1[t2[1]])
+        }
+    }
+--- request
+GET /t
+--- response_body
+hello world
 --- no_error_log
 [error]
---- error_log eval
-qr{\[emerg\] .*? unexpected lua closing long-bracket in .*?/nginx\.conf:41}
---- must_die
 
 
 
-=== TEST 17: simple set_by_lua_block (integer)
+=== TEST 18: simple set_by_lua_block (integer)
 --- config
     location /lua {
         set_by_lua_block $res { return 1+1 }
@@ -437,7 +452,7 @@ GET /lua
 
 
 
-=== TEST 18: ambiguous line comments inside a long bracket string (GitHub #596)
+=== TEST 19: ambiguous line comments inside a long bracket string (GitHub #596)
 --- config
     location = /t {
         content_by_lua_block {
@@ -459,7 +474,7 @@ done
 
 
 
-=== TEST 19: double quotes in long brackets
+=== TEST 20: double quotes in long brackets
 --- config
     location = /t {
         rewrite_by_lua_block { print([[Hey, it is "!]]) } content_by_lua_block { ngx.say([["]]) }
@@ -475,7 +490,7 @@ Hey, it is "!
 
 
 
-=== TEST 20: single quotes in long brackets
+=== TEST 21: single quotes in long brackets
 --- config
     location = /t {
         rewrite_by_lua_block { print([[Hey, it is '!]]) } content_by_lua_block { ngx.say([[']]) }
@@ -491,7 +506,7 @@ Hey, it is '!
 
 
 
-=== TEST 21: lexer no match due to incomplete data chunks in a fixed size buffer
+=== TEST 22: lexer no match due to incomplete data chunks in a fixed size buffer
 --- config
         location /test1 {
             content_by_lua_block {


### PR DESCRIPTION
Fix for #748 dropping support for detecting unexpected closing long brackets.

Should I propose the same patch against the ngx_lua_stream module or will you apply it there too?