### PR TITLE
feature: ssl: add FFI functions to parse cert/priv key to cdata instead of DER

### DIFF
--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -952,6 +952,254 @@ ngx_http_lua_ffi_priv_key_pem_to_der(const u_char *pem, size_t pem_len,
 }
 
 
+void *
+ngx_http_lua_ffi_parse_pem_cert(const u_char *pem, size_t pem_len,
+    char **err)
+{
+    BIO             *bio;
+    X509            *x509;
+    u_long           n;
+    STACK_OF(X509)  *chain;
+
+    bio = BIO_new_mem_buf((char *) pem, (int) pem_len);
+    if (bio == NULL) {
+        *err = "BIO_new_mem_buf() failed";
+        ERR_clear_error();
+        return NULL;
+    }
+
+    x509 = PEM_read_bio_X509_AUX(bio, NULL, NULL, NULL);
+    if (x509 == NULL) {
+        *err = "PEM_read_bio_X509_AUX() failed";
+        BIO_free(bio);
+        ERR_clear_error();
+        return NULL;
+    }
+
+    chain = sk_X509_new_null();
+    if (chain == NULL) {
+        *err = "sk_X509_new_null() failed";
+        X509_free(x509);
+        BIO_free(bio);
+        ERR_clear_error();
+        return NULL;
+    }
+
+    if (sk_X509_push(chain, x509) == 0) {
+        *err = "sk_X509_push() failed";
+        sk_X509_free(chain);
+        X509_free(x509);
+        BIO_free(bio);
+        ERR_clear_error();
+        return NULL;
+    }
+
+    /* read rest of the chain */
+
+    for ( ;; ) {
+
+        x509 = PEM_read_bio_X509(bio, NULL, NULL, NULL);
+        if (x509 == NULL) {
+            n = ERR_peek_last_error();
+
+            if (ERR_GET_LIB(n) == ERR_LIB_PEM
+                && ERR_GET_REASON(n) == PEM_R_NO_START_LINE)
+            {
+                /* end of file */
+                ERR_clear_error();
+                break;
+            }
+
+            /* some real error */
+
+            *err = "PEM_read_bio_X509() failed";
+            sk_X509_pop_free(chain, X509_free);
+            BIO_free(bio);
+            ERR_clear_error();
+            return NULL;
+        }
+
+        if (sk_X509_push(chain, x509) == 0) {
+            *err = "sk_X509_push() failed";
+            sk_X509_pop_free(chain, X509_free);
+            X509_free(x509);
+            BIO_free(bio);
+            ERR_clear_error();
+            return NULL;
+        }
+    }
+
+    BIO_free(bio);
+
+    return chain;
+}
+
+
+void
+ngx_http_lua_ffi_free_cert(void *cdata)
+{
+    STACK_OF(X509)  *chain = cdata;
+    sk_X509_pop_free(chain, X509_free);
+}
+
+
+void *
+ngx_http_lua_ffi_parse_pem_priv_key(const u_char *pem, size_t pem_len,
+    char **err)
+{
+    BIO         *in;
+    EVP_PKEY    *pkey;
+
+    in = BIO_new_mem_buf((char *) pem, (int) pem_len);
+    if (in == NULL) {
+        *err = "BIO_new_mem_buf() failed";
+        ERR_clear_error();
+        return NULL;
+    }
+
+    pkey = PEM_read_bio_PrivateKey(in, NULL, NULL, NULL);
+    if (pkey == NULL) {
+        *err = "PEM_read_bio_PrivateKey failed";
+        BIO_free(in);
+        ERR_clear_error();
+        return NULL;
+    }
+
+    BIO_free(in);
+
+    return pkey;
+}
+
+
+void
+ngx_http_lua_ffi_free_priv_key(void *cdata)
+{
+    EVP_PKEY *pkey = cdata;
+    EVP_PKEY_free(pkey);
+}
+
+
+int
+ngx_http_lua_ffi_set_cert(ngx_http_request_t *r,
+    void *cdata, char **err)
+{
+#ifdef LIBRESSL_VERSION_NUMBER
+
+    *err = "LibreSSL not supported";
+    return NGX_ERROR;
+
+#else
+
+#   if OPENSSL_VERSION_NUMBER < 0x1000205fL
+
+    *err = "at least OpenSSL 1.0.2e required but found " OPENSSL_VERSION_TEXT;
+    return NGX_ERROR;
+
+#   else
+
+    int                i;
+    X509              *x509 = NULL;
+    ngx_ssl_conn_t    *ssl_conn;
+    STACK_OF(X509)    *chain = cdata;
+
+    if (r->connection == NULL || r->connection->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = r->connection->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+
+    if (sk_X509_num(chain) < 1) {
+        *err = "invalid certificate chain";
+        goto failed;
+    }
+
+    x509 = sk_X509_value(chain, 0);
+    if (x509 == NULL) {
+        *err = "sk_X509_delete() failed";
+        goto failed;
+    }
+
+    if (SSL_use_certificate(ssl_conn, x509) == 0) {
+        *err = "SSL_use_certificate() failed";
+        goto failed;
+    }
+
+    x509 = NULL;
+
+    /* read rest of the chain */
+
+    for (i = 1; i < sk_X509_num(chain); i++) {
+
+        x509 = sk_X509_value(chain, i);
+        if (x509 == NULL) {
+            *err = "sk_X509_value() failed";
+            goto failed;
+        }
+
+        if (SSL_add1_chain_cert(ssl_conn, x509) == 0) {
+            *err = "SSL_add1_chain_cert() failed";
+            goto failed;
+        }
+    }
+
+    *err = NULL;
+    return NGX_OK;
+
+failed:
+
+    ERR_clear_error();
+
+    return NGX_ERROR;
+
+#   endif  /* OPENSSL_VERSION_NUMBER < 0x1000205fL */
+#endif
+}
+
+
+int
+ngx_http_lua_ffi_set_priv_key(ngx_http_request_t *r,
+    void *cdata, char **err)
+{
+    EVP_PKEY          *pkey = NULL;
+    ngx_ssl_conn_t    *ssl_conn;
+
+    if (r->connection == NULL || r->connection->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = r->connection->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+
+    pkey = cdata;
+    if (pkey == NULL) {
+        *err = "invalid private key failed";
+        goto failed;
+    }
+
+    if (SSL_use_PrivateKey(ssl_conn, pkey) == 0) {
+        *err = "SSL_CTX_use_PrivateKey() failed";
+        goto failed;
+    }
+
+    return NGX_OK;
+
+failed:
+
+    ERR_clear_error();
+
+    return NGX_ERROR;
+}
+
+
 #endif  /* NGX_LUA_NO_FFI_API */
 
 

--- a/t/140-ssl-c-api.t
+++ b/t/140-ssl-c-api.t
@@ -497,3 +497,341 @@ failed to parse PEM priv key: PEM_read_bio_PrivateKey failed
 
 --- no_error_log
 [alert]
+
+
+
+=== TEST 4: simple cert + private key cdata
+--- http_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+
+        ssl_certificate_by_lua_block {
+            collectgarbage()
+
+            local ffi = require "ffi"
+
+            ffi.cdef[[
+                void *ngx_http_lua_ffi_parse_pem_cert(const unsigned char *pem,
+                    size_t pem_len, char **err);
+
+                void *ngx_http_lua_ffi_parse_pem_priv_key(const unsigned char *pem,
+                    size_t pem_len, char **err);
+
+                int ngx_http_lua_ffi_set_cert(void *r,
+                    void *cdata, char **err);
+
+                int ngx_http_lua_ffi_set_priv_key(void *r,
+                    void *cdata, char **err);
+
+                void ngx_http_lua_ffi_free_cert(void *cdata);
+
+                void ngx_http_lua_ffi_free_priv_key(void *cdata);
+
+                int ngx_http_lua_ffi_ssl_clear_certs(void *r, char **err);
+            ]]
+
+            local errmsg = ffi.new("char *[1]")
+
+            local r = getfenv(0).__ngx_req
+            if not r then
+                ngx.log(ngx.ERR, "no request found")
+                return
+            end
+
+            ffi.C.ngx_http_lua_ffi_ssl_clear_certs(r, errmsg)
+
+            local f = assert(io.open("t/cert/test.crt", "rb"))
+            local cert_data = f:read("*all")
+            f:close()
+
+            local cert = ffi.C.ngx_http_lua_ffi_parse_pem_cert(cert_data, #cert_data, errmsg)
+            if not cert then
+                ngx.log(ngx.ERR, "failed to parse PEM cert: ",
+                        ffi.string(errmsg[0]))
+                return
+            end
+
+            local rc = ffi.C.ngx_http_lua_ffi_set_cert(r, cert, errmsg)
+            if rc ~= 0 then
+                ngx.log(ngx.ERR, "failed to set cdata cert: ",
+                        ffi.string(errmsg[0]))
+                return
+            end
+
+            ffi.C.ngx_http_lua_ffi_free_cert(cert)
+
+            f = assert(io.open("t/cert/test.key", "rb"))
+            local pkey_data = f:read("*all")
+            f:close()
+
+            local pkey = ffi.C.ngx_http_lua_ffi_parse_pem_priv_key(pkey_data, #pkey_data, errmsg)
+            if not pkey then
+                ngx.log(ngx.ERR, "failed to parse PEM priv key: ",
+                        ffi.string(errmsg[0]))
+                return
+            end
+
+            local rc = ffi.C.ngx_http_lua_ffi_set_priv_key(r, pkey, errmsg)
+            if rc ~= 0 then
+                ngx.log(ngx.ERR, "failed to set cdata priv key: ",
+                        ffi.string(errmsg[0]))
+                return
+            end
+
+            ffi.C.ngx_http_lua_ffi_free_priv_key(pkey)
+        }
+
+        ssl_certificate ../../cert/test2.crt;
+        ssl_certificate_key ../../cert/test2.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block { ngx.status = 201 ngx.say("foo") ngx.exit(201) }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /foo HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to recieve response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+sent http request: 56 bytes.
+received: HTTP/1.1 201 Created
+received: Server: nginx
+received: Content-Type: text/plain
+received: Content-Length: 4
+received: Connection: close
+received: 
+received: foo
+close: 1 nil
+
+--- error_log
+lua ssl server name: "test.com"
+
+--- no_error_log
+[error]
+[alert]
+
+
+
+=== TEST 5: ECDSA cert + private key cdata
+--- http_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+
+        ssl_certificate_by_lua_block {
+            collectgarbage()
+
+            local ffi = require "ffi"
+
+            ffi.cdef[[
+                void *ngx_http_lua_ffi_parse_pem_cert(const unsigned char *pem,
+                    size_t pem_len, char **err);
+
+                void *ngx_http_lua_ffi_parse_pem_priv_key(const unsigned char *pem,
+                    size_t pem_len, char **err);
+
+                int ngx_http_lua_ffi_set_cert(void *r,
+                    void *cdata, char **err);
+
+                int ngx_http_lua_ffi_set_priv_key(void *r,
+                    void *cdata, char **err);
+
+                void ngx_http_lua_ffi_free_cert(void *cdata);
+
+                void ngx_http_lua_ffi_free_priv_key(void *cdata);
+
+                int ngx_http_lua_ffi_ssl_clear_certs(void *r, char **err);
+            ]]
+
+            local errmsg = ffi.new("char *[1]")
+
+            local r = getfenv(0).__ngx_req
+            if not r then
+                ngx.log(ngx.ERR, "no request found")
+                return
+            end
+
+            ffi.C.ngx_http_lua_ffi_ssl_clear_certs(r, errmsg)
+
+            local f = assert(io.open("t/cert/test_ecdsa.crt", "rb"))
+            local cert_data = f:read("*all")
+            f:close()
+
+            local cert = ffi.C.ngx_http_lua_ffi_parse_pem_cert(cert_data, #cert_data, errmsg)
+            if not cert then
+                ngx.log(ngx.ERR, "failed to parse PEM cert: ",
+                        ffi.string(errmsg[0]))
+                return
+            end
+
+            local rc = ffi.C.ngx_http_lua_ffi_set_cert(r, cert, errmsg)
+            if rc ~= 0 then
+                ngx.log(ngx.ERR, "failed to set cdata cert: ",
+                        ffi.string(errmsg[0]))
+                return
+            end
+
+            ffi.C.ngx_http_lua_ffi_free_cert(cert)
+
+            f = assert(io.open("t/cert/test_ecdsa.key", "rb"))
+            local pkey_data = f:read("*all")
+            f:close()
+
+            local pkey = ffi.C.ngx_http_lua_ffi_parse_pem_priv_key(pkey_data, #pkey_data, errmsg)
+            if not pkey then
+                ngx.log(ngx.ERR, "failed to parse PEM priv key: ",
+                        ffi.string(errmsg[0]))
+                return
+            end
+
+            local rc = ffi.C.ngx_http_lua_ffi_set_priv_key(r, pkey, errmsg)
+            if rc ~= 0 then
+                ngx.log(ngx.ERR, "failed to set cdata priv key: ",
+                        ffi.string(errmsg[0]))
+                return
+            end
+
+            ffi.C.ngx_http_lua_ffi_free_priv_key(pkey)
+        }
+
+        ssl_certificate ../../cert/test2.crt;
+        ssl_certificate_key ../../cert/test2.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block { ngx.status = 201 ngx.say("foo") ngx.exit(201) }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test_ecdsa.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /foo HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to recieve response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+sent http request: 56 bytes.
+received: HTTP/1.1 201 Created
+received: Server: nginx
+received: Content-Type: text/plain
+received: Content-Length: 4
+received: Connection: close
+received: 
+received: foo
+close: 1 nil
+
+--- error_log
+lua ssl server name: "test.com"
+
+--- no_error_log
+[error]
+[alert]


### PR DESCRIPTION
With the current FFI functions the certificate chain and the private key
are parsed from DER every time they are set into the SSL state.

These new functions make it possible to avoid the DER -> OpenSSL parsing.