### PR TITLE
Fix multiple spelling errors

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5657,7 +5657,7 @@ ngx.re.find
 
 **context:** *init_worker_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;*
 
-Similar to [ngx.re.match](#ngxrematch) but only returns the begining index (`from`) and end index (`to`) of the matched substring. The returned indexes are 1-based and can be fed directly into the [string.sub](http://www.lua.org/manual/5.1/manual.html#pdf-string.sub) API function to obtain the matched substring.
+Similar to [ngx.re.match](#ngxrematch) but only returns the beginning index (`from`) and end index (`to`) of the matched substring. The returned indexes are 1-based and can be fed directly into the [string.sub](http://www.lua.org/manual/5.1/manual.html#pdf-string.sub) API function to obtain the matched substring.
 
 In case of errors (like bad regexes or any PCRE runtime errors), this API function returns two `nil` values followed by a string describing the error.
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -4713,7 +4713,7 @@ This feature was introduced in the <code>v0.2.1rc11</code> release.
 
 '''context:''' ''init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*''
 
-Similar to [[#ngx.re.match|ngx.re.match]] but only returns the begining index (<code>from</code>) and end index (<code>to</code>) of the matched substring. The returned indexes are 1-based and can be fed directly into the [http://www.lua.org/manual/5.1/manual.html#pdf-string.sub string.sub] API function to obtain the matched substring.
+Similar to [[#ngx.re.match|ngx.re.match]] but only returns the beginning index (<code>from</code>) and end index (<code>to</code>) of the matched substring. The returned indexes are 1-based and can be fed directly into the [http://www.lua.org/manual/5.1/manual.html#pdf-string.sub string.sub] API function to obtain the matched substring.
 
 In case of errors (like bad regexes or any PCRE runtime errors), this API function returns two <code>nil</code> values followed by a string describing the error.
 

--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -372,7 +372,7 @@ ngx_http_lua_balancer_by_chunk(lua_State *L, ngx_http_request_t *r)
     dd("rc == %d", (int) rc);
 
     if (rc != 0) {
-        /*  error occured when running loaded code */
+        /*  error occurred when running loaded code */
         err_msg = (u_char *) lua_tolstring(L, -1, &len);
 
         if (err_msg == NULL) {

--- a/src/ngx_http_lua_bodyfilterby.c
+++ b/src/ngx_http_lua_bodyfilterby.c
@@ -116,7 +116,7 @@ ngx_http_lua_body_filter_by_chunk(lua_State *L, ngx_http_request_t *r,
 
     if (rc != 0) {
 
-        /*  error occured */
+        /*  error occurred */
         err_msg = (u_char *) lua_tolstring(L, -1, &len);
 
         if (err_msg == NULL) {

--- a/src/ngx_http_lua_cache.c
+++ b/src/ngx_http_lua_cache.c
@@ -166,7 +166,7 @@ ngx_http_lua_cache_loadbuffer(ngx_log_t *log, lua_State *L,
     rc = ngx_http_lua_clfactory_loadbuffer(L, (char *) src, src_len, name);
 
     if (rc != 0) {
-        /*  Oops! error occured when loading Lua script */
+        /*  Oops! error occurred when loading Lua script */
         if (rc == LUA_ERRMEM) {
             err = "memory allocation error";
 
@@ -252,7 +252,7 @@ ngx_http_lua_cache_loadfile(ngx_log_t *log, lua_State *L,
     dd("loadfile returns %d (%d)", (int) rc, LUA_ERRFILE);
 
     if (rc != 0) {
-        /*  Oops! error occured when loading Lua script */
+        /*  Oops! error occurred when loading Lua script */
         switch (rc) {
         case LUA_ERRMEM:
             err = "memory allocation error";

--- a/src/ngx_http_lua_clfactory.c
+++ b/src/ngx_http_lua_clfactory.c
@@ -93,7 +93,7 @@
  * | Char              | Number of upvalues referenced by this function
  * | [nups]            |
  * ---------------------
- * | Char              | Number of paramters of this function
+ * | Char              | Number of parameters of this function
  * | [numparams]       |
  * ---------------------
  * | Char              | Does this function has variable number of arguments?
@@ -177,7 +177,7 @@
  * | Char              | F(ffi) | V(vararg)| C(has internal funcs)
  * | [func flag]       |
  * ---------------------
- * | Char              | Number of paramters of this function
+ * | Char              | Number of parameters of this function
  * | [numparams]       |
  * ---------------------
  * | Char              |
@@ -498,7 +498,7 @@ ngx_http_lua_clfactory_bytecode_prepare(lua_State *L,
                     sizeof(size_t) + sizeof(int) * 2);
         /* number of upvalues */
         *(lf->begin_code.str + POS_NUM_OF_UPVS) = 0;
-        /* number of paramters */
+        /* number of parameters */
         *(lf->begin_code.str + POS_NUM_OF_PARA) = 0;
         /* is var-argument function? */
         *(lf->begin_code.str + POS_IS_VAR_ARG) = 2;

--- a/src/ngx_http_lua_headerfilterby.c
+++ b/src/ngx_http_lua_headerfilterby.c
@@ -112,7 +112,7 @@ ngx_http_lua_header_filter_by_chunk(lua_State *L, ngx_http_request_t *r)
     dd("rc == %d", (int) rc);
 
     if (rc != 0) {
-        /*  error occured when running loaded code */
+        /*  error occurred when running loaded code */
         err_msg = (u_char *) lua_tolstring(L, -1, &len);
 
         if (err_msg == NULL) {

--- a/src/ngx_http_lua_logby.c
+++ b/src/ngx_http_lua_logby.c
@@ -198,7 +198,7 @@ ngx_http_lua_log_by_chunk(lua_State *L, ngx_http_request_t *r)
 #endif
 
         if (rc != 0) {
-            /*  error occured when running loaded code */
+            /*  error occurred when running loaded code */
             err_msg = (u_char *) lua_tolstring(L, -1, &len);
 
             if (err_msg == NULL) {

--- a/src/ngx_http_lua_setby.c
+++ b/src/ngx_http_lua_setby.c
@@ -88,7 +88,7 @@ ngx_http_lua_set_by_chunk(lua_State *L, ngx_http_request_t *r, ngx_str_t *val,
 #endif
 
         if (rc != 0) {
-            /*  error occured when running loaded code */
+            /*  error occurred when running loaded code */
             err_msg = (u_char *) lua_tolstring(L, -1, &len);
 
             if (err_msg == NULL) {

--- a/src/ngx_http_lua_subrequest.c
+++ b/src/ngx_http_lua_subrequest.c
@@ -375,7 +375,7 @@ ngx_http_lua_ngx_location_capture_multi(lua_State *L)
             always_forward_body = lua_toboolean(L, -1);
             lua_pop(L, 1);
 
-            dd("always foward body: %d", always_forward_body);
+            dd("always forward body: %d", always_forward_body);
 
             /* check the "method" option */
 

--- a/t/020-subrequest.t
+++ b/t/020-subrequest.t
@@ -427,7 +427,7 @@ cached: hello
 
 
 
-=== TEST 14: emtpy args option table
+=== TEST 14: empty args option table
 --- config
     location /foo {
         echo $query_string;

--- a/t/023-rewrite/subrequest.t
+++ b/t/023-rewrite/subrequest.t
@@ -409,7 +409,7 @@ cached: hello
 
 
 
-=== TEST 14: emtpy args option table
+=== TEST 14: empty args option table
 --- config
     location /foo {
         echo $query_string;

--- a/t/024-access/subrequest.t
+++ b/t/024-access/subrequest.t
@@ -409,7 +409,7 @@ cached: hello
 
 
 
-=== TEST 14: emtpy args option table
+=== TEST 14: empty args option table
 --- config
     location /foo {
         echo $query_string;

--- a/t/030-uri-args.t
+++ b/t/030-uri-args.t
@@ -276,7 +276,7 @@ done
 
 
 
-=== TEST 10: empty key, but non-emtpy values
+=== TEST 10: empty key, but non-empty values
 --- config
     location /lua {
         content_by_lua '
@@ -818,7 +818,7 @@ lua hit query args limit 2
 
 
 
-=== TEST 36: max args (limited after an empty key, but non-emtpy values)
+=== TEST 36: max args (limited after an empty key, but non-empty values)
 --- config
     location /lua {
         content_by_lua '

--- a/t/031-post-args.t
+++ b/t/031-post-args.t
@@ -152,7 +152,7 @@ lua hit query args limit 2
 
 
 
-=== TEST 6: max args (limited after an empty key, but non-emtpy values)
+=== TEST 6: max args (limited after an empty key, but non-empty values)
 --- config
     location /lua {
         content_by_lua '

--- a/t/129-ssl-socket.t
+++ b/t/129-ssl-socket.t
@@ -86,7 +86,7 @@ __DATA__
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -162,7 +162,7 @@ SSL reused session
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -239,7 +239,7 @@ SSL reused session
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -320,7 +320,7 @@ SSL reused session
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -412,7 +412,7 @@ The certificate for "blah.agentzh.org" does not contain the name "blah.agentzh.o
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -492,7 +492,7 @@ The certificate for "blah.agentzh.org" does not contain the name "blah.agentzh.o
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -569,7 +569,7 @@ SSL reused session
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -650,7 +650,7 @@ SSL reused session
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -734,7 +734,7 @@ SSL reused session
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -813,7 +813,7 @@ SSL reused session
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -902,7 +902,7 @@ SSL reused session
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -995,7 +995,7 @@ SSL reused session
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -1072,7 +1072,7 @@ SSL reused session
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -1156,7 +1156,7 @@ SSL reused session
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -1236,7 +1236,7 @@ SSL reused session
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -1316,7 +1316,7 @@ SSL reused session
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -1396,7 +1396,7 @@ SSL reused session
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -1684,7 +1684,7 @@ attempt to call method 'sslhandshake' (a nil value)
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -1789,7 +1789,7 @@ SSL reused session
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -1893,7 +1893,7 @@ SSL reused session
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -1987,7 +1987,7 @@ SSL reused session
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -2071,7 +2071,7 @@ SSL reused session
 
                 local line, err = sock:receive()
                 if not line then
-                    ngx.say("failed to recieve response status line: ", err)
+                    ngx.say("failed to receive response status line: ", err)
                     return
                 end
 
@@ -2444,7 +2444,7 @@ SSL reused session
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -2549,7 +2549,7 @@ SSL reused session
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 

--- a/t/139-ssl-cert-by.t
+++ b/t/139-ssl-cert-by.t
@@ -82,7 +82,7 @@ __DATA__
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -180,7 +180,7 @@ ssl_certificate_by_lua:1: ssl cert by lua is running!
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -285,7 +285,7 @@ qr/elapsed in ssl cert by lua: 0.(?:09|1[01])\d+,/,
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -403,7 +403,7 @@ my timer run!
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -1108,7 +1108,7 @@ print("ssl cert by lua is running!")
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -1219,7 +1219,7 @@ a.lua:1: ssl cert by lua is running!
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -1343,7 +1343,7 @@ lua ssl server name: "test.com"
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -1439,7 +1439,7 @@ GitHub openresty/lua-resty-core#42
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 

--- a/t/140-ssl-c-api.t
+++ b/t/140-ssl-c-api.t
@@ -157,7 +157,7 @@ __DATA__
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -326,7 +326,7 @@ lua ssl server name: "test.com"
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -461,7 +461,7 @@ lua ssl server name: "test.com"
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 

--- a/t/lib/CRC32.lua
+++ b/t/lib/CRC32.lua
@@ -157,7 +157,7 @@ end
 -- CRC32.lua
 --
 -- A pure Lua implementation of a CRC32 hashing algorithm. Slower than using a C implemtation,
--- but useful having no other dependancies.
+-- but useful having no other dependencies.
 --
 --
 -- Synopsis


### PR DESCRIPTION
While packaging a new version of Nginx for Debian, I noticed the quality assurance tool Lintian complained about a lot of spelling errors.