### PR TITLE
More spelling corrections found via github.com/client9/misspell

### DIFF
--- a/Changes
+++ b/Changes
@@ -19,7 +19,7 @@
 
 * fixed ngx.exit(status) where status >= 200 and status < 300 for access_by_lua* and rewrite_by_lua*: it should quit the whole request altegother and skip all those subsequent phase handlers (if any). thanks moodydeath for reporting it.
 
-* fixed github issue #39: setting differnt response headers in Lua with common prefix might interfere with each other. thanks moodydeath.
+* fixed github issue #39: setting different response headers in Lua with common prefix might interfere with each other. thanks moodydeath.
 
 * fixed GitHub issue #38: request headers did not forward to subrequests when the "method" or "body" option is explicitly specified by a non-nil value for ngx.location.capture(). thanks Richard Kearsley.
 

--- a/README.markdown
+++ b/README.markdown
@@ -7229,7 +7229,7 @@ Here is a simple example:
  }
 ```
 
-One can also create infinite re-occuring timers, for instance, a timer getting triggered every `5` seconds, by calling `ngx.timer.at` recursively in the timer callback function. Here is such an example,
+One can also create infinite re-occurring timers, for instance, a timer getting triggered every `5` seconds, by calling `ngx.timer.at` recursively in the timer callback function. Here is such an example,
 
 ```lua
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -6125,7 +6125,7 @@ Here is a simple example:
     }
 </geshi>
 
-One can also create infinite re-occuring timers, for instance, a timer getting triggered every <code>5</code> seconds, by calling <code>ngx.timer.at</code> recursively in the timer callback function. Here is such an example,
+One can also create infinite re-occurring timers, for instance, a timer getting triggered every <code>5</code> seconds, by calling <code>ngx.timer.at</code> recursively in the timer callback function. Here is such an example,
 
 <geshi lang="lua">
     local delay = 5

--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -128,7 +128,7 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
 
     dd("enter");
 
-    /*  must specifiy a content handler */
+    /*  must specify a content handler */
     if (cmd->post == NULL) {
         return NGX_CONF_ERROR;
     }

--- a/src/ngx_http_lua_clfactory.c
+++ b/src/ngx_http_lua_clfactory.c
@@ -100,7 +100,7 @@
  * | [is_var_arg]      | main function always set to VARARG_ISVARARG (2)
  * ---------------------
  * | Char              | Maximum stack size this function used
- * | [maxstacksize]    | Intially set to 2
+ * | [maxstacksize]    | Initially set to 2
  * ---------------------
  * | Vector(instr)     | Code instructions of this function
  * | [code]            |

--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -459,7 +459,7 @@ ngx_http_lua_rewrite_by_lua(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     return "does not work with " NGINX_VER;
 #endif
 
-    /*  must specifiy a content handler */
+    /*  must specify a content handler */
     if (cmd->post == NULL) {
         return NGX_CONF_ERROR;
     }
@@ -569,7 +569,7 @@ ngx_http_lua_access_by_lua(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     dd("enter");
 
-    /*  must specifiy a content handler */
+    /*  must specify a content handler */
     if (cmd->post == NULL) {
         return NGX_CONF_ERROR;
     }
@@ -681,7 +681,7 @@ ngx_http_lua_content_by_lua(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     dd("enter");
 
-    /*  must specifiy a content handler */
+    /*  must specify a content handler */
     if (cmd->post == NULL) {
         return NGX_CONF_ERROR;
     }
@@ -802,7 +802,7 @@ ngx_http_lua_log_by_lua(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     dd("enter");
 
-    /*  must specifiy a content handler */
+    /*  must specify a content handler */
     if (cmd->post == NULL) {
         return NGX_CONF_ERROR;
     }
@@ -912,7 +912,7 @@ ngx_http_lua_header_filter_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
 
     dd("enter");
 
-    /*  must specifiy a content handler */
+    /*  must specify a content handler */
     if (cmd->post == NULL) {
         return NGX_CONF_ERROR;
     }
@@ -1012,7 +1012,7 @@ ngx_http_lua_body_filter_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
 
     dd("enter");
 
-    /*  must specifiy a content handler */
+    /*  must specify a content handler */
     if (cmd->post == NULL) {
         return NGX_CONF_ERROR;
     }
@@ -1110,7 +1110,7 @@ ngx_http_lua_init_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
 
     dd("enter");
 
-    /*  must specifiy a content handler */
+    /*  must specify a content handler */
     if (cmd->post == NULL) {
         return NGX_CONF_ERROR;
     }
@@ -1177,7 +1177,7 @@ ngx_http_lua_init_worker_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
 
     dd("enter");
 
-    /*  must specifiy a content handler */
+    /*  must specify a content handler */
     if (cmd->post == NULL) {
         return NGX_CONF_ERROR;
     }

--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -4902,7 +4902,7 @@ ngx_http_lua_socket_downstream_destroy(lua_State *L)
 {
     ngx_http_lua_socket_tcp_upstream_t     *u;
 
-    dd("downstream destory");
+    dd("downstream destroy");
 
     u = lua_touserdata(L, 1);
     if (u == NULL) {

--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -120,7 +120,7 @@ ngx_http_lua_ssl_cert_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
     ngx_str_t                   *value;
     ngx_http_lua_srv_conf_t    *lscf = conf;
 
-    /*  must specifiy a concrete handler */
+    /*  must specify a concrete handler */
     if (cmd->post == NULL) {
         return NGX_CONF_ERROR;
     }

--- a/src/ngx_http_lua_timer.c
+++ b/src/ngx_http_lua_timer.c
@@ -603,7 +603,7 @@ ngx_http_lua_abort_pending_timers(ngx_event_t *ev)
 
     cur = ngx_event_timer_rbtree.root;
 
-    /* XXX nginx does not guarentee the parent of root is meaningful,
+    /* XXX nginx does not guarantee the parent of root is meaningful,
      * so we temporarily override it to simplify tree traversal. */
     temp = cur->parent;
     cur->parent = NULL;

--- a/t/009-log.t
+++ b/t/009-log.t
@@ -4,7 +4,7 @@ use Test::Nginx::Socket::Lua;
 
 #worker_connections(1014);
 #master_process_enabled(1);
-log_level('debug'); # to ensure any log-level can be outputed
+log_level('debug'); # to ensure any log-level can be outputted
 
 repeat_each(2);
 

--- a/t/010-request_body.t
+++ b/t/010-request_body.t
@@ -4,7 +4,7 @@ use Test::Nginx::Socket::Lua;
 
 #worker_connections(1014);
 #master_process_enabled(1);
-log_level('debug'); # to ensure any log-level can be outputed
+log_level('debug'); # to ensure any log-level can be outputted
 
 repeat_each(2);
 

--- a/t/016-resp-header.t
+++ b/t/016-resp-header.t
@@ -530,7 +530,7 @@ Hellofoo, baz
 
 
 
-=== TEST 27: get non-existant header
+=== TEST 27: get non-existent header
 --- config
     location /lua {
         content_by_lua '
@@ -546,7 +546,7 @@ nil
 
 
 
-=== TEST 28: get non-existant header
+=== TEST 28: get non-existent header
 --- config
     location /lua {
         content_by_lua '

--- a/t/023-rewrite/request_body.t
+++ b/t/023-rewrite/request_body.t
@@ -3,7 +3,7 @@ use Test::Nginx::Socket::Lua;
 
 #worker_connections(1014);
 #master_process_enabled(1);
-log_level('debug'); # to ensure any log-level can be outputed
+log_level('debug'); # to ensure any log-level can be outputted
 
 repeat_each(2);
 

--- a/t/024-access/request_body.t
+++ b/t/024-access/request_body.t
@@ -3,7 +3,7 @@ use Test::Nginx::Socket::Lua;
 
 #worker_connections(1014);
 #master_process_enabled(1);
-log_level('debug'); # to ensure any log-level can be outputed
+log_level('debug'); # to ensure any log-level can be outputted
 
 repeat_each(2);
 

--- a/t/139-ssl-cert-by.t
+++ b/t/139-ssl-cert-by.t
@@ -1537,7 +1537,7 @@ github issue #723
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 

--- a/util/ngx-links
+++ b/util/ngx-links
@@ -10,7 +10,7 @@ my %opts;
 getopts('f', \%opts) or
     die "Usage: $0 [-f]
 Options:
-    -f          Override exising symbolic links with force
+    -f          Override existing symbolic links with force
 ";
 
 my $root = shift || 'src';


### PR DESCRIPTION
Hello,

First, thanks for your work with lua-nginx-module.   It is fantastic!

I saw the commits in
https://github.com/openresty/lua-nginx-module/commit/cb09230414b688c21efa0fa8c7afa8f4c59518df
by @ottok 

These were automatically found and corrected by github.com/client9/misspell

It code appears to be primarily EN-US, not EN-UK   If you want to standardize on American English, then I can add to the PR the following:

```
find . -name '*' -type 'f' | xargs misspell -locale=US
./t/lib/Memcached.lua:38:4:found "\'SERIALISED\'," a misspelling of "\'SERIALIZED\',"
./t/lib/Memcached.lua:120:15:found "flags.SERIALISED" a misspelling of "flags.SERIALIZED"
./t/lib/Memcached.lua:547:41:found "serialising" a misspelling of "serializing"
./t/lib/Memcached.lua:551:41:found "deserialising" a misspelling of "deserializing"
./README.markdown:468:128:found "minimise" a misspelling of "minimize"
./README.markdown:7147:44:found "cancelling" a misspelling of "canceling"
./doc/HttpLuaModule.wiki:361:129:found "minimise" a misspelling of "minimize"
./doc/HttpLuaModule.wiki:6047:47:found "cancelling" a misspelling of "canceling"
```

regards,

n
