### PR TITLE
use ngx_hash_t to optimize the header look-up for ngx.req.set_header

### DIFF
--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -94,6 +94,9 @@ typedef struct {
 #define NGX_HTTP_LUA_MAX_HEADERS 100
 #endif
 
+#ifndef NGX_HTTP_LUA_BUILTIN_HEADER_LEN_MAX
+#define NGX_HTTP_LUA_BUILTIN_HEADER_LEN_MAX 64
+#endif
 
 /* must be within 16 bit */
 #define NGX_HTTP_LUA_CONTEXT_SET            0x001
@@ -183,6 +186,8 @@ struct ngx_http_lua_main_conf_s {
     ngx_uint_t                      shm_zones_inited;
 
     ngx_http_lua_sema_mm_t         *sema_mm;
+    ngx_hash_t                      headers_in_hash;
+    ngx_uint_t                      headers_in_len_max;
 
     unsigned             requires_header_filter:1;
     unsigned             requires_body_filter:1;

--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -952,6 +952,7 @@ ngx_http_lua_inject_req_header_api(lua_State *L)
 
     lua_pushcfunction(L, ngx_http_lua_ngx_req_header_set);
     lua_setfield(L, -2, "set_header");
+    lua_req_set_header_hash_init();
 
     lua_pushcfunction(L, ngx_http_lua_ngx_req_get_headers);
     lua_setfield(L, -2, "get_headers");

--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -939,7 +939,7 @@ ngx_http_lua_inject_resp_header_api(lua_State *L)
 
 
 void
-ngx_http_lua_inject_req_header_api(lua_State *L)
+ngx_http_lua_inject_req_header_api(lua_State *L, ngx_http_lua_main_conf_t *lmcf)
 {
     lua_pushcfunction(L, ngx_http_lua_ngx_req_http_version);
     lua_setfield(L, -2, "http_version");
@@ -952,7 +952,7 @@ ngx_http_lua_inject_req_header_api(lua_State *L)
 
     lua_pushcfunction(L, ngx_http_lua_ngx_req_header_set);
     lua_setfield(L, -2, "set_header");
-    lua_req_set_header_hash_init();
+    lua_req_set_header_hash_init(lmcf);
 
     lua_pushcfunction(L, ngx_http_lua_ngx_req_get_headers);
     lua_setfield(L, -2, "get_headers");

--- a/src/ngx_http_lua_headers.h
+++ b/src/ngx_http_lua_headers.h
@@ -13,7 +13,8 @@
 
 
 void ngx_http_lua_inject_resp_header_api(lua_State *L);
-void ngx_http_lua_inject_req_header_api(lua_State *L);
+void ngx_http_lua_inject_req_header_api(lua_State *L,
+    ngx_http_lua_main_conf_t *lmcf);
 void ngx_http_lua_create_headers_metatable(ngx_log_t *log, lua_State *L);
 
 

--- a/src/ngx_http_lua_headers_in.c
+++ b/src/ngx_http_lua_headers_in.c
@@ -645,16 +645,14 @@ ngx_http_clear_builtin_header(ngx_http_request_t *r,
 }
 
 
-static ngx_hash_init_t  lua_req_header_hash;
-static u_char           header_string[512];
-
-
-ngx_int_t lua_req_set_header_hash_init(void)
+ngx_int_t lua_req_set_header_hash_init(ngx_http_lua_main_conf_t *lmcf)
 {
     ngx_int_t                   rc;
     ngx_uint_t                  i;
     ngx_uint_t                  pos = 0;
-    ngx_uint_t                  key_max_len = 0;
+    ngx_uint_t                  key_len_max = 0;
+    ngx_hash_init_t             lua_req_header_hash;
+    u_char                      header_string[512];
     ngx_str_t                   tmp_key = {0, &header_string[0]};
     ngx_hash_keys_arrays_t      ha;
     ngx_http_lua_set_header_t  *handlers = ngx_http_lua_set_handlers;
@@ -671,38 +669,43 @@ ngx_int_t lua_req_set_header_hash_init(void)
         goto failed;
     }
 
-    if (ngx_hash_keys_array_init(&ha, 50) != NGX_OK) {
+    i = sizeof(ngx_http_lua_set_handlers) / sizeof(ngx_http_lua_set_header_t);
+    if (ngx_hash_keys_array_init(&ha, i) != NGX_OK) {
         goto failed;
     }
 
     for (i = 0; handlers[i].name.len; i++) {
         tmp_key.len = handlers[i].name.len;
-        if (tmp_key.len > key_max_len) {
-            key_max_len = tmp_key.len;
+        if (tmp_key.len > key_len_max) {
+            key_len_max = tmp_key.len;
         }
         if (pos + tmp_key.len + 1 >= sizeof(header_string)) {
             goto failed;
         }
         tmp_key.data = &header_string[pos];
-        strncpy((char *)tmp_key.data, (char *)handlers[i].name.data,
-                tmp_key.len + 1);
+        ngx_memcpy(tmp_key.data, handlers[i].name.data, tmp_key.len + 1);
         pos += tmp_key.len + 1;
 
         rc = ngx_hash_add_key(&ha, &tmp_key, (void *)(i + 1), 0);
         if (rc == NGX_ERROR) {
-            return NGX_ERROR;
+            goto failed;
         }
     }
 
+    if (key_len_max > NGX_HTTP_LUA_BUILTIN_HEADER_LEN_MAX) {
+        goto failed;
+    }
+    lmcf->headers_in_len_max = key_len_max;
+
     lua_req_header_hash.key = ngx_hash_key_lc;
     lua_req_header_hash.max_size = 512;
-    i = ngx_align((key_max_len + 3 * sizeof(void *)), sizeof(void *));
+    i = ngx_align((key_len_max + 3 * sizeof(void *)), sizeof(void *));
     lua_req_header_hash.bucket_size = i;
     lua_req_header_hash.name = "req_set_header_hash";
     lua_req_header_hash.pool = ha.pool;
 
     if (ha.keys.nelts) {
-        lua_req_header_hash.hash = NULL;
+        lua_req_header_hash.hash = &lmcf->headers_in_hash;
         lua_req_header_hash.temp_pool = NULL;
 
         rc = ngx_hash_init(&lua_req_header_hash, ha.keys.elts, ha.keys.nelts);
@@ -711,6 +714,7 @@ ngx_int_t lua_req_set_header_hash_init(void)
         }
     }
 
+    ngx_destroy_pool(ha.temp_pool);
     return NGX_OK;
 
 failed:
@@ -727,13 +731,13 @@ ngx_int_t
 ngx_http_lua_set_input_header(ngx_http_request_t *r, ngx_str_t key,
     ngx_str_t value, unsigned override)
 {
-#define HTTP_BUILDIN_HEADER_MAX_LEN 64
     ngx_http_lua_header_val_t         hv;
     ngx_http_lua_set_header_t        *handlers = ngx_http_lua_set_handlers;
 
     ngx_uint_t                        i;
-    u_char                            uc[HTTP_BUILDIN_HEADER_MAX_LEN];
+    u_char                            uc[NGX_HTTP_LUA_BUILTIN_HEADER_LEN_MAX];
     void                             *v;
+    ngx_http_lua_main_conf_t         *lmcf;
 
     dd("set header value: %.*s", (int) value.len, value.data);
 
@@ -777,13 +781,14 @@ ngx_http_lua_set_input_header(ngx_http_request_t *r, ngx_str_t key,
 
 #endif
 
-    /*split to 2 lines for style check*/
+    /* split to 2 lines for style check */
     i = sizeof(ngx_http_lua_set_handlers) / sizeof(ngx_http_lua_set_header_t);
-    i -= 1;
+    i --;
 
-    if (key.len < HTTP_BUILDIN_HEADER_MAX_LEN) {
+    lmcf = ngx_http_cycle_get_module_main_conf(ngx_cycle, ngx_http_lua_module);
+    if (key.len <= lmcf->headers_in_len_max) {
         ngx_strlow(&uc[0], key.data, key.len);
-        v = ngx_hash_find(lua_req_header_hash.hash, hv.hash, &uc[0], key.len);
+        v = ngx_hash_find(&lmcf->headers_in_hash, hv.hash, &uc[0], key.len);
         if (v != NULL) {
             i = (ngx_uint_t) v - 1;
         }

--- a/src/ngx_http_lua_headers_in.c
+++ b/src/ngx_http_lua_headers_in.c
@@ -694,8 +694,8 @@ lua_req_set_header_hash_init(void)
     }
 
     lua_req_header_hash.key = ngx_hash_key_lc;
-    lua_req_header_hash.max_size = 100;
-    lua_req_header_hash.bucket_size = key_max_len + 3 * sizeof(void *);
+    lua_req_header_hash.max_size = 512;
+    lua_req_header_hash.bucket_size = ngx_align((key_max_len + 3 * sizeof(void *)), sizeof(void *));
     lua_req_header_hash.name = "req_set_header_hash";
     lua_req_header_hash.pool = ha.pool;
 

--- a/src/ngx_http_lua_headers_in.h
+++ b/src/ngx_http_lua_headers_in.h
@@ -16,6 +16,7 @@
 ngx_int_t ngx_http_lua_set_input_header(ngx_http_request_t *r, ngx_str_t key,
     ngx_str_t value, unsigned override);
 
+ngx_int_t lua_req_set_header_hash_init(void);
 
 #endif /* _NGX_HTTP_LUA_HEADERS_IN_H_INCLUDED_ */
 

--- a/src/ngx_http_lua_headers_in.h
+++ b/src/ngx_http_lua_headers_in.h
@@ -16,7 +16,7 @@
 ngx_int_t ngx_http_lua_set_input_header(ngx_http_request_t *r, ngx_str_t key,
     ngx_str_t value, unsigned override);
 
-ngx_int_t lua_req_set_header_hash_init(void);
+ngx_int_t lua_req_set_header_hash_init(ngx_http_lua_main_conf_t *lmcf);
 
 #endif /* _NGX_HTTP_LUA_HEADERS_IN_H_INCLUDED_ */
 

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -742,7 +742,7 @@ ngx_http_lua_inject_ngx_api(lua_State *L, ngx_http_lua_main_conf_t *lmcf,
     ngx_http_lua_inject_regex_api(L);
 #endif
 
-    ngx_http_lua_inject_req_api(log, L);
+    ngx_http_lua_inject_req_api(log, L, lmcf);
     ngx_http_lua_inject_resp_header_api(L);
     ngx_http_lua_create_headers_metatable(log, L);
     ngx_http_lua_inject_variable_api(L);
@@ -2090,13 +2090,14 @@ done:
 
 
 void
-ngx_http_lua_inject_req_api(ngx_log_t *log, lua_State *L)
+ngx_http_lua_inject_req_api(ngx_log_t *log, lua_State *L,
+    ngx_http_lua_main_conf_t *lmcf)
 {
     /* ngx.req table */
 
     lua_createtable(L, 0 /* narr */, 24 /* nrec */);    /* .req */
 
-    ngx_http_lua_inject_req_header_api(L);
+    ngx_http_lua_inject_req_header_api(L, lmcf);
     ngx_http_lua_inject_req_uri_api(log, L);
     ngx_http_lua_inject_req_args_api(L);
     ngx_http_lua_inject_req_body_api(L);

--- a/src/ngx_http_lua_util.h
+++ b/src/ngx_http_lua_util.h
@@ -179,7 +179,8 @@ void ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
 uintptr_t ngx_http_lua_escape_uri(u_char *dst, u_char *src,
     size_t size, ngx_uint_t type);
 
-void ngx_http_lua_inject_req_api(ngx_log_t *log, lua_State *L);
+void ngx_http_lua_inject_req_api(ngx_log_t *log, lua_State *L,
+    ngx_http_lua_main_conf_t *lmcf);
 
 void ngx_http_lua_process_args_option(ngx_http_request_t *r,
     lua_State *L, int table, ngx_str_t *args);


### PR DESCRIPTION
use ngx_hash_t to optimize the header look-up for ngx.req.set_header and clear_header, if this is ok, i will port it to "ngx.header.HEADER"

I have run the testsuite like this:
ps: the dav_methods error is not caused by this commit.

rako@t450s:~/gitroot/rako9000/lua-nginx-module$ prove -I/opt/openresty/test-nginx/lib  t/028-req-header.t 
t/028-req-header.t .. 145/256 nginx: [emerg] unknown directive "dav_methods" in /home/rako/gitroot/rako9000/lua-nginx-module/t/servroot/conf/nginx.conf:43
Bailout called.  Further testing stopped:  TEST 49: set the Destination request header for WebDav - Cannot start nginx using command "nginx -p /home/rako/gitroot/rako9000/lua-nginx-module/t/servroot/ -c /home/rako/gitroot/rako9000/lua-nginx-module/t/servroot/conf/nginx.conf > /dev/null" (status code 256).
FAILED--Further testing stopped: TEST 49: set the Destination request header for WebDav - Cannot start nginx using command "nginx -p /home/rako/gitroot/rako9000/lua-nginx-module/t/servroot/ -c /home/rako/gitroot/rako9000/lua-nginx-module/t/servroot/conf/nginx.conf > /dev/null" (status code 256).
rako@t450s:~/gitroot/rako9000/lua-nginx-module$ prove -I/opt/openresty/test-nginx/lib  t/111-req-header-ua.t 
t/111-req-header-ua.t .. ok  
All tests successful.
Files=1, Tests=144,  3 wallclock secs ( 0.04 usr  0.00 sys +  0.19 cusr  0.06 csys =  0.29 CPU)
Result: PASS
rako@t450s:~/gitroot/rako9000/lua-nginx-module$ prove -I/opt/openresty/test-nginx/lib  t/112-req-header-conn.t 
t/112-req-header-conn.t .. ok  
All tests successful.
Files=1, Tests=32,  1 wallclock secs ( 0.02 usr  0.00 sys +  0.12 cusr  0.02 csys =  0.16 CPU)
Result: PASS
rako@t450s:~/gitroot/rako9000/lua-nginx-module$ prove -I/opt/openresty/test-nginx/lib  t/113-req-header-cookie.t 
t/113-req-header-cookie.t .. ok  
All tests successful.
Files=1, Tests=48,  1 wallclock secs ( 0.03 usr  0.00 sys +  0.12 cusr  0.03 csys =  0.18 CPU)
Result: PASS
