### PR TITLE
bugfix: set peer.tries to next_upstream_tries when balanced by lua

### DIFF
--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -237,6 +237,10 @@ ngx_http_lua_balancer_init_peer(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
+#if (nginx_version >= 1007005)
+    r->upstream->peer.tries = r->upstream->conf->next_upstream_tries;
+#endif
+
     r->upstream->peer.get = ngx_http_lua_balancer_get_peer;
     r->upstream->peer.free = ngx_http_lua_balancer_free_peer;
 


### PR DESCRIPTION
Set peer.tries to next_upstream_tries when balanced by lua, otherwise, peer.tries will be the number of servers in the upstream block, which may always be 1 if we have the following example configuration:
```
upstream backend {
        server 0.0.0.1;   # just an invalid address as a place holder

        balancer_by_lua_block {
            local balancer = require "ngx.balancer"

            -- well, usually we calculate the peer's host and port
            -- according to some balancing policies instead of using
            -- hard-coded values like below
            local host = "127.0.0.2"
            local port = 8080

            local ok, err = balancer.set_current_peer(host, port)
            if not ok then
                ngx.log(ngx.ERR, "failed to set the current peer: ", err)
                return ngx.exit(500)
            end
        }

        keepalive 10;  # connection pool
    }
```
If so, directives like `proxy_next_upstream_tries 2;` will not work.
