### PR TITLE
doc: ngx.worker.count() is available in init_worker_by_lua context

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7565,7 +7565,7 @@ ngx.worker.count
 
 **syntax:** *count = ngx.worker.count()*
 
-**context:** *set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, init_by_lua&#42;*
+**context:** *set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, init_by_lua&#42;, init_worker_by_lua&#42;*
 
 Returns the total number of the Nginx worker processes (i.e., the value configured
 by the [worker_processes](http://nginx.org/en/docs/ngx_core_module.html#worker_processes)

--- a/t/133-worker-count.t
+++ b/t/133-worker-count.t
@@ -50,3 +50,23 @@ GET /lua
 workers: 1
 --- no_error_log
 [error]
+
+
+
+=== TEST 3: init_worker_by_lua
+--- http_config
+    init_worker_by_lua_block {
+        init_worker_count = ngx.worker.count()
+    }
+--- config
+    location /lua {
+        content_by_lua_block {
+            ngx.say("workers: ", init_worker_count)
+        }
+    }
+--- request
+GET /lua
+--- response_body
+workers: 1
+--- no_error_log
+[error]


### PR DESCRIPTION
The `ngx.worker.count` documentation was missing `init_worker_by_lua` as a valid context. This updates the documentation and adds a test to demonstrate that this method does in fact work in the `init_worker_by_lua` context.