### PR TITLE
bugfix:avoid the package.preload module not found while code cache off

### DIFF
--- a/src/ngx_http_lua_api.c
+++ b/src/ngx_http_lua_api.c
@@ -47,12 +47,11 @@ ngx_http_lua_add_package_preload(ngx_conf_t *cf, const char *package,
         lua_pushcfunction(L, func);
         lua_setfield(L, -2, package);
         lua_pop(L, 2);
-
-        return NGX_OK;
     }
 
     /* L == NULL */
 
+    /* still store for a new vm init */
     if (lmcf->preload_hooks == NULL) {
         lmcf->preload_hooks =
             ngx_array_create(cf->pool, 4,


### PR DESCRIPTION
I've got a tiny bug in  ngx_http_lua_new_state : in [https://github.com/rainingmaster/lua-nginx-module/blob/master/src/ngx_http_lua_util.c#L218](url) , there is not copy the packge.preload from parent_vm to the new one.

My nginx.conf:
`...
lua_code_cache off;
...`

My ngx_modules.c(ngx_http_lua_upstream_module behind ngx_http_lua_module)
`
&ngx_http_lua_module, 
&ngx_http_lua_upstream_module,
`

My code.lua
`local upstream = require "ngx.upstream"`

And it will report the 

> error：lua entry thread aborted: runtime error: code.lua:1: module 'ngx.upstream' not found:

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
