### PR TITLE
Add support for 303 in ngx.redirect()

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4999,6 +4999,7 @@ The optional `status` parameter specifies the HTTP status code to be used. The f
 
 * `301`
 * `302` (default)
+* `303`
 * `307`
 
 It is `302` (`ngx.HTTP_MOVED_TEMPORARILY`) by default.

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -4164,6 +4164,7 @@ The optional <code>status</code> parameter specifies the HTTP status code to be 
 
 * <code>301</code>
 * <code>302</code> (default)
+* <code>303</code>
 * <code>307</code>
 
 It is <code>302</code> (<code>ngx.HTTP_MOVED_TEMPORARILY</code>) by default.

--- a/src/ngx_http_lua_control.c
+++ b/src/ngx_http_lua_control.c
@@ -212,10 +212,12 @@ ngx_http_lua_ngx_redirect(lua_State *L)
 
         if (rc != NGX_HTTP_MOVED_TEMPORARILY
             && rc != NGX_HTTP_MOVED_PERMANENTLY
+            && rc != NGX_HTTP_SEE_OTHER
             && rc != NGX_HTTP_TEMPORARY_REDIRECT)
         {
             return luaL_error(L, "only ngx.HTTP_MOVED_TEMPORARILY, "
-                              "ngx.HTTP_MOVED_PERMANENTLY, and "
+                              "ngx.HTTP_MOVED_PERMANENTLY, "
+                              "ngx.HTTP_SEE_OTHER, and "
                               "ngx.HTTP_TEMPORARY_REDIRECT are allowed");
         }
 

--- a/t/022-redirect.t
+++ b/t/022-redirect.t
@@ -224,10 +224,10 @@ Location: http://agentzh.org/foo?a=b&c=d
 === TEST 12: explicit 303
 --- config
     location /read {
-        content_by_lua '
+        content_by_lua_block {
             ngx.redirect("http://agentzh.org/foo", ngx.HTTP_SEE_OTHER);
             ngx.say("hi")
-        ';
+        }
     }
 --- request
 GET /read
@@ -241,10 +241,10 @@ Location: http://agentzh.org/foo
 === TEST 13: explicit 303 with args
 --- config
     location /read {
-        content_by_lua '
+        content_by_lua_block {
             ngx.redirect("http://agentzh.org/foo?a=b&c=d", ngx.HTTP_SEE_OTHER);
             ngx.say("hi")
-        ';
+        }
     }
 --- request
 GET /read
@@ -258,10 +258,10 @@ Location: http://agentzh.org/foo?a=b&c=d
 === TEST 14: explicit 303
 --- config
     location /read {
-        content_by_lua '
+        content_by_lua_block {
             ngx.redirect("http://agentzh.org/foo?a=b&c=d", 303);
             ngx.say("hi")
-        ';
+        }
     }
 --- request
 GET /read

--- a/t/022-redirect.t
+++ b/t/022-redirect.t
@@ -84,7 +84,7 @@ GET /read
 --- response_body_like: 500 Internal Server Error
 --- error_code: 500
 --- error_log
-only ngx.HTTP_MOVED_TEMPORARILY, ngx.HTTP_MOVED_PERMANENTLY, and ngx.HTTP_TEMPORARY_REDIRECT are allowed
+only ngx.HTTP_MOVED_TEMPORARILY, ngx.HTTP_MOVED_PERMANENTLY, ngx.HTTP_SEE_OTHER, and ngx.HTTP_TEMPORARY_REDIRECT are allowed
 
 
 
@@ -218,3 +218,54 @@ GET /read
 Location: http://agentzh.org/foo?a=b&c=d
 --- response_body_like: 307 Temporary Redirect
 --- error_code: 307
+
+
+
+=== TEST 12: explicit 303
+--- config
+    location /read {
+        content_by_lua '
+            ngx.redirect("http://agentzh.org/foo", ngx.HTTP_SEE_OTHER);
+            ngx.say("hi")
+        ';
+    }
+--- request
+GET /read
+--- response_headers
+Location: http://agentzh.org/foo
+--- response_body_like: 303 See Other
+--- error_code: 303
+
+
+
+=== TEST 13: explicit 303 with args
+--- config
+    location /read {
+        content_by_lua '
+            ngx.redirect("http://agentzh.org/foo?a=b&c=d", ngx.HTTP_SEE_OTHER);
+            ngx.say("hi")
+        ';
+    }
+--- request
+GET /read
+--- response_headers
+Location: http://agentzh.org/foo?a=b&c=d
+--- response_body_like: 303 See Other
+--- error_code: 303
+
+
+
+=== TEST 14: explicit 303
+--- config
+    location /read {
+        content_by_lua '
+            ngx.redirect("http://agentzh.org/foo?a=b&c=d", 303);
+            ngx.say("hi")
+        ';
+    }
+--- request
+GET /read
+--- response_headers
+Location: http://agentzh.org/foo?a=b&c=d
+--- response_body_like: 303 See Other
+--- error_code: 303


### PR DESCRIPTION
ngx.redirect() is missing [303 See Other](https://httpstatuses.com/303) support which this PR adds. This PR also adds the appropriate test case. It makes no other changes. This PR is based on #416 and 932584be2278ca3f5ca577afebb44c2ef9da9f85.

I hereby granted the copyright of the changes in this pull request to the authors of this lua-nginx-module project.
