### PR TITLE
bypass next_upstream_tries check when its value is 0

### DIFF
--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -682,7 +682,7 @@ ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
 #if (nginx_version >= 1007005)
     max_tries = r->upstream->conf->next_upstream_tries;
 
-    if (bp->total_tries + count > max_tries) {
+    if (max_tries && bp->total_tries + count > max_tries) {
         count = max_tries - bp->total_tries;
         *err = "reduced tries due to limit";
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

When the value of next_upstream_tries is 0, it means the limitation is turned off, then no need to check it.
