### PR TITLE
[bugfix] Retry count would exceed the limit of proxy_next_upstream_tries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,8 +107,8 @@ script:
   - cd ..
   - tar zxf download-cache/openssl-$OPENSSL_VER.tar.gz
   - cd openssl-$OPENSSL_VER/
-  - wget https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-1.0.2h-sess_set_get_cb_yield.patch
-  - patch -p1 < openssl-1.0.2h-sess_set_get_cb_yield.patch
+  - if [ ! -f ../download-cache/openssl-1.0.2h-sess_set_get_cb_yield.patch ]; then wget -O ../download-cache/openssl-1.0.2h-sess_set_get_cb_yield.patch https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-1.0.2h-sess_set_get_cb_yield.patch; fi
+  - patch -p1 < ../download-cache/openssl-1.0.2h-sess_set_get_cb_yield.patch
   - ./config shared --prefix=$OPENSSL_PREFIX -DPURIFY > build.log 2>&1 || (cat build.log && exit 1)
   - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make PATH=$PATH install_sw > build.log 2>&1 || (cat build.log && exit 1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ env:
     - TEST_NGINX_SLEEP=0.006
   matrix:
     - NGINX_VERSION=1.9.15
-#    - NGINX_VERSION=1.10.0
+    - NGINX_VERSION=1.11.2
 
 services:
  - memcache

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
     - OPENSSL_PREFIX=/opt/ssl
     - OPENSSL_LIB=$OPENSSL_PREFIX/lib
     - OPENSSL_INC=$OPENSSL_PREFIX/include
-    - OPENSSL_VER=1.0.2i
+    - OPENSSL_VER=1.0.2j
     - LIBDRIZZLE_PREFIX=/opt/drizzle
     - LIBDRIZZLE_INC=$LIBDRIZZLE_PREFIX/include/libdrizzle-1.0
     - LIBDRIZZLE_LIB=$LIBDRIZZLE_PREFIX/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
     - OPENSSL_PREFIX=/opt/ssl
     - OPENSSL_LIB=$OPENSSL_PREFIX/lib
     - OPENSSL_INC=$OPENSSL_PREFIX/include
-    - OPENSSL_VER=1.0.2h
+    - OPENSSL_VER=1.0.2i
     - LIBDRIZZLE_PREFIX=/opt/drizzle
     - LIBDRIZZLE_INC=$LIBDRIZZLE_PREFIX/include/libdrizzle-1.0
     - LIBDRIZZLE_LIB=$LIBDRIZZLE_PREFIX/lib
@@ -107,8 +107,8 @@ script:
   - cd ..
   - tar zxf download-cache/openssl-$OPENSSL_VER.tar.gz
   - cd openssl-$OPENSSL_VER/
-  - wget https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-$OPENSSL_VER-sess_set_get_cb_yield.patch
-  - patch -p1 < openssl-$OPENSSL_VER-sess_set_get_cb_yield.patch
+  - wget https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-1.0.2h-sess_set_get_cb_yield.patch
+  - patch -p1 < openssl-1.0.2h-sess_set_get_cb_yield.patch
   - ./config shared --prefix=$OPENSSL_PREFIX -DPURIFY > build.log 2>&1 || (cat build.log && exit 1)
   - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make PATH=$PATH install_sw > build.log 2>&1 || (cat build.log && exit 1)

--- a/README.markdown
+++ b/README.markdown
@@ -62,7 +62,7 @@ Production ready.
 Version
 =======
 
-This document describes ngx_lua [v0.10.6](https://github.com/openresty/lua-nginx-module/tags) released on 15 August 2016.
+This document describes ngx_lua [v0.10.7](https://github.com/openresty/lua-nginx-module/tags) released on 4 November 2016.
 
 Synopsis
 ========

--- a/README.markdown
+++ b/README.markdown
@@ -1176,6 +1176,8 @@ The default number of entries allowed is 1024 and when this limit is reached, ne
     2011/08/27 23:18:26 [warn] 31997#0: *1 lua exceeding regex cache max entries (1024), ...
 
 
+If you are using the `ngx.re.*` implementation of [lua-resty-core](https://github.com/openresty/lua-resty-core) by loading the `resty.core.regex` module (or just the `resty.core` module), then an LRU cache is used for the regex cache being used here.
+
 Do not activate the `o` option for regular expressions (and/or `replace` string arguments for [ngx.re.sub](#ngxresub) and [ngx.re.gsub](#ngxregsub)) that are generated *on the fly* and give rise to infinite variations to avoid hitting the specified limit.
 
 [Back to TOC](#directives)

--- a/README.markdown
+++ b/README.markdown
@@ -3394,7 +3394,7 @@ HTTP status constants
 
 Nginx log level constants
 -------------------------
-**context:** *set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;*
+**context:** *init_by_lua&#42;, init_worker_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;*
 
 ```lua
 

--- a/README.markdown
+++ b/README.markdown
@@ -2485,7 +2485,7 @@ ssl_session_fetch_by_lua_block
 
 **syntax:** *ssl_session_fetch_by_lua_block { lua-script }*
 
-**context:** *server*
+**context:** *http*
 
 **phase:** *right-before-SSL-handshake*
 
@@ -2541,6 +2541,9 @@ apply the following patch to the standard NGINX core 1.11.2 or later:
 
 This directive was first introduced in the `v0.10.6` release.
 
+Note that: this directive is only allowed to used in **http context** from the `v0.10.7` release
+(because SSL session resumption happens before server name dispatch).
+
 [Back to TOC](#directives)
 
 ssl_session_fetch_by_lua_file
@@ -2548,7 +2551,7 @@ ssl_session_fetch_by_lua_file
 
 **syntax:** *ssl_session_fetch_by_lua_file &lt;path-to-lua-script-file&gt;*
 
-**context:** *server*
+**context:** *http*
 
 **phase:** *right-before-SSL-handshake*
 
@@ -2558,6 +2561,9 @@ When a relative path like `foo/bar.lua` is given, they will be turned into the a
 
 This directive was first introduced in the `v0.10.6` release.
 
+Note that: this directive is only allowed to used in **http context** from the `v0.10.7` release
+(because SSL session resumption happens before server name dispatch).
+
 [Back to TOC](#directives)
 
 ssl_session_store_by_lua_block
@@ -2565,7 +2571,7 @@ ssl_session_store_by_lua_block
 
 **syntax:** *ssl_session_store_by_lua_block { lua-script }*
 
-**context:** *server*
+**context:** *http*
 
 **phase:** *right-after-SSL-handshake*
 
@@ -2592,6 +2598,9 @@ But do not forget to comment this line out before publishing your site to the wo
 
 This directive was first introduced in the `v0.10.6` release.
 
+Note that: this directive is only allowed to used in **http context** from the `v0.10.7` release
+(because SSL session resumption happens before server name dispatch).
+
 [Back to TOC](#directives)
 
 ssl_session_store_by_lua_file
@@ -2599,7 +2608,7 @@ ssl_session_store_by_lua_file
 
 **syntax:** *ssl_session_store_by_lua_file &lt;path-to-lua-script-file&gt;*
 
-**context:** *server*
+**context:** *http*
 
 **phase:** *right-before-SSL-handshake*
 
@@ -2608,6 +2617,9 @@ Equivalent to [ssl_session_store_by_lua_block](#ssl_session_store_by_lua_block),
 When a relative path like `foo/bar.lua` is given, they will be turned into the absolute path relative to the `server prefix` path determined by the `-p PATH` command-line option while starting the Nginx server.
 
 This directive was first introduced in the `v0.10.6` release.
+
+Note that: this directive is only allowed to used in **http context** from the `v0.10.7` release
+(because SSL session resumption happens before server name dispatch).
 
 [Back to TOC](#directives)
 

--- a/README.markdown
+++ b/README.markdown
@@ -4995,8 +4995,13 @@ ngx.redirect
 
 Issue an `HTTP 301` or `302` redirection to `uri`.
 
-The optional `status` parameter specifies whether
-`301` or `302` to be used. It is `302` (`ngx.HTTP_MOVED_TEMPORARILY`) by default.
+The optional `status` parameter specifies the HTTP status code to be used. The following status codes are supported right now:
+
+* `301`
+* `302` (default)
+* `307`
+
+It is `302` (`ngx.HTTP_MOVED_TEMPORARILY`) by default.
 
 Here is an example assuming the current server name is `localhost` and that it is listening on port 1984:
 

--- a/README.markdown
+++ b/README.markdown
@@ -1002,6 +1002,7 @@ Directives
 ==========
 
 * [lua_use_default_type](#lua_use_default_type)
+* [lua_malloc_trim](#lua_malloc_trim)
 * [lua_code_cache](#lua_code_cache)
 * [lua_regex_cache_max_entries](#lua_regex_cache_max_entries)
 * [lua_regex_match_limit](#lua_regex_match_limit)
@@ -1086,6 +1087,31 @@ Specifies whether to use the MIME type specified by the [default_type](http://ng
 This directive is turned on by default.
 
 This directive was first introduced in the `v0.9.1` release.
+
+[Back to TOC](#directives)
+
+lua_malloc_trim
+---------------
+**syntax:** *lua_malloc_trim &lt;request-count&gt;*
+
+**default:** *lua_malloc_trim 1000*
+
+**context:** *http*
+
+Asks the underlying `libc` runtime library to release its cached free memory back to the operating system every
+`N` requests processed by the NGINX core. By default, `N` is 1000. You can configure the request count
+by using your own numbers. Smaller numbers mean more frequent releases, which may introduce higher CPU time consumption and
+smaller memory footprint while larger numbers usually lead to less CPU time overhead and relatively larger memory footprint.
+Just tune the number for your own use cases.
+
+Configuring the argument to `0` essentially turns off the periodical memory trimming altogether.
+
+The current implementation uses an NGINX log phase handler to do the request counting. So the appearance of the
+[log_subrequest on](http://nginx.org/en/docs/http/ngx_http_core_module.html#log_subrequest) directives in `nginx.conf`
+may make the counting faster when subrequests are involved. By default, only "main requests" count.
+
+Note that this directive does *not* affect the memory allocated by LuaJIT's own allocator based on the `mmap`
+system call.
 
 [Back to TOC](#directives)
 

--- a/README.markdown
+++ b/README.markdown
@@ -7047,7 +7047,7 @@ You are recommended to use [settimeouts](#tcpsocksettimeouts) instead of [settim
 
 Note that this method does *not* affect the [lua_socket_keepalive_timeout](#lua_socket_keepalive_timeout) setting; the `timeout` argument to the [setkeepalive](#tcpsocksetkeepalive) method should be used for this purpose instead.
 
-This feature was first introduced in the `vXXX` release.
+This feature was first introduced in the `v0.10.7` release.
 
 [Back to TOC](#nginx-api-for-lua)
 

--- a/README.markdown
+++ b/README.markdown
@@ -2654,7 +2654,7 @@ lua_socket_connect_timeout
 
 **context:** *http, server, location*
 
-This directive controls the default timeout value used in TCP/unix-domain socket object's [connect](#tcpsockconnect) method and can be overridden by the [settimeout](#tcpsocksettimeout) method.
+This directive controls the default timeout value used in TCP/unix-domain socket object's [connect](#tcpsockconnect) method and can be overridden by the [settimeout](#tcpsocksettimeout) or [settimeouts](#tcpsocksettimeouts) methods.
 
 The `<time>` argument can be an integer, with an optional time unit, like `s` (second), `ms` (millisecond), `m` (minute). The default time unit is `s`, i.e., "second". The default setting is `60s`.
 
@@ -2671,7 +2671,7 @@ lua_socket_send_timeout
 
 **context:** *http, server, location*
 
-Controls the default timeout value used in TCP/unix-domain socket object's [send](#tcpsocksend) method and can be overridden by the [settimeout](#tcpsocksettimeout) method.
+Controls the default timeout value used in TCP/unix-domain socket object's [send](#tcpsocksend) method and can be overridden by the [settimeout](#tcpsocksettimeout) or [settimeouts](#tcpsocksettimeouts) methods.
 
 The `<time>` argument can be an integer, with an optional time unit, like `s` (second), `ms` (millisecond), `m` (minute). The default time unit is `s`, i.e., "second". The default setting is `60s`.
 
@@ -2703,7 +2703,7 @@ lua_socket_read_timeout
 
 **phase:** *depends on usage*
 
-This directive controls the default timeout value used in TCP/unix-domain socket object's [receive](#tcpsockreceive) method and iterator functions returned by the [receiveuntil](#tcpsockreceiveuntil) method. This setting can be overridden by the [settimeout](#tcpsocksettimeout) method.
+This directive controls the default timeout value used in TCP/unix-domain socket object's [receive](#tcpsockreceive) method and iterator functions returned by the [receiveuntil](#tcpsockreceiveuntil) method. This setting can be overridden by the [settimeout](#tcpsocksettimeout) or [settimeouts](#tcpsocksettimeouts) methods.
 
 The `<time>` argument can be an integer, with an optional time unit, like `s` (second), `ms` (millisecond), `m` (minute). The default time unit is `s`, i.e., "second". The default setting is `60s`.
 
@@ -3113,6 +3113,7 @@ Nginx API for Lua
 * [tcpsock:receiveuntil](#tcpsockreceiveuntil)
 * [tcpsock:close](#tcpsockclose)
 * [tcpsock:settimeout](#tcpsocksettimeout)
+* [tcpsock:settimeouts](#tcpsocksettimeouts)
 * [tcpsock:setoption](#tcpsocksetoption)
 * [tcpsock:setkeepalive](#tcpsocksetkeepalive)
 * [tcpsock:getreusedtimes](#tcpsockgetreusedtimes)
@@ -6669,6 +6670,7 @@ Creates and returns a TCP or stream-oriented unix domain socket object (also kno
 * [receive](#tcpsockreceive)
 * [close](#tcpsockclose)
 * [settimeout](#tcpsocksettimeout)
+* [settimeouts](#tcpsocksettimeouts)
 * [setoption](#tcpsocksetoption)
 * [receiveuntil](#tcpsockreceiveuntil)
 * [setkeepalive](#tcpsocksetkeepalive)
@@ -7027,6 +7029,25 @@ Settings done by this method takes priority over those config directives, i.e., 
 Note that this method does *not* affect the [lua_socket_keepalive_timeout](#lua_socket_keepalive_timeout) setting; the `timeout` argument to the [setkeepalive](#tcpsocksetkeepalive) method should be used for this purpose instead.
 
 This feature was first introduced in the `v0.5.0rc1` release.
+
+[Back to TOC](#nginx-api-for-lua)
+
+tcpsock:settimeouts
+-------------------
+**syntax:** *tcpsock:settimeouts(connect_timeout, send_timeout, read_timeout)*
+
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;*
+
+Sets the connect timeout thresold, send timeout threshold, and read timeout threshold, respetively, in milliseconds, for subsequent socket
+operations ([connect](#tcpsockconnect), [send](#tcpsocksend), [receive](#tcpsockreceive), and iterators returned from [receiveuntil](#tcpsockreceiveuntil)).
+
+Settings done by this method takes priority over those config directives, i.e., [lua_socket_connect_timeout](#lua_socket_connect_timeout), [lua_socket_send_timeout](#lua_socket_send_timeout), and [lua_socket_read_timeout](#lua_socket_read_timeout).
+
+You are recommended to use [settimeouts](#tcpsocksettimeouts) instead of [settimeout](#tcpsocksettimeout).
+
+Note that this method does *not* affect the [lua_socket_keepalive_timeout](#lua_socket_keepalive_timeout) setting; the `timeout` argument to the [setkeepalive](#tcpsocksetkeepalive) method should be used for this purpose instead.
+
+This feature was first introduced in the `vXXX` release.
 
 [Back to TOC](#nginx-api-for-lua)
 

--- a/README.markdown
+++ b/README.markdown
@@ -1106,12 +1106,19 @@ Just tune the number for your own use cases.
 
 Configuring the argument to `0` essentially turns off the periodical memory trimming altogether.
 
+```nginx
+
+ lua_malloc_trim 0;  # turn off trimming completely
+```
+
 The current implementation uses an NGINX log phase handler to do the request counting. So the appearance of the
 [log_subrequest on](http://nginx.org/en/docs/http/ngx_http_core_module.html#log_subrequest) directives in `nginx.conf`
 may make the counting faster when subrequests are involved. By default, only "main requests" count.
 
 Note that this directive does *not* affect the memory allocated by LuaJIT's own allocator based on the `mmap`
 system call.
+
+This directive was first introduced in the `v0.10.7` release.
 
 [Back to TOC](#directives)
 

--- a/config
+++ b/config
@@ -519,6 +519,24 @@ CC_TEST_FLAGS="-Werror -Wall $CC_TEST_FLAGS"
 
 CC_TEST_FLAGS="$SAVED_CC_TEST_FLAGS"
 
+# ----------------------------------------
+
+ngx_feature="malloc_trim"
+ngx_feature_libs=
+ngx_feature_name="NGX_HTTP_LUA_HAVE_MALLOC_TRIM"
+ngx_feature_run=yes
+ngx_feature_incs="#include <malloc.h>
+#include <stdio.h>"
+ngx_feature_test="int rc = malloc_trim((size_t) 0); printf(\"%d\", rc);"
+SAVED_CC_TEST_FLAGS="$CC_TEST_FLAGS"
+CC_TEST_FLAGS="-Werror -Wall $CC_TEST_FLAGS"
+
+. auto/feature
+
+CC_TEST_FLAGS="$SAVED_CC_TEST_FLAGS"
+
+# ----------------------------------------
+
 if test -n "$ngx_module_link"; then
     ngx_module_type=HTTP_AUX_FILTER
     ngx_module_name=$ngx_addon_name

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -918,6 +918,8 @@ The default number of entries allowed is 1024 and when this limit is reached, ne
     2011/08/27 23:18:26 [warn] 31997#0: *1 lua exceeding regex cache max entries (1024), ...
 </geshi>
 
+If you are using the `ngx.re.*` implementation of [lua-resty-core](https://github.com/openresty/lua-resty-core) by loading the `resty.core.regex` module (or just the `resty.core` module), then an LRU cache is used for the regex cache being used here.
+
 Do not activate the <code>o</code> option for regular expressions (and/or <code>replace</code> string arguments for [[#ngx.re.sub|ngx.re.sub]] and [[#ngx.re.gsub|ngx.re.gsub]]) that are generated ''on the fly'' and give rise to infinite variations to avoid hitting the specified limit.
 
 == lua_regex_match_limit ==

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -4160,8 +4160,13 @@ It is recommended that a coding style that combines this method call with the <c
 
 Issue an <code>HTTP 301</code> or <code>302</code> redirection to <code>uri</code>.
 
-The optional <code>status</code> parameter specifies whether
-<code>301</code> or <code>302</code> to be used. It is <code>302</code> (<code>ngx.HTTP_MOVED_TEMPORARILY</code>) by default.
+The optional <code>status</code> parameter specifies the HTTP status code to be used. The following status codes are supported right now:
+
+* <code>301</code>
+* <code>302</code> (default)
+* <code>307</code>
+
+It is <code>302</code> (<code>ngx.HTTP_MOVED_TEMPORARILY</code>) by default.
 
 Here is an example assuming the current server name is <code>localhost</code> and that it is listening on port 1984:
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -840,6 +840,32 @@ This directive is turned on by default.
 
 This directive was first introduced in the <code>v0.9.1</code> release.
 
+== lua_malloc_trim ==
+'''syntax:''' ''lua_malloc_trim <request-count>''
+
+'''default:''' ''lua_malloc_trim 1000''
+
+'''context:''' ''http''
+
+Asks the underlying <code>libc</code> runtime library to release its cached free memory back to the operating system every
+<code>N</code> requests processed by the NGINX core. By default, <code>N</code> is 1000. You can configure the request count
+by using your own numbers. Smaller numbers mean more frequent releases, which may introduce higher CPU time consumption and
+smaller memory footprint while larger numbers usually lead to less CPU time overhead and relatively larger memory footprint.
+Just tune the number for your own use cases.
+
+Configuring the argument to <code>0</code> essentially turns off the periodical memory trimming altogether.
+
+<geshi lang="nginx">
+    lua_malloc_trim 0;  # turn off trimming completely
+</geshi>
+
+The current implementation uses an NGINX log phase handler to do the request counting. So the appearance of the
+[http://nginx.org/en/docs/http/ngx_http_core_module.html#log_subrequest log_subrequest on] directives in <code>nginx.conf</code>
+may make the counting faster when subrequests are involved. By default, only "main requests" count.
+
+Note that this directive does *not* affect the memory allocated by LuaJIT's own allocator based on the <code>mmap</code>
+system call.
+
 == lua_code_cache ==
 '''syntax:''' ''lua_code_cache on | off''
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -2240,7 +2240,7 @@ This directive was first introduced in the <code>v0.3.1rc22</code> release.
 
 '''context:''' ''http, server, location''
 
-This directive controls the default timeout value used in TCP/unix-domain socket object's [[#tcpsock:connect|connect]] method and can be overridden by the [[#tcpsock:settimeout|settimeout]] method.
+This directive controls the default timeout value used in TCP/unix-domain socket object's [[#tcpsock:connect|connect]] method and can be overridden by the [[#tcpsock:settimeout|settimeout]] or [[#tcpsock:settimeouts|settimeouts]] methods.
 
 The <code><time></code> argument can be an integer, with an optional time unit, like <code>s</code> (second), <code>ms</code> (millisecond), <code>m</code> (minute). The default time unit is <code>s</code>, i.e., "second". The default setting is <code>60s</code>.
 
@@ -2254,7 +2254,7 @@ This directive was first introduced in the <code>v0.5.0rc1</code> release.
 
 '''context:''' ''http, server, location''
 
-Controls the default timeout value used in TCP/unix-domain socket object's [[#tcpsock:send|send]] method and can be overridden by the [[#tcpsock:settimeout|settimeout]] method.
+Controls the default timeout value used in TCP/unix-domain socket object's [[#tcpsock:send|send]] method and can be overridden by the [[#tcpsock:settimeout|settimeout]] or [[#tcpsock:settimeouts|settimeouts]] methods.
 
 The <code><time></code> argument can be an integer, with an optional time unit, like <code>s</code> (second), <code>ms</code> (millisecond), <code>m</code> (minute). The default time unit is <code>s</code>, i.e., "second". The default setting is <code>60s</code>.
 
@@ -2280,7 +2280,7 @@ Controls the <code>lowat</code> (low water) value for the cosocket send buffer.
 
 '''phase:''' ''depends on usage''
 
-This directive controls the default timeout value used in TCP/unix-domain socket object's [[#tcpsock:receive|receive]] method and iterator functions returned by the [[#tcpsock:receiveuntil|receiveuntil]] method. This setting can be overridden by the [[#tcpsock:settimeout|settimeout]] method.
+This directive controls the default timeout value used in TCP/unix-domain socket object's [[#tcpsock:receive|receive]] method and iterator functions returned by the [[#tcpsock:receiveuntil|receiveuntil]] method. This setting can be overridden by the [[#tcpsock:settimeout|settimeout]] or [[#tcpsock:settimeouts|settimeouts]] methods.
 
 The <code><time></code> argument can be an integer, with an optional time unit, like <code>s</code> (second), <code>ms</code> (millisecond), <code>m</code> (minute). The default time unit is <code>s</code>, i.e., "second". The default setting is <code>60s</code>.
 
@@ -5592,6 +5592,7 @@ Creates and returns a TCP or stream-oriented unix domain socket object (also kno
 * [[#tcpsock:receive|receive]]
 * [[#tcpsock:close|close]]
 * [[#tcpsock:settimeout|settimeout]]
+* [[#tcpsock:settimeouts|settimeouts]]
 * [[#tcpsock:setoption|setoption]]
 * [[#tcpsock:receiveuntil|receiveuntil]]
 * [[#tcpsock:setkeepalive|setkeepalive]]
@@ -5919,6 +5920,22 @@ Settings done by this method takes priority over those config directives, i.e., 
 Note that this method does ''not'' affect the [[#lua_socket_keepalive_timeout|lua_socket_keepalive_timeout]] setting; the <code>timeout</code> argument to the [[#tcpsock:setkeepalive|setkeepalive]] method should be used for this purpose instead.
 
 This feature was first introduced in the <code>v0.5.0rc1</code> release.
+
+== tcpsock:settimeouts ==
+'''syntax:''' ''tcpsock:settimeouts(connect_timeout, send_timeout, read_timeout)''
+
+'''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*, ngx.timer.*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*''
+
+Sets the connect timeout thresold, send timeout threshold, and read timeout threshold, respetively, in milliseconds, for subsequent socket
+operations ([[#tcpsock:connect|connect]], [[#tcpsock:send|send]], [[#tcpsock:receive|receive]], and iterators returned from [[#tcpsock:receiveuntil|receiveuntil]]).
+
+Settings done by this method takes priority over those config directives, i.e., [[#lua_socket_connect_timeout|lua_socket_connect_timeout]], [[#lua_socket_send_timeout|lua_socket_send_timeout]], and [[#lua_socket_read_timeout|lua_socket_read_timeout]].
+
+You are recommended to use [[#tcpsock:settimeouts|settimeouts]] instead of [[#tcpsock:settimeout|settimeout]].
+
+Note that this method does ''not'' affect the [[#lua_socket_keepalive_timeout|lua_socket_keepalive_timeout]] setting; the <code>timeout</code> argument to the [[#tcpsock:setkeepalive|setkeepalive]] method should be used for this purpose instead.
+
+This feature was first introduced in the <code>vXXX</code> release.
 
 == tcpsock:setoption ==
 '''syntax:''' ''tcpsock:setoption(option, value?)''

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -10,7 +10,7 @@ Production ready.
 
 = Version =
 
-This document describes ngx_lua [https://github.com/openresty/lua-nginx-module/tags v0.10.6] released on 15 August 2016.
+This document describes ngx_lua [https://github.com/openresty/lua-nginx-module/tags v0.10.7] released on 4 November 2016.
 
 = Synopsis =
 <geshi lang="nginx">

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -5935,7 +5935,7 @@ You are recommended to use [[#tcpsock:settimeouts|settimeouts]] instead of [[#tc
 
 Note that this method does ''not'' affect the [[#lua_socket_keepalive_timeout|lua_socket_keepalive_timeout]] setting; the <code>timeout</code> argument to the [[#tcpsock:setkeepalive|setkeepalive]] method should be used for this purpose instead.
 
-This feature was first introduced in the <code>vXXX</code> release.
+This feature was first introduced in the <code>v0.10.7</code> release.
 
 == tcpsock:setoption ==
 '''syntax:''' ''tcpsock:setoption(option, value?)''

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -2087,7 +2087,7 @@ This directive was first introduced in the <code>v0.10.0</code> release.
 
 '''syntax:''' ''ssl_session_fetch_by_lua_block { lua-script }''
 
-'''context:''' ''server''
+'''context:''' ''http''
 
 '''phase:''' ''right-before-SSL-handshake''
 
@@ -2143,11 +2143,14 @@ http://openresty.org/download/nginx-1.11.2-nonblocking_ssl_handshake_hooks.patch
 
 This directive was first introduced in the <code>v0.10.6</code> release.
 
+Note that: this directive is only allowed to used in '''http context''' from the <code>v0.10.7</code> release
+(because SSL session resumption happens before server name dispatch).
+
 == ssl_session_fetch_by_lua_file ==
 
 '''syntax:''' ''ssl_session_fetch_by_lua_file <path-to-lua-script-file>''
 
-'''context:''' ''server''
+'''context:''' ''http''
 
 '''phase:''' ''right-before-SSL-handshake''
 
@@ -2157,11 +2160,14 @@ When a relative path like <code>foo/bar.lua</code> is given, they will be turned
 
 This directive was first introduced in the <code>v0.10.6</code> release.
 
+Note that: this directive is only allowed to used in '''http context''' from the <code>v0.10.7</code> release
+(because SSL session resumption happens before server name dispatch).
+
 == ssl_session_store_by_lua_block ==
 
 '''syntax:''' ''ssl_session_store_by_lua_block { lua-script }''
 
-'''context:''' ''server''
+'''context:''' ''http''
 
 '''phase:''' ''right-after-SSL-handshake''
 
@@ -2188,11 +2194,14 @@ But do not forget to comment this line out before publishing your site to the wo
 
 This directive was first introduced in the <code>v0.10.6</code> release.
 
+Note that: this directive is only allowed to used in '''http context''' from the <code>v0.10.7</code> release
+(because SSL session resumption happens before server name dispatch).
+
 == ssl_session_store_by_lua_file ==
 
 '''syntax:''' ''ssl_session_store_by_lua_file <path-to-lua-script-file>''
 
-'''context:''' ''server''
+'''context:''' ''http''
 
 '''phase:''' ''right-before-SSL-handshake''
 
@@ -2201,6 +2210,9 @@ Equivalent to [[#ssl_session_store_by_lua_block|ssl_session_store_by_lua_block]]
 When a relative path like <code>foo/bar.lua</code> is given, they will be turned into the absolute path relative to the <code>server prefix</code> path determined by the <code>-p PATH</code> command-line option while starting the Nginx server.
 
 This directive was first introduced in the <code>v0.10.6</code> release.
+
+Note that: this directive is only allowed to used in '''http context''' from the <code>v0.10.7</code> release
+(because SSL session resumption happens before server name dispatch).
 
 == lua_shared_dict ==
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -463,10 +463,10 @@ and then accessing it from <code>nginx.conf</code>:
 
 <geshi lang="nginx">
     location /lua {
-        content_by_lua '
+        content_by_lua_block {
             local mydata = require "mydata"
             ngx.say(mydata.get_age("dog"))
-        ';
+        }
     }
 </geshi>
 
@@ -545,9 +545,9 @@ The [[#ngx.location.capture|ngx.location.capture]] and [[#ngx.location.capture_m
 
 <geshi lang="nginx">
     location /foo {
-        content_by_lua '
+        content_by_lua_block {
             res = ngx.location.capture("/bar")
-        ';
+        }
     }
     location /bar {
         echo_location /blah;
@@ -693,9 +693,9 @@ servers in Lua. For example,
     datagram {
         server {
             listen 1953;
-            handler_by_lua '
+            handler_by_lua_block {
                 -- custom Lua code implementing the special UDP server...
-            ';
+            }
         }
     }
 </geshi>
@@ -957,9 +957,9 @@ Usually you can register (true) Lua global variables or pre-load Lua modules at 
 
     server {
         location = /api {
-            content_by_lua '
+            content_by_lua_block {
                 ngx.say(cjson.encode({dog = 5, cat = 6}))
-            ';
+            }
         }
     }
 </geshi>
@@ -976,10 +976,10 @@ You can also initialize the [[#lua_shared_dict|lua_shared_dict]] shm storage at 
 
     server {
         location = /api {
-            content_by_lua '
+            content_by_lua_block {
                 local dogs = ngx.shared.dogs;
                 ngx.say(dogs:get("Tom"))
-            ';
+            }
         }
     }
 </geshi>
@@ -1707,7 +1707,7 @@ When the Lua code may change the length of the response body, then it is require
     location /foo {
         # fastcgi_pass/proxy_pass/...
 
-        header_filter_by_lua 'ngx.header.content_length = nil';
+        header_filter_by_lua_block { ngx.header.content_length = nil }
         body_filter_by_lua 'ngx.arg[1] = string.len(ngx.arg[1]) .. "\\n"';
     }
 </geshi>
@@ -1806,7 +1806,7 @@ Here is an example of gathering average data for [[HttpUpstreamModule#$upstream_
         }
 
         location = /status {
-            content_by_lua '
+            content_by_lua_block {
                 local log_dict = ngx.shared.log_dict
                 local sum = log_dict:get("upstream_time-sum")
                 local nb = log_dict:get("upstream_time-nb")
@@ -1817,7 +1817,7 @@ Here is an example of gathering average data for [[HttpUpstreamModule#$upstream_
                 else
                     ngx.say("no data yet")
                 end
-            ';
+            }
         }
     }
 </geshi>
@@ -1946,15 +1946,15 @@ Determines whether to force the request body data to be read before running rewr
 To read the request body data within the [[HttpCoreModule#$request_body|$request_body]] variable,
 [[HttpCoreModule#client_body_buffer_size|client_body_buffer_size]] must have the same value as [[HttpCoreModule#client_max_body_size|client_max_body_size]]. Because when the content length exceeds [[HttpCoreModule#client_body_buffer_size|client_body_buffer_size]] but less than [[HttpCoreModule#client_max_body_size|client_max_body_size]], Nginx will buffer the data into a temporary file on the disk, which will lead to empty value in the [[HttpCoreModule#$request_body|$request_body]] variable.
 
-If the current location includes [[#rewrite_by_lua|rewrite_by_lua]] or [[#rewrite_by_lua_file|rewrite_by_lua_file]] directives,
-then the request body will be read just before the [[#rewrite_by_lua|rewrite_by_lua]] or [[#rewrite_by_lua_file|rewrite_by_lua_file]] code is run (and also at the
+If the current location includes [[#rewrite_by_lua|rewrite_by_lua*]] directives,
+then the request body will be read just before the [[#rewrite_by_lua|rewrite_by_lua*]] code is run (and also at the
 <code>rewrite</code> phase). Similarly, if only [[#content_by_lua|content_by_lua]] is specified,
 the request body will not be read until the content handler's Lua code is
 about to run (i.e., the request body will be read during the content phase).
 
 It is recommended however, to use the [[#ngx.req.read_body|ngx.req.read_body]] and [[#ngx.req.discard_body|ngx.req.discard_body]] functions for finer control over the request body reading process instead.
 
-This also applies to [[#access_by_lua|access_by_lua]] and [[#access_by_lua_file|access_by_lua_file]].
+This also applies to [[#access_by_lua|access_by_lua*]].
 
 == ssl_certificate_by_lua_block ==
 
@@ -2408,7 +2408,7 @@ This directive was first introduced in the <code>v0.5.0rc19</code> release.
 
 '''context:''' ''http''
 
-Controls whether or not to disable postponing [[#rewrite_by_lua|rewrite_by_lua]]* directives to run at the end of the <code>rewrite</code> request-processing phase. By default, this directive is turned off and the Lua code is postponed to run at the end of the <code>rewrite</code> phase.
+Controls whether or not to disable postponing [[#rewrite_by_lua|rewrite_by_lua*]] directives to run at the end of the <code>rewrite</code> request-processing phase. By default, this directive is turned off and the Lua code is postponed to run at the end of the <code>rewrite</code> phase.
 
 This directive was first introduced in the <code>v0.5.0rc29</code> release.
 
@@ -2420,7 +2420,7 @@ This directive was first introduced in the <code>v0.5.0rc29</code> release.
 
 '''context:''' ''http''
 
-Controls whether or not to disable postponing [[#access_by_lua|access_by_lua]]* directives to run at the end of the <code>access</code> request-processing phase. By default, this directive is turned off and the Lua code is postponed to run at the end of the <code>access</code> phase.
+Controls whether or not to disable postponing [[#access_by_lua|access_by_lua*]] directives to run at the end of the <code>access</code> request-processing phase. By default, this directive is turned off and the Lua code is postponed to run at the end of the <code>access</code> phase.
 
 This directive was first introduced in the <code>v0.9.20</code> release.
 
@@ -2504,7 +2504,7 @@ This directive was first introduced in the <code>v0.8.0</code> release.
 <!-- inline-toc -->
 
 == Introduction ==
-The various <code>*_by_lua</code> and <code>*_by_lua_file</code> configuration directives serve as gateways to the Lua API within the <code>nginx.conf</code> file. The Nginx Lua API described below can only be called within the user Lua code run in the context of these configuration directives.
+The various <code>*_by_lua</code>, <code>*_by_lua_block</code> and <code>*_by_lua_file</code> configuration directives serve as gateways to the Lua API within the <code>nginx.conf</code> file. The Nginx Lua API described below can only be called within the user Lua code run in the context of these configuration directives.
 
 The API is exposed to Lua in the form of two standard packages <code>ngx</code> and <code>ndk</code>. These packages are in the default global scope within ngx_lua and are always available within ngx_lua directives.
 
@@ -2540,7 +2540,7 @@ Network I/O operations in user code should only be done through the Nginx Lua AP
 
 '''context:''' ''set_by_lua*, body_filter_by_lua*''
 
-When this is used in the context of the [[#set_by_lua|set_by_lua]] or [[#set_by_lua_file|set_by_lua_file]] directives, this table is read-only and holds the input arguments to the config directives:
+When this is used in the context of the [[#set_by_lua|set_by_lua*]] directives, this table is read-only and holds the input arguments to the config directives:
 
 <geshi lang="lua">
     value = ngx.arg[n]
@@ -2563,7 +2563,7 @@ Here is an example
 
 that writes out <code>88</code>, the sum of <code>32</code> and <code>56</code>.
 
-When this table is used in the context of [[#body_filter_by_lua|body_filter_by_lua]] or [[#body_filter_by_lua_file|body_filter_by_lua_file]], the first element holds the input data chunk to the output filter code and the second element holds the boolean flag for the "eof" flag indicating the end of the whole output data stream.
+When this table is used in the context of [[#body_filter_by_lua|body_filter_by_lua*]], the first element holds the input data chunk to the output filter code and the second element holds the boolean flag for the "eof" flag indicating the end of the whole output data stream.
 
 The data chunk and "eof" flag passed to the downstream Nginx output filters can also be overridden by assigning values directly to the corresponding table elements. When setting <code>nil</code> or an empty Lua string value to <code>ngx.arg[1]</code>, no data chunk will be passed to the downstream Nginx output filters at all.
 
@@ -2585,10 +2585,10 @@ For example:
 <geshi lang="nginx">
     location /foo {
         set $my_var ''; # this line is required to create $my_var at config time
-        content_by_lua '
+        content_by_lua_block {
             ngx.var.my_var = 123;
             ...
-        ';
+        }
     }
 </geshi>
 
@@ -2620,7 +2620,7 @@ Undefined NGINX variables are evaluated to `nil` while uninitialized (but define
 This API requires a relatively expensive metamethod call and it is recommended to avoid using it on hot code paths.
 
 == Core constants ==
-'''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, *log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
+'''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, *log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
 
 <geshi lang="lua">
   ngx.OK (0)
@@ -2641,7 +2641,7 @@ The <code>ngx.null</code> constant is a <code>NULL</code> light userdata usually
 The <code>ngx.DECLINED</code> constant was first introduced in the <code>v0.5.0rc19</code> release.
 
 == HTTP method constants ==
-'''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
+'''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
 
 <geshi lang="text">
   ngx.HTTP_GET
@@ -2664,7 +2664,7 @@ The <code>ngx.DECLINED</code> constant was first introduced in the <code>v0.5.0r
 These constants are usually used in [[#ngx.location.capture|ngx.location.capture]] and [[#ngx.location.capture_multi|ngx.location.capture_multi]] method calls.
 
 == HTTP status constants ==
-'''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
+'''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
 
 <geshi lang="nginx">
   value = ngx.HTTP_CONTINUE (100) (first added in the v0.9.20 release)
@@ -2704,7 +2704,7 @@ These constants are usually used in [[#ngx.location.capture|ngx.location.capture
 </geshi>
 
 == Nginx log level constants ==
-'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
+'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
 
 <geshi lang="lua">
   ngx.STDERR
@@ -2723,7 +2723,7 @@ These constants are usually used by the [[#ngx.log|ngx.log]] method.
 == print ==
 '''syntax:''' ''print(...)''
 
-'''context:''' ''init_by_lua*, init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
+'''context:''' ''init_by_lua*, init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
 
 Writes argument values into the nginx <code>error.log</code> file with the <code>ngx.NOTICE</code> log level.
 
@@ -2738,7 +2738,7 @@ Lua <code>nil</code> arguments are accepted and result in literal <code>"nil"</c
 There is a hard coded <code>2048</code> byte limitation on error message lengths in the Nginx core. This limit includes trailing newlines and leading time stamps. If the message size exceeds this limit, Nginx will truncate the message text accordingly. This limit can be manually modified by editing the <code>NGX_MAX_ERROR_STR</code> macro definition in the <code>src/core/ngx_log.h</code> file in the Nginx source tree.
 
 == ngx.ctx ==
-'''context:''' ''init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*, ngx.timer.*, balancer_by_lua*''
+'''context:''' ''init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*''
 
 This table can be used to store per-request Lua context data and has a life time identical to the current request (as with the Nginx variables). 
 
@@ -2746,15 +2746,15 @@ Consider the following example,
 
 <geshi lang="nginx">
     location /test {
-        rewrite_by_lua '
+        rewrite_by_lua_block {
             ngx.ctx.foo = 76
-        ';
-        access_by_lua '
+        }
+        access_by_lua_block {
             ngx.ctx.foo = ngx.ctx.foo + 3
-        ';
-        content_by_lua '
+        }
+        content_by_lua_block {
             ngx.say(ngx.ctx.foo)
-        ';
+        }
     }
 </geshi>
 
@@ -2770,21 +2770,21 @@ Every request, including subrequests, has its own copy of the table. For example
 
 <geshi lang="nginx">
     location /sub {
-        content_by_lua '
+        content_by_lua_block {
             ngx.say("sub pre: ", ngx.ctx.blah)
             ngx.ctx.blah = 32
             ngx.say("sub post: ", ngx.ctx.blah)
-        ';
+        }
     }
  
     location /main {
-        content_by_lua '
+        content_by_lua_block {
             ngx.ctx.blah = 73
             ngx.say("main pre: ", ngx.ctx.blah)
             local res = ngx.location.capture("/sub")
             ngx.print(res.body)
             ngx.say("main post: ", ngx.ctx.blah)
-        ';
+        }
     }
 </geshi>
 
@@ -2803,16 +2803,16 @@ Internal redirection will destroy the original request <code>ngx.ctx</code> data
 
 <geshi lang="nginx">
     location /new {
-        content_by_lua '
+        content_by_lua_block {
             ngx.say(ngx.ctx.foo)
-        ';
+        }
     }
  
     location /orig {
-        content_by_lua '
+        content_by_lua_block {
             ngx.ctx.foo = "hello"
             ngx.exec("/new")
-        ';
+        }
     }
 </geshi>
 
@@ -2999,13 +2999,13 @@ This option is set to <code>false</code> by default
 
     location /lua {
         set $dog 'hello';
-        content_by_lua '
+        content_by_lua_block {
             res = ngx.location.capture("/other",
                 { share_all_vars = true });
 
             ngx.print(res.body)
             ngx.say(ngx.var.uri, ": ", ngx.var.dog)
-        ';
+        }
     }
 </geshi>
 
@@ -3026,13 +3026,13 @@ The <code>copy_all_vars</code> option provides a copy of the parent request's Ng
 
     location /lua {
         set $dog 'hello';
-        content_by_lua '
+        content_by_lua_block {
             res = ngx.location.capture("/other",
                 { copy_all_vars = true });
 
             ngx.print(res.body)
             ngx.say(ngx.var.uri, ": ", ngx.var.dog)
-        ';
+        }
     }
 </geshi>
 
@@ -3054,21 +3054,21 @@ unescaping them in the Nginx config file.
 
 <geshi lang="nginx">
     location /other {
-        content_by_lua '
+        content_by_lua_block {
             ngx.say("dog = ", ngx.var.dog)
             ngx.say("cat = ", ngx.var.cat)
-        ';
+        }
     }
 
     location /lua {
         set $dog '';
         set $cat '';
-        content_by_lua '
+        content_by_lua_block {
             res = ngx.location.capture("/other",
                 { vars = { dog = "hello", cat = 32 }});
 
             ngx.print(res.body)
-        ';
+        }
     }
 </geshi>
 
@@ -3083,18 +3083,18 @@ The <code>ctx</code> option can be used to specify a custom Lua table to serve a
 
 <geshi lang="nginx">
     location /sub {
-        content_by_lua '
+        content_by_lua_block {
             ngx.ctx.foo = "bar";
-        ';
+        }
     }
     location /lua {
-        content_by_lua '
+        content_by_lua_block {
             local ctx = {}
             res = ngx.location.capture("/sub", { ctx = ctx })
 
             ngx.say(ctx.foo);
             ngx.say(ngx.ctx.foo);
-        ';
+        }
     }
 </geshi>
 
@@ -3109,15 +3109,15 @@ It is also possible to use this <code>ctx</code> option to share the same [[#ngx
 
 <geshi lang="nginx">
     location /sub {
-        content_by_lua '
+        content_by_lua_block {
             ngx.ctx.foo = "bar";
-        ';
+        }
     }
     location /lua {
-        content_by_lua '
+        content_by_lua_block {
             res = ngx.location.capture("/sub", { ctx = ngx.ctx })
             ngx.say(ngx.ctx.foo);
-        ';
+        }
     }
 </geshi>
 
@@ -3206,7 +3206,7 @@ of this function. Logically speaking, the [[#ngx.location.capture|ngx.location.c
 Please also refer to restrictions on capturing locations configured by [[#Locations_Configured_by_Subrequest_Directives_of_Other_Modules|subrequest directives of other modules]].
 
 == ngx.status ==
-'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*''
+'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*''
 
 Read and write the current request's response status. This should be called
 before sending out the response headers.
@@ -3227,7 +3227,7 @@ Setting <code>ngx.status</code> after the response header is sent out has no eff
 
 '''syntax:''' ''value = ngx.header.HEADER''
 
-'''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*''
+'''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*''
 
 Set, add to, or clear the current request's <code>HEADER</code> response header that is to be sent.
 
@@ -3287,7 +3287,7 @@ Reading <code>ngx.header.HEADER</code> will return the value of the response hea
 
 Underscores (<code>_</code>) in the header names will also be replaced by dashes (<code>-</code>) and the header names will be matched case-insensitively. If the response header is not present at all, <code>nil</code> will be returned.
 
-This is particularly useful in the context of [[#header_filter_by_lua|header_filter_by_lua]] and [[#header_filter_by_lua_file|header_filter_by_lua_file]], for example,
+This is particularly useful in the context of [[#header_filter_by_lua|header_filter_by_lua*]], for example,
 
 <geshi lang="nginx">
     location /test {
@@ -3295,11 +3295,11 @@ This is particularly useful in the context of [[#header_filter_by_lua|header_fil
 
         proxy_pass http://some-backend;
 
-        header_filter_by_lua '
+        header_filter_by_lua_block {
             if ngx.header["X-My-Header"] == "blah" then
                 ngx.var.footer = "some value"
             end
-        ';
+        }
 
         echo_after_body $footer;
     }
@@ -3327,7 +3327,7 @@ For reading ''request'' headers, use the [[#ngx.req.get_headers|ngx.req.get_head
 == ngx.resp.get_headers ==
 '''syntax:''' ''headers = ngx.resp.get_headers(max_headers?, raw?)''
 
-'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*, balancer_by_lua*''
+'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, balancer_by_lua*''
 
 Returns a Lua table holding all the current response headers for the current request.
 
@@ -3492,16 +3492,16 @@ or equivalently,
     ngx.req.set_uri("/foo")
 </geshi>
 
-The <code>jump</code> argument can only be set to <code>true</code> in [[#rewrite_by_lua|rewrite_by_lua]] and [[#rewrite_by_lua_file|rewrite_by_lua_file]]. Use of jump in other contexts is prohibited and will throw out a Lua exception.
+The <code>jump</code> argument can only be set to <code>true</code> in [[#rewrite_by_lua|rewrite_by_lua*]]. Use of jump in other contexts is prohibited and will throw out a Lua exception.
 
 A more sophisticated example involving regex substitutions is as follows
 
 <geshi lang="nginx">
     location /test {
-        rewrite_by_lua '
+        rewrite_by_lua_block {
             local uri = ngx.re.sub(ngx.var.uri, "^/test/(.*)", "/$1", "o")
             ngx.req.set_uri(uri)
-        ';
+        }
         proxy_pass http://my_backend;
     }
 </geshi>
@@ -3571,13 +3571,13 @@ See also [[#ngx.req.set_uri|ngx.req.set_uri]].
 == ngx.req.get_uri_args ==
 '''syntax:''' ''args = ngx.req.get_uri_args(max_args?)''
 
-'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*, balancer_by_lua*''
+'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, balancer_by_lua*''
 
 Returns a Lua table holding all the current request URL query arguments.
 
 <geshi lang="nginx">
     location = /test {
-        content_by_lua '
+        content_by_lua_block {
             local args = ngx.req.get_uri_args()
             for key, val in pairs(args) do
                 if type(val) == "table" then
@@ -3586,7 +3586,7 @@ Returns a Lua table holding all the current request URL query arguments.
                     ngx.say(key, ": ", val)
                 end
             end
-        ';
+        }
     }
 </geshi>
 
@@ -3655,13 +3655,13 @@ Removing the <code>max_args</code> cap is strongly discouraged.
 == ngx.req.get_post_args ==
 '''syntax:''' ''args, err = ngx.req.get_post_args(max_args?)''
 
-'''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*''
+'''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*''
 
 Returns a Lua table holding all the current request POST query arguments (of the MIME type <code>application/x-www-form-urlencoded</code>). Call [[#ngx.req.read_body|ngx.req.read_body]] to read the request body first or turn on the [[#lua_need_request_body|lua_need_request_body]] directive to avoid errors.
 
 <geshi lang="nginx">
     location = /test {
-        content_by_lua '
+        content_by_lua_block {
             ngx.req.read_body()
             local args, err = ngx.req.get_post_args()
             if not args then
@@ -3675,7 +3675,7 @@ Returns a Lua table holding all the current request POST query arguments (of the
                     ngx.say(key, ": ", val)
                 end
             end
-        ';
+        }
     }
 </geshi>
 
@@ -3745,7 +3745,7 @@ Removing the <code>max_args</code> cap is strongly discouraged.
 == ngx.req.get_headers ==
 '''syntax:''' ''headers = ngx.req.get_headers(max_headers?, raw?)''
 
-'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua, log_by_lua*''
+'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*''
 
 Returns a Lua table holding all the current request headers.
 
@@ -3809,7 +3809,7 @@ The <code>__index</code> metamethod will not be added when the <code>raw</code> 
 == ngx.req.set_header ==
 '''syntax:''' ''ngx.req.set_header(header_name, header_value)''
 
-'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua''
+'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*''
 
 Set the current request's request header named <code>header_name</code> to value <code>header_value</code>, overriding any existing ones.
 
@@ -3995,7 +3995,7 @@ The usage of this function is often like this:
     ngx.req.finish_body()
 </geshi>
 
-This function can be used with [[#ngx.req.append_body|ngx.req.append_body]], [[#ngx.req.finish_body|ngx.req.finish_body]], and [[#ngx.req.socket|ngx.req.socket]] to implement efficient input filters in pure Lua (in the context of [[#rewrite_by_lua|rewrite_by_lua]]* or [[#access_by_lua|access_by_lua]]*), which can be used with other Nginx content handler or upstream modules like [[HttpProxyModule]] and [[HttpFastcgiModule]].
+This function can be used with [[#ngx.req.append_body|ngx.req.append_body]], [[#ngx.req.finish_body|ngx.req.finish_body]], and [[#ngx.req.socket|ngx.req.socket]] to implement efficient input filters in pure Lua (in the context of [[#rewrite_by_lua|rewrite_by_lua*]] or [[#access_by_lua|access_by_lua*]]), which can be used with other Nginx content handler or upstream modules like [[HttpProxyModule]] and [[HttpFastcgiModule]].
 
 This function was first introduced in the <code>v0.5.11</code> release.
 
@@ -4010,7 +4010,7 @@ When the data can no longer be hold in the memory buffer for the request body, t
 
 It is important to always call the [[#ngx.req.finish_body|ngx.req.finish_body]] after all the data has been appended onto the current request body.
 
-This function can be used with [[#ngx.req.init_body|ngx.req.init_body]], [[#ngx.req.finish_body|ngx.req.finish_body]], and [[#ngx.req.socket|ngx.req.socket]] to implement efficient input filters in pure Lua (in the context of [[#rewrite_by_lua|rewrite_by_lua]]* or [[#access_by_lua|access_by_lua]]*), which can be used with other Nginx content handler or upstream modules like [[HttpProxyModule]] and [[HttpFastcgiModule]].
+This function can be used with [[#ngx.req.init_body|ngx.req.init_body]], [[#ngx.req.finish_body|ngx.req.finish_body]], and [[#ngx.req.socket|ngx.req.socket]] to implement efficient input filters in pure Lua (in the context of [[#rewrite_by_lua|rewrite_by_lua*]] or [[#access_by_lua|access_by_lua*]]), which can be used with other Nginx content handler or upstream modules like [[HttpProxyModule]] and [[HttpFastcgiModule]].
 
 This function was first introduced in the <code>v0.5.11</code> release.
 
@@ -4023,7 +4023,7 @@ See also [[#ngx.req.init_body|ngx.req.init_body]].
 
 Completes the construction process of the new request body created by the [[#ngx.req.init_body|ngx.req.init_body]] and [[#ngx.req.append_body|ngx.req.append_body]] calls.
 
-This function can be used with [[#ngx.req.init_body|ngx.req.init_body]], [[#ngx.req.append_body|ngx.req.append_body]], and [[#ngx.req.socket|ngx.req.socket]] to implement efficient input filters in pure Lua (in the context of [[#rewrite_by_lua|rewrite_by_lua]]* or [[#access_by_lua|access_by_lua]]*), which can be used with other Nginx content handler or upstream modules like [[HttpProxyModule]] and [[HttpFastcgiModule]].
+This function can be used with [[#ngx.req.init_body|ngx.req.init_body]], [[#ngx.req.append_body|ngx.req.append_body]], and [[#ngx.req.socket|ngx.req.socket]] to implement efficient input filters in pure Lua (in the context of [[#rewrite_by_lua|rewrite_by_lua*]] or [[#access_by_lua|access_by_lua*]]), which can be used with other Nginx content handler or upstream modules like [[HttpProxyModule]] and [[HttpFastcgiModule]].
 
 This function was first introduced in the <code>v0.5.11</code> release.
 
@@ -4088,20 +4088,20 @@ Named locations are also supported but the second <code>args</code> argument wil
 
 <geshi lang="nginx">
     location /foo {
-        content_by_lua '
+        content_by_lua_block {
             ngx.exec("@bar", "a=goodbye");
-        ';
+        }
     }
 
     location @bar {
-        content_by_lua '
+        content_by_lua_block {
             local args = ngx.req.get_uri_args()
             for key, val in pairs(args) do
                 if key == "a" then
                     ngx.say(val)
                 end
             end
-        ';
+        }
     }
 </geshi>
 
@@ -4111,7 +4111,7 @@ it is purely an internal redirect and that no new external HTTP traffic is invol
 Also note that this method call terminates the processing of the current request and that it ''must'' be called before [[#ngx.send_headers|ngx.send_headers]] or explicit response body
 outputs by either [[#ngx.print|ngx.print]] or [[#ngx.say|ngx.say]].
 
-It is recommended that a coding style that combines this method call with the <code>return</code> statement, i.e., <code>return ngx.exec(...)</code> be adopted when this method call is used in contexts other than [[#header_filter_by_lua|header_filter_by_lua]] to reinforce the fact that the request processing is being terminated.
+It is recommended that a coding style that combines this method call with the <code>return</code> statement, i.e., <code>return ngx.exec(...)</code> be adopted when this method call is used in contexts other than [[#header_filter_by_lua|header_filter_by_lua*]] to reinforce the fact that the request processing is being terminated.
 
 == ngx.redirect ==
 '''syntax:''' ''ngx.redirect(uri, status?)''
@@ -4181,7 +4181,7 @@ URI arguments can be specified as well, for example:
 Note that this method call terminates the processing of the current request and that it ''must'' be called before [[#ngx.send_headers|ngx.send_headers]] or explicit response body
 outputs by either [[#ngx.print|ngx.print]] or [[#ngx.say|ngx.say]].
 
-It is recommended that a coding style that combines this method call with the <code>return</code> statement, i.e., <code>return ngx.redirect(...)</code> be adopted when this method call is used in contexts other than [[#header_filter_by_lua|header_filter_by_lua]] to reinforce the fact that the request processing is being terminated.
+It is recommended that a coding style that combines this method call with the <code>return</code> statement, i.e., <code>return ngx.redirect(...)</code> be adopted when this method call is used in contexts other than [[#header_filter_by_lua|header_filter_by_lua*]] to reinforce the fact that the request processing is being terminated.
 
 == ngx.send_headers ==
 '''syntax:''' ''ok, err = ngx.send_headers()''
@@ -4193,7 +4193,7 @@ Explicitly send out the response headers.
 Since <code>v0.8.3</code> this function returns <code>1</code> on success, or returns <code>nil</code> and a string describing the error otherwise.
 
 Note that there is normally no need to manually send out response headers as ngx_lua will automatically send headers out
-before content is output with [[#ngx.say|ngx.say]] or [[#ngx.print|ngx.print]] or when [[#content_by_lua|content_by_lua]] exits normally.
+before content is output with [[#ngx.say|ngx.say]] or [[#ngx.print|ngx.print]] or when [[#content_by_lua|content_by_lua*]] exits normally.
 
 == ngx.headers_sent ==
 '''syntax:''' ''value = ngx.headers_sent''
@@ -4284,7 +4284,7 @@ Since <code>v0.8.3</code> this function returns <code>1</code> on success, or re
 
 When <code>status >= 200</code> (i.e., <code>ngx.HTTP_OK</code> and above), it will interrupt the execution of the current request and return status code to nginx.
 
-When <code>status == 0</code> (i.e., <code>ngx.OK</code>), it will only quit the current phase handler (or the content handler if the [[#content_by_lua|content_by_lua]] directive is used) and continue to run later phases (if any) for the current request.
+When <code>status == 0</code> (i.e., <code>ngx.OK</code>), it will only quit the current phase handler (or the content handler if the [[#content_by_lua|content_by_lua*]] directive is used) and continue to run later phases (if any) for the current request.
 
 The <code>status</code> argument can be <code>ngx.OK</code>, <code>ngx.ERROR</code>, <code>ngx.HTTP_NOT_FOUND</code>,
 <code>ngx.HTTP_MOVED_TEMPORARILY</code>, or other [[#HTTP status constants|HTTP status constants]].
@@ -4338,11 +4338,11 @@ When you disable the HTTP 1.1 keep-alive feature for your downstream connections
 <geshi lang="nginx">
     location = /async {
         keepalive_timeout 0;
-        content_by_lua '
+        content_by_lua_block {
             ngx.say("got the task!")
             ngx.eof()  -- a descent HTTP client will close the connection at this point
             -- access MySQL, PostgreSQL, Redis, Memcached, and etc here...
-        ';
+        }
     }
 </geshi>
 
@@ -4546,7 +4546,7 @@ For example,
 
 <geshi lang="nginx">
     location = /md5 {
-        content_by_lua 'ngx.say(ngx.md5("hello"))';
+        content_by_lua_block { ngx.say(ngx.md5("hello")) }
     }
 </geshi>
 
@@ -5085,17 +5085,17 @@ Here is an example:
         lua_shared_dict dogs 10m;
         server {
             location /set {
-                content_by_lua '
+                content_by_lua_block {
                     local dogs = ngx.shared.dogs
                     dogs:set("Jim", 8)
                     ngx.say("STORED")
-                ';
+                }
             }
             location /get {
-                content_by_lua '
+                content_by_lua_block {
                     local dogs = ngx.shared.dogs
                     ngx.say(dogs:get("Jim"))
-                ';
+                }
             }
         }
     }
@@ -5448,7 +5448,7 @@ Here is an example for connecting to a UDP (memcached) server:
     location /test {
         resolver 8.8.8.8;
 
-        content_by_lua '
+        content_by_lua_block {
             local sock = ngx.socket.udp()
             local ok, err = sock:setpeername("my.memcached.server.domain", 11211)
             if not ok then
@@ -5457,7 +5457,7 @@ Here is an example for connecting to a UDP (memcached) server:
             end
             ngx.say("successfully connected to memcached!")
             sock:close()
-        ';
+        }
     }
 </geshi>
 
@@ -5619,7 +5619,7 @@ Here is an example for connecting to a TCP server:
     location /test {
         resolver 8.8.8.8;
 
-        content_by_lua '
+        content_by_lua_block {
             local sock = ngx.socket.tcp()
             local ok, err = sock:connect("www.google.com", 80)
             if not ok then
@@ -5628,7 +5628,7 @@ Here is an example for connecting to a TCP server:
             end
             ngx.say("successfully connected to google!")
             sock:close()
-        ';
+        }
     }
 </geshi>
 
@@ -5967,31 +5967,31 @@ This feature was first introduced in the <code>v0.5.0rc1</code> release.
 Retrieves the current running phase name. Possible return values are
 
 * <code>init</code>
-: for the context of [[#init_by_lua|init_by_lua]] or [[#init_by_lua_file|init_by_lua_file]].
+: for the context of [[#init_by_lua|init_by_lua*]].
 * <code>init_worker</code>
-: for the context of [[#init_worker_by_lua|init_worker_by_lua]] or [[#init_worker_by_lua_file|init_worker_by_lua_file]].
+: for the context of [[#init_worker_by_lua|init_worker_by_lua*]].
 * <code>ssl_cert</code>
-: for the context of [[#ssl_certificate_by_lua_block|ssl_certificate_by_lua_block]] or [[#ssl_certificate_by_lua_file|ssl_certificate_by_lua_file]].
+: for the context of [[#ssl_certificate_by_lua_block|ssl_certificate_by_lua*]].
 * <code>ssl_session_fetch</code>
 : for the context of [[#ssl_session_fetch_by_lua_block|ssl_session_fetch_by_lua*]].
 * <code>ssl_session_store</code>
 : for the context of [[#ssl_session_store_by_lua_block|ssl_session_store_by_lua*]].
 * <code>set</code>
-: for the context of [[#set_by_lua|set_by_lua]] or [[#set_by_lua_file|set_by_lua_file]].
+: for the context of [[#set_by_lua|set_by_lua*]].
 * <code>rewrite</code>
-: for the context of [[#rewrite_by_lua|rewrite_by_lua]] or [[#rewrite_by_lua_file|rewrite_by_lua_file]].
+: for the context of [[#rewrite_by_lua|rewrite_by_lua*]].
 * <code>balancer</code>
-: for the context of [[#balancer_by_lua_block|balancer_by_lua_block]] or [[#balancer_by_lua_file|balancer_by_lua_file]].
+: for the context of [[#balancer_by_lua_block|balancer_by_lua*]].
 * <code>access</code>
-: for the context of [[#access_by_lua|access_by_lua]] or [[#access_by_lua_file|access_by_lua_file]].
+: for the context of [[#access_by_lua|access_by_lua*]].
 * <code>content</code>
-: for the context of [[#content_by_lua|content_by_lua]] or [[#content_by_lua_file|content_by_lua_file]].
+: for the context of [[#content_by_lua|content_by_lua*]].
 * <code>header_filter</code>
-: for the context of [[#header_filter_by_lua|header_filter_by_lua]] or [[#header_filter_by_lua_file|header_filter_by_lua_file]].
+: for the context of [[#header_filter_by_lua|header_filter_by_lua*]].
 * <code>body_filter</code>
-: for the context of [[#body_filter_by_lua|body_filter_by_lua]] or [[#body_filter_by_lua_file|body_filter_by_lua_file]].
+: for the context of [[#body_filter_by_lua|body_filter_by_lua*]].
 * <code>log</code>
-: for the context of [[#log_by_lua|log_by_lua]] or [[#log_by_lua_file|log_by_lua_file]].
+: for the context of [[#log_by_lua|log_by_lua*]].
 * <code>timer</code>
 : for the context of user callback functions for [[#ngx.timer.at|ngx.timer.*]].
 
@@ -6318,7 +6318,7 @@ Here is a simple example:
 <geshi lang="nginx">
     location / {
         ...
-        log_by_lua '
+        log_by_lua_block {
             local function push_data(premature, uri, args, status)
                 -- push the data uri, args, and status to the remote
                 -- via ngx.socket.tcp or ngx.socket.udp
@@ -6331,7 +6331,7 @@ Here is a simple example:
                 ngx.log(ngx.ERR, "failed to create timer: ", err)
                 return
             end
-        ';
+        }
     }
 </geshi>
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -2744,7 +2744,7 @@ These constants are usually used in [[#ngx.location.capture|ngx.location.capture
 </geshi>
 
 == Nginx log level constants ==
-'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
+'''context:''' ''init_by_lua*, init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
 
 <geshi lang="lua">
   ngx.STDERR

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -866,6 +866,8 @@ may make the counting faster when subrequests are involved. By default, only "ma
 Note that this directive does *not* affect the memory allocated by LuaJIT's own allocator based on the <code>mmap</code>
 system call.
 
+This directive was first introduced in the <code>v0.10.7</code> release.
+
 == lua_code_cache ==
 '''syntax:''' ''lua_code_cache on | off''
 

--- a/src/api/ngx_http_lua_api.h
+++ b/src/api/ngx_http_lua_api.h
@@ -19,7 +19,7 @@
 /* Public API for other Nginx modules */
 
 
-#define ngx_http_lua_version  10006
+#define ngx_http_lua_version  10007
 
 
 typedef struct {

--- a/src/api/ngx_http_lua_api.h
+++ b/src/api/ngx_http_lua_api.h
@@ -46,6 +46,9 @@ ngx_int_t ngx_http_lua_shared_dict_get(ngx_shm_zone_t *shm_zone,
 
 ngx_shm_zone_t *ngx_http_lua_find_zone(u_char *name_data, size_t name_len);
 
+ngx_shm_zone_t *ngx_http_lua_shared_memory_add(ngx_conf_t *cf, ngx_str_t *name,
+    size_t size, void *tag);
+
 
 #endif /* _NGX_HTTP_LUA_API_H_INCLUDED_ */
 

--- a/src/ngx_http_lua_api.c
+++ b/src/ngx_http_lua_api.c
@@ -4,10 +4,15 @@
  */
 
 
+#ifndef DDEBUG
+#define DDEBUG 0
+#endif
 #include "ddebug.h"
+
 
 #include "ngx_http_lua_common.h"
 #include "api/ngx_http_lua_api.h"
+#include "ngx_http_lua_shdict.h"
 #include "ngx_http_lua_util.h"
 
 
@@ -27,6 +32,10 @@ ngx_http_lua_get_request(lua_State *L)
 {
     return ngx_http_lua_get_req(L);
 }
+
+
+static ngx_int_t ngx_http_lua_shared_memory_init(ngx_shm_zone_t *shm_zone,
+    void *data);
 
 
 ngx_int_t
@@ -70,6 +79,135 @@ ngx_http_lua_add_package_preload(ngx_conf_t *cf, const char *package,
 
     hook->package = (u_char *) package;
     hook->loader = func;
+
+    return NGX_OK;
+}
+
+
+ngx_shm_zone_t *
+ngx_http_lua_shared_memory_add(ngx_conf_t *cf, ngx_str_t *name, size_t size,
+    void *tag)
+{
+    ngx_http_lua_main_conf_t     *lmcf;
+    ngx_shm_zone_t              **zp;
+    ngx_shm_zone_t               *zone;
+    ngx_http_lua_shm_zone_ctx_t  *ctx;
+    ngx_int_t                     n;
+
+    lmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_lua_module);
+    if (lmcf == NULL) {
+        return NULL;
+    }
+
+    if (lmcf->shm_zones == NULL) {
+        lmcf->shm_zones = ngx_palloc(cf->pool, sizeof(ngx_array_t));
+        if (lmcf->shm_zones == NULL) {
+            return NULL;
+        }
+
+        if (ngx_array_init(lmcf->shm_zones, cf->pool, 2,
+                           sizeof(ngx_shm_zone_t *))
+            != NGX_OK)
+        {
+            return NULL;
+        }
+    }
+
+    zone = ngx_shared_memory_add(cf, name, (size_t) size, tag);
+    if (zone == NULL) {
+        return NULL;
+    }
+
+    if (zone->data) {
+        ctx = (ngx_http_lua_shm_zone_ctx_t *) zone->data;
+        return &ctx->zone;
+    }
+
+    n = sizeof(ngx_http_lua_shm_zone_ctx_t);
+
+    ctx = ngx_pcalloc(cf->pool, n);
+    if (ctx == NULL) {
+        return NULL;
+    }
+
+    ctx->lmcf = lmcf;
+    ctx->log = &cf->cycle->new_log;
+    ctx->cycle = cf->cycle;
+
+    ngx_memcpy(&ctx->zone, zone, sizeof(ngx_shm_zone_t));
+
+    zp = ngx_array_push(lmcf->shm_zones);
+    if (zp == NULL) {
+        return NULL;
+    }
+
+    *zp = zone;
+
+    /* set zone init */
+    zone->init = ngx_http_lua_shared_memory_init;
+    zone->data = ctx;
+
+    lmcf->requires_shm = 1;
+
+    return &ctx->zone;
+}
+
+
+static ngx_int_t
+ngx_http_lua_shared_memory_init(ngx_shm_zone_t *shm_zone, void *data)
+{
+    ngx_http_lua_shm_zone_ctx_t *octx = data;
+    ngx_shm_zone_t              *ozone;
+    void                        *odata;
+
+    ngx_int_t                    rc;
+    volatile ngx_cycle_t        *saved_cycle;
+    ngx_http_lua_main_conf_t    *lmcf;
+    ngx_http_lua_shm_zone_ctx_t *ctx;
+    ngx_shm_zone_t              *zone;
+
+    ctx = (ngx_http_lua_shm_zone_ctx_t *) shm_zone->data;
+    zone = &ctx->zone;
+
+    odata = NULL;
+    if (octx) {
+        ozone = &octx->zone;
+        odata = ozone->data;
+    }
+
+    zone->shm = shm_zone->shm;
+    zone->noreuse = shm_zone->noreuse;
+
+    if (zone->init(zone, odata) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    dd("get lmcf");
+
+    lmcf = ctx->lmcf;
+    if (lmcf == NULL) {
+        return NGX_ERROR;
+    }
+
+    dd("lmcf->lua: %p", lmcf->lua);
+
+    lmcf->shm_zones_inited++;
+
+    if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts
+        && lmcf->init_handler)
+    {
+        saved_cycle = ngx_cycle;
+        ngx_cycle = ctx->cycle;
+
+        rc = lmcf->init_handler(ctx->log, lmcf, lmcf->lua);
+
+        ngx_cycle = saved_cycle;
+
+        if (rc != NGX_OK) {
+            /* an error happened */
+            return NGX_ERROR;
+        }
+    }
 
     return NGX_OK;
 }

--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -25,7 +25,6 @@ struct ngx_http_lua_balancer_peer_data_s {
 
     ngx_uint_t                          more_tries;
     ngx_uint_t                          total_tries;
-    ngx_uint_t                          tries;
 
     struct sockaddr                    *sockaddr;
     socklen_t                           socklen;
@@ -298,7 +297,6 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
     bp->socklen = 0;
     bp->more_tries = 0;
     bp->total_tries++;
-    bp->tries = r->upstream->peer.tries;
 
     lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
 
@@ -683,7 +681,7 @@ ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
 
 #if (nginx_version >= 1007005)
     max_tries = r->upstream->conf->next_upstream_tries;
-    total = bp->total_tries + bp->tries - 1;
+    total = bp->total_tries + r->upstream->peer.tries - 1;
 
     if (max_tries && (total + count) > max_tries) {
         count = max_tries - total;

--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -25,6 +25,7 @@ struct ngx_http_lua_balancer_peer_data_s {
 
     ngx_uint_t                          more_tries;
     ngx_uint_t                          total_tries;
+    ngx_uint_t                          tries;
 
     struct sockaddr                    *sockaddr;
     socklen_t                           socklen;
@@ -297,6 +298,7 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
     bp->socklen = 0;
     bp->more_tries = 0;
     bp->total_tries++;
+    bp->tries = r->upstream->peer.tries;
 
     lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
 
@@ -640,7 +642,7 @@ ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
     int count, char **err)
 {
 #if (nginx_version >= 1007005)
-    ngx_uint_t             max_tries;
+    ngx_uint_t             max_tries, total;
 #endif
     ngx_http_lua_ctx_t    *ctx;
     ngx_http_upstream_t   *u;
@@ -681,9 +683,10 @@ ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
 
 #if (nginx_version >= 1007005)
     max_tries = r->upstream->conf->next_upstream_tries;
+    total = bp->total_tries + bp->tries - 1;
 
-    if (bp->total_tries + count > max_tries) {
-        count = max_tries - bp->total_tries;
+    if (max_tries && (total + count) > max_tries) {
+        count = max_tries - total;
         *err = "reduced tries due to limit";
 
     } else {

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -172,6 +172,8 @@ struct ngx_http_lua_main_conf_s {
 
     ngx_array_t         *shm_zones;  /* of ngx_shm_zone_t* */
 
+    ngx_array_t         *shdict_zones; /* shm zones of "shdict" */
+
     ngx_array_t         *preload_hooks; /* of ngx_http_lua_preload_hook_t */
 
     ngx_flag_t           postponed_to_rewrite_phase_end;

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -193,6 +193,10 @@ struct ngx_http_lua_main_conf_s {
 
     ngx_http_lua_sema_mm_t         *sema_mm;
 
+    ngx_uint_t           malloc_trim_cycle;  /* a cycle is defined as the number
+                                                of reqeusts */
+    ngx_uint_t           malloc_trim_req_count;
+
     unsigned             requires_header_filter:1;
     unsigned             requires_body_filter:1;
     unsigned             requires_capture_filter:1;

--- a/src/ngx_http_lua_control.c
+++ b/src/ngx_http_lua_control.c
@@ -105,10 +105,10 @@ ngx_http_lua_ngx_exec(lua_State *L)
 
     ngx_http_lua_check_if_abortable(L, ctx);
 
-    if (ngx_http_parse_unsafe_uri(r, &uri, &args, &flags)
-        != NGX_OK)
-    {
-        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    flags = NGX_HTTP_LOG_UNSAFE;
+
+    if (ngx_http_parse_unsafe_uri(r, &uri, &args, &flags) != NGX_OK) {
+        return luaL_error(L, "unsafe uri");
     }
 
     if (n == 2) {

--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -26,6 +26,7 @@
 #include "ngx_http_lua_shdict.h"
 #include "ngx_http_lua_ssl_certby.h"
 #include "ngx_http_lua_lex.h"
+#include "api/ngx_http_lua_api.h"
 
 
 typedef struct ngx_http_lua_block_parser_ctx_s
@@ -78,13 +79,13 @@ ngx_http_lua_shared_dict(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_http_lua_shdict_ctx_t  *ctx;
     ssize_t                     size;
 
-    if (lmcf->shm_zones == NULL) {
-        lmcf->shm_zones = ngx_palloc(cf->pool, sizeof(ngx_array_t));
-        if (lmcf->shm_zones == NULL) {
+    if (lmcf->shdict_zones == NULL) {
+        lmcf->shdict_zones = ngx_palloc(cf->pool, sizeof(ngx_array_t));
+        if (lmcf->shdict_zones == NULL) {
             return NGX_CONF_ERROR;
         }
 
-        if (ngx_array_init(lmcf->shm_zones, cf->pool, 2,
+        if (ngx_array_init(lmcf->shdict_zones, cf->pool, 2,
                            sizeof(ngx_shm_zone_t *))
             != NGX_OK)
         {
@@ -120,10 +121,9 @@ ngx_http_lua_shared_dict(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ctx->name = name;
     ctx->main_conf = lmcf;
     ctx->log = &cf->cycle->new_log;
-    ctx->cycle = cf->cycle;
 
-    zone = ngx_shared_memory_add(cf, &name, (size_t) size,
-                                 &ngx_http_lua_module);
+    zone = ngx_http_lua_shared_memory_add(cf, &name, (size_t) size,
+                                          &ngx_http_lua_module);
     if (zone == NULL) {
         return NGX_CONF_ERROR;
     }
@@ -140,7 +140,7 @@ ngx_http_lua_shared_dict(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     zone->init = ngx_http_lua_shdict_init_zone;
     zone->data = ctx;
 
-    zp = ngx_array_push(lmcf->shm_zones);
+    zp = ngx_array_push(lmcf->shdict_zones);
     if (zp == NULL) {
         return NGX_CONF_ERROR;
     }

--- a/src/ngx_http_lua_headers_in.c
+++ b/src/ngx_http_lua_headers_in.c
@@ -263,11 +263,6 @@ retry:
 
 new_header:
 
-    if (r->headers_in.headers.last == NULL) {
-        /* must be 400 bad request */
-        return NGX_OK;
-    }
-
     h = ngx_list_push(&r->headers_in.headers);
 
     if (h == NULL) {
@@ -697,6 +692,11 @@ ngx_http_lua_set_input_header(ngx_http_request_t *r, ngx_str_t key,
         return NGX_ERROR;
     }
 #endif
+
+    if (r->headers_out.status == 400 || r->headers_in.headers.last == NULL) {
+        /* must be a 400 Bad Request */
+        return NGX_OK;
+    }
 
     return hv.handler(r, &hv, &value);
 }

--- a/src/ngx_http_lua_logby.c
+++ b/src/ngx_http_lua_logby.c
@@ -27,6 +27,9 @@
 #include "ngx_http_lua_shdict.h"
 #include "ngx_http_lua_util.h"
 #include "ngx_http_lua_exception.h"
+#if (NGX_HTTP_LUA_HAVE_MALLOC_TRIM)
+#include <malloc.h>
+#endif
 
 
 static ngx_int_t ngx_http_lua_log_by_chunk(lua_State *L, ngx_http_request_t *r);
@@ -67,8 +70,42 @@ ngx_http_lua_log_by_lua_env(lua_State *L, ngx_http_request_t *r)
 ngx_int_t
 ngx_http_lua_log_handler(ngx_http_request_t *r)
 {
+#if (NGX_HTTP_LUA_HAVE_MALLOC_TRIM)
+    ngx_uint_t                   trim_cycle, trim_nreq;
+    ngx_http_lua_main_conf_t    *lmcf;
+#endif
     ngx_http_lua_loc_conf_t     *llcf;
     ngx_http_lua_ctx_t          *ctx;
+
+#if (NGX_HTTP_LUA_HAVE_MALLOC_TRIM)
+    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
+
+    trim_cycle = lmcf->malloc_trim_cycle;
+
+    if (trim_cycle > 0) {
+
+        dd("cycle: %d", (int) trim_cycle);
+
+        trim_nreq = ++lmcf->malloc_trim_req_count;
+
+        if (trim_nreq >= trim_cycle) {
+            lmcf->malloc_trim_req_count = 0;
+
+#if (NGX_DEBUG)
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "malloc_trim(1) returned %d", malloc_trim(1));
+#else
+            (void) malloc_trim(1);
+#endif
+        }
+    }
+#   if (NGX_DEBUG)
+    else {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "malloc_trim() disabled");
+    }
+#   endif
+#endif
 
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "lua log handler, uri:\"%V\" c:%ud", &r->uri,

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -53,6 +53,8 @@ void ngx_http_lua_limit_data_segment(void);
 static ngx_int_t ngx_http_lua_pre_config(ngx_conf_t *cf);
 #   endif
 #endif
+static char *ngx_http_lua_malloc_trim(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
 
 
 static ngx_conf_post_t  ngx_http_lua_lowat_post =
@@ -578,6 +580,13 @@ static ngx_command_t ngx_http_lua_cmds[] = {
 
 #endif  /* NGX_HTTP_SSL */
 
+     { ngx_string("lua_malloc_trim"),
+      NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+      ngx_http_lua_malloc_trim,
+      NGX_HTTP_MAIN_CONF_OFFSET,
+      0,
+      NULL },
+
     ngx_null_command
 };
 
@@ -832,6 +841,10 @@ ngx_http_lua_create_main_conf(ngx_conf_t *cf)
     lmcf->postponed_to_rewrite_phase_end = NGX_CONF_UNSET;
     lmcf->postponed_to_access_phase_end = NGX_CONF_UNSET;
 
+#if (NGX_HTTP_LUA_HAVE_MALLOC_TRIM)
+    lmcf->malloc_trim_cycle = NGX_CONF_UNSET_UINT;
+#endif
+
 #ifndef NGX_LUA_NO_FFI_API
     rc = ngx_http_lua_sema_mm_init(cf, lmcf);
     if (rc != NGX_OK) {
@@ -867,6 +880,12 @@ ngx_http_lua_init_main_conf(ngx_conf_t *cf, void *conf)
     if (lmcf->max_running_timers == NGX_CONF_UNSET) {
         lmcf->max_running_timers = 256;
     }
+
+#if (NGX_HTTP_LUA_HAVE_MALLOC_TRIM)
+    if (lmcf->malloc_trim_cycle == NGX_CONF_UNSET_UINT) {
+        lmcf->malloc_trim_cycle = 1000;  /* number of reqs */
+    }
+#endif
 
     lmcf->cycle = cf->cycle;
 
@@ -1282,5 +1301,40 @@ ngx_http_lua_limit_data_segment(void)
     }
 }
 #endif
+
+
+static char *
+ngx_http_lua_malloc_trim(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+#if (NGX_HTTP_LUA_HAVE_MALLOC_TRIM)
+
+    ngx_int_t       nreqs;
+    ngx_str_t      *value;
+
+    ngx_http_lua_main_conf_t    *lmcf = conf;
+
+    value = cf->args->elts;
+
+    nreqs = ngx_atoi(value[1].data, value[1].len);
+    if (nreqs == NGX_ERROR) {
+        return "invalid number in the 1st argument";
+    }
+
+    lmcf->malloc_trim_cycle = (ngx_uint_t) nreqs;
+
+    if (nreqs == 0) {
+        return NGX_CONF_OK;
+    }
+
+    lmcf->requires_log = 1;
+
+#else
+
+    ngx_conf_log_error(NGX_LOG_WARN, cf, 0, "lua_malloc_trim is not supported "
+                       "on this platform, ignored");
+
+#endif
+    return NGX_CONF_OK;
+}
 
 /* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -821,6 +821,7 @@ ngx_http_lua_create_main_conf(ngx_conf_t *cf)
      *      lmcf->init_handler = NULL;
      *      lmcf->init_src = { 0, NULL };
      *      lmcf->shm_zones_inited = 0;
+     *      lmcf->shdict_zones = NULL;
      *      lmcf->preload_hooks = NULL;
      *      lmcf->requires_header_filter = 0;
      *      lmcf->requires_body_filter = 0;

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -84,10 +84,7 @@ ngx_http_lua_shdict_init_zone(ngx_shm_zone_t *shm_zone, void *data)
     ngx_http_lua_shdict_ctx_t  *octx = data;
 
     size_t                      len;
-    ngx_int_t                   rc;
-    volatile ngx_cycle_t       *saved_cycle;
     ngx_http_lua_shdict_ctx_t  *ctx;
-    ngx_http_lua_main_conf_t   *lmcf;
 
     dd("init zone");
 
@@ -97,7 +94,7 @@ ngx_http_lua_shdict_init_zone(ngx_shm_zone_t *shm_zone, void *data)
         ctx->sh = octx->sh;
         ctx->shpool = octx->shpool;
 
-        goto done;
+        return NGX_OK;
     }
 
     ctx->shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
@@ -105,7 +102,7 @@ ngx_http_lua_shdict_init_zone(ngx_shm_zone_t *shm_zone, void *data)
     if (shm_zone->shm.exists) {
         ctx->sh = ctx->shpool->data;
 
-        goto done;
+        return NGX_OK;
     }
 
     ctx->sh = ngx_slab_alloc(ctx->shpool, sizeof(ngx_http_lua_shdict_shctx_t));
@@ -133,32 +130,6 @@ ngx_http_lua_shdict_init_zone(ngx_shm_zone_t *shm_zone, void *data)
 #if defined(nginx_version) && nginx_version >= 1005013
     ctx->shpool->log_nomem = 0;
 #endif
-
-done:
-
-    dd("get lmcf");
-
-    lmcf = ctx->main_conf;
-
-    dd("lmcf->lua: %p", lmcf->lua);
-
-    lmcf->shm_zones_inited++;
-
-    if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts
-        && lmcf->init_handler)
-    {
-        saved_cycle = ngx_cycle;
-        ngx_cycle = ctx->cycle;
-
-        rc = lmcf->init_handler(ctx->log, lmcf, lmcf->lua);
-
-        ngx_cycle = saved_cycle;
-
-        if (rc != NGX_OK) {
-            /* an error happened */
-            return NGX_ERROR;
-        }
-    }
 
     return NGX_OK;
 }
@@ -355,8 +326,8 @@ ngx_http_lua_inject_shdict_api(ngx_http_lua_main_conf_t *lmcf, lua_State *L)
     ngx_uint_t                   i;
     ngx_shm_zone_t             **zone;
 
-    if (lmcf->shm_zones != NULL) {
-        lua_createtable(L, 0, lmcf->shm_zones->nelts /* nrec */);
+    if (lmcf->shdict_zones != NULL) {
+        lua_createtable(L, 0, lmcf->shdict_zones->nelts /* nrec */);
                 /* ngx.shared */
 
         lua_createtable(L, 0 /* narr */, 18 /* nrec */); /* shared mt */
@@ -415,9 +386,9 @@ ngx_http_lua_inject_shdict_api(ngx_http_lua_main_conf_t *lmcf, lua_State *L)
         lua_pushvalue(L, -1); /* shared mt mt */
         lua_setfield(L, -2, "__index"); /* shared mt */
 
-        zone = lmcf->shm_zones->elts;
+        zone = lmcf->shdict_zones->elts;
 
-        for (i = 0; i < lmcf->shm_zones->nelts; i++) {
+        for (i = 0; i < lmcf->shdict_zones->nelts; i++) {
             ctx = zone[i]->data;
 
             lua_pushlstring(L, (char *) ctx->name.data, ctx->name.len);
@@ -2202,6 +2173,7 @@ ngx_http_lua_find_zone(u_char *name_data, size_t name_len)
     ngx_str_t                       *name;
     ngx_uint_t                       i;
     ngx_shm_zone_t                  *zone;
+    ngx_http_lua_shm_zone_ctx_t     *ctx;
     volatile ngx_list_part_t        *part;
 
     part = &ngx_cycle->shared_memory.part;
@@ -2227,7 +2199,8 @@ ngx_http_lua_find_zone(u_char *name_data, size_t name_len)
         if (name->len == name_len
             && ngx_strncmp(name->data, name_data, name_len) == 0)
         {
-            return &zone[i];
+            ctx = (ngx_http_lua_shm_zone_ctx_t *) zone[i].data;
+            return &ctx->zone;
         }
     }
 

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -1195,6 +1195,9 @@ insert:
         + key.len
         + value.len;
 
+    dd("overhead = %d", (int) (offsetof(ngx_rbtree_node_t, color)
+       + offsetof(ngx_http_lua_shdict_node_t, data)));
+
     node = ngx_slab_alloc_locked(ctx->shpool, n);
 
     if (node == NULL) {

--- a/src/ngx_http_lua_shdict.h
+++ b/src/ngx_http_lua_shdict.h
@@ -44,8 +44,15 @@ typedef struct {
     ngx_str_t                     name;
     ngx_http_lua_main_conf_t     *main_conf;
     ngx_log_t                    *log;
-    ngx_cycle_t                  *cycle;
 } ngx_http_lua_shdict_ctx_t;
+
+
+typedef struct {
+    ngx_log_t                   *log;
+    ngx_http_lua_main_conf_t    *lmcf;
+    ngx_cycle_t                 *cycle;
+    ngx_shm_zone_t               zone;
+} ngx_http_lua_shm_zone_ctx_t;
 
 
 ngx_int_t ngx_http_lua_shdict_init_zone(ngx_shm_zone_t *shm_zone, void *data);

--- a/src/ngx_http_lua_shdict.h
+++ b/src/ngx_http_lua_shdict.h
@@ -13,12 +13,11 @@
 
 typedef struct {
     u_char                       color;
-    u_char                       dummy;
-    u_short                      key_len;
-    ngx_queue_t                  queue;
-    uint64_t                     expires;
     uint8_t                      value_type;
+    u_short                      key_len;
     uint32_t                     value_len;
+    uint64_t                     expires;
+    ngx_queue_t                  queue;
     uint32_t                     user_flags;
     u_char                       data[1];
 } ngx_http_lua_shdict_node_t;

--- a/t/023-rewrite/tcp-socket.t
+++ b/t/023-rewrite/tcp-socket.t
@@ -446,7 +446,7 @@ attempt to send data on a closed socket
 --- request
 GET /t
 --- response_body_like
-^failed to connect: blah-blah-not-found\.agentzh\.org could not be resolved(?: \(\d+: Operation timed out\))?
+^failed to connect: blah-blah-not-found\.agentzh\.org could not be resolved(?: \(\d+: (?:Operation timed out|Host not found)\))?
 connected: nil
 failed to send request: closed$
 --- error_log

--- a/t/023-rewrite/uthread-exit.t
+++ b/t/023-rewrite/uthread-exit.t
@@ -521,7 +521,7 @@ after
             ngx.say("after")
             local sock = ngx.socket.tcp()
             sock:settimeout(12000)
-            local ok, err = sock:connect("106.187.41.147", 12345)
+            local ok, err = sock:connect("106.184.1.99", 12345)
             if not ok then
                 ngx.say("failed to connect: ", err)
                 return

--- a/t/024-access/uthread-exit.t
+++ b/t/024-access/uthread-exit.t
@@ -502,7 +502,7 @@ after
             ngx.say("after")
             local sock = ngx.socket.tcp()
             sock:settimeout(12000)
-            local ok, err = sock:connect("106.187.41.147", 12345)
+            local ok, err = sock:connect("106.184.1.99", 12345)
             if not ok then
                 ngx.say("failed to connect: ", err)
                 return

--- a/t/028-req-header.t
+++ b/t/028-req-header.t
@@ -8,7 +8,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (2 * blocks() + 30);
+plan tests => repeat_each() * (2 * blocks() + 31);
 
 #no_diff();
 #no_long_string();
@@ -1622,3 +1622,24 @@ ok
 --- no_error_log
 [error]
 --- no_check_leak
+
+
+
+=== TEST 54: for bad requests causing segfaults when setting & getting multi-value headers
+--- config
+    error_page 400 = /err;
+
+    location = /err {
+        content_by_lua_block {
+            ngx.req.set_header("Cookie", "foo=bar")
+            local test = ngx.var.cookie_bar
+
+            ngx.say("ok")
+        }
+    }
+--- raw_request
+GeT / HTTP/1.1
+--- response_body
+ok
+--- no_error_log
+[error]

--- a/t/028-req-header.t
+++ b/t/028-req-header.t
@@ -1643,3 +1643,4 @@ GeT / HTTP/1.1
 ok
 --- no_error_log
 [error]
+--- no_check_leak

--- a/t/043-shdict.t
+++ b/t/043-shdict.t
@@ -7,7 +7,7 @@ use Test::Nginx::Socket::Lua;
 
 #repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 3 + 18);
+plan tests => repeat_each() * (blocks() * 3 + 17);
 
 #no_diff();
 no_long_string();
@@ -2448,3 +2448,26 @@ GET /test
 --- error_code: 500
 --- error_log
 bad "exptime" argument
+
+
+
+=== TEST 93: duplicate zones
+--- http_config
+    lua_shared_dict dogs 1m;
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua '
+            local dogs = ngx.shared.dogs
+            ngx.say("error")
+        ';
+    }
+--- request
+    GET /test
+--- request_body_unlike
+error
+--- must_die
+--- error_log
+lua_shared_dict "dogs" is already defined as "dogs"
+--- error_log
+[emerg]

--- a/t/043-shdict.t
+++ b/t/043-shdict.t
@@ -585,7 +585,7 @@ hello, world
 --- request
 GET /test
 --- response_body_like
-^true nil true\nabort at (?:139|140)$
+^true nil true\nabort at (?:141|140)$
 --- no_error_log
 [error]
 

--- a/t/062-count.t
+++ b/t/062-count.t
@@ -259,7 +259,7 @@ n = 10
 POST /test
 hello world
 --- response_body
-n = 4
+n = 5
 --- no_error_log
 [error]
 
@@ -491,6 +491,6 @@ n = 6
 --- request
 GET /test
 --- response_body
-n = 5
+n = 6
 --- no_error_log
 [error]

--- a/t/094-uthread-exit.t
+++ b/t/094-uthread-exit.t
@@ -501,7 +501,7 @@ after
             ngx.say("after")
             local sock = ngx.socket.tcp()
             sock:settimeout(12000)
-            local ok, err = sock:connect("106.187.41.147", 12345)
+            local ok, err = sock:connect("106.184.1.99", 12345)
             if not ok then
                 ngx.say("failed to connect: ", err)
                 return

--- a/t/128-duplex-tcp-socket.t
+++ b/t/128-duplex-tcp-socket.t
@@ -357,7 +357,7 @@ F(ngx_http_lua_socket_tcp_finalize_write_part) {
 --- config
     server_tokens off;
     lua_socket_log_errors off;
-    resolver $TEST_NGINX_RESOLVER;
+    resolver $TEST_NGINX_RESOLVER ipv6=off;
     location /t {
         content_by_lua '
             local sock = ngx.socket.tcp()
@@ -390,7 +390,7 @@ F(ngx_http_lua_socket_tcp_finalize_write_part) {
             end
 
             sock:settimeout(300)
-            local ok, err = sock:connect("106.187.41.147", 12345)
+            local ok, err = sock:connect("106.184.1.99", 12345)
             ngx.say("connect: ", ok, " ", err)
 
             local ok, err = sock:close()

--- a/t/146-malloc-trim.t
+++ b/t/146-malloc-trim.t
@@ -1,0 +1,337 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua;
+
+#worker_connections(1014);
+#master_process_enabled(1);
+#log_level('warn');
+
+#repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 4 + 3);
+
+#no_diff();
+no_long_string();
+#master_on();
+#workers(2);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: malloc_trim() every 1 req, in subreq
+--- http_config
+    lua_malloc_trim 1;
+--- config
+    location = /t {
+        return 200 "ok\n";
+    }
+
+    location = /main {
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+    }
+--- request
+GET /main
+--- response_body
+ok
+ok
+ok
+ok
+ok
+--- grep_error_log eval: qr/malloc_trim\(\d+\) returned \d+/
+--- grep_error_log_out
+malloc_trim(1) returned 0
+--- wait: 0.2
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: malloc_trim() every 1 req, in subreq
+--- http_config
+    lua_malloc_trim 1;
+--- config
+    location = /t {
+        log_subrequest on;
+        return 200 "ok\n";
+    }
+
+    location = /main {
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+    }
+--- request
+GET /main
+--- response_body
+ok
+ok
+ok
+ok
+ok
+--- grep_error_log eval: qr/malloc_trim\(\d+\) returned \d+/
+--- grep_error_log_out
+malloc_trim(1) returned 0
+malloc_trim(1) returned 0
+malloc_trim(1) returned 0
+malloc_trim(1) returned 0
+malloc_trim(1) returned 0
+malloc_trim(1) returned 0
+--- wait: 0.2
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: malloc_trim() every 2 req, in subreq
+--- http_config
+    lua_malloc_trim 2;
+--- config
+    location = /t {
+        log_subrequest on;
+        return 200 "ok\n";
+    }
+
+    location = /main {
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+    }
+--- request
+GET /main
+--- response_body
+ok
+ok
+ok
+ok
+ok
+--- grep_error_log eval: qr/malloc_trim\(\d+\) returned \d+/
+--- grep_error_log_out
+malloc_trim(1) returned 0
+malloc_trim(1) returned 0
+malloc_trim(1) returned 0
+--- wait: 0.2
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: malloc_trim() every 3 req, in subreq
+--- http_config
+    lua_malloc_trim 3;
+--- config
+    location = /t {
+        log_subrequest on;
+        return 200 "ok\n";
+    }
+
+    location = /main {
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+    }
+--- request
+GET /main
+--- response_body
+ok
+ok
+ok
+ok
+ok
+--- grep_error_log eval: qr/malloc_trim\(\d+\) returned \d+/
+--- grep_error_log_out
+malloc_trim(1) returned 0
+malloc_trim(1) returned 0
+--- wait: 0.2
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: malloc_trim() every 2 req, in subreq, big memory usage
+--- http_config
+    lua_malloc_trim 2;
+    lua_package_path "$prefix/html/?.lua;;";
+--- config
+    location = /t {
+        log_subrequest on;
+        content_by_lua_block {
+            require("foo")()
+        }
+    }
+
+    location = /main {
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+    }
+--- user_files
+>>> foo.lua
+local ffi = require "ffi"
+
+ffi.cdef[[
+    void *malloc(size_t sz);
+    void free(void *p);
+]]
+
+return function ()
+    local t = {}
+    for i = 1, 10 do
+        t[i] = ffi.C.malloc(1024 * 128)
+    end
+    for i = 1, 10 do
+        ffi.C.free(t[i])
+    end
+    ngx.say("ok")
+end
+--- request
+GET /main
+--- response_body
+ok
+ok
+ok
+ok
+ok
+--- grep_error_log eval: qr/malloc_trim\(\d+\) returned \d+/
+--- grep_error_log_out
+malloc_trim(1) returned 1
+malloc_trim(1) returned 1
+malloc_trim(1) returned 1
+--- wait: 0.2
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: zero count means off
+--- http_config
+    lua_malloc_trim 0;
+    lua_package_path "$prefix/html/?.lua;;";
+--- config
+    location = /t {
+        content_by_lua_block {
+            require("foo")()
+        }
+    }
+--- user_files
+>>> foo.lua
+local ffi = require "ffi"
+
+ffi.cdef[[
+    void *malloc(size_t sz);
+    void free(void *p);
+]]
+
+return function ()
+    local t = {}
+    for i = 1, 10 do
+        t[i] = ffi.C.malloc(1024 * 128)
+    end
+    for i = 1, 10 do
+        ffi.C.free(t[i])
+    end
+    ngx.say("ok")
+end
+
+--- request
+GET /t
+--- response_body
+ok
+--- grep_error_log eval: qr/malloc_trim\(\d+\) returned \d+/
+--- grep_error_log_out
+--- wait: 0.2
+--- no_error_log
+malloc_trim() disabled
+[error]
+
+
+
+=== TEST 7: zero count means off, log_by_lua
+--- http_config
+    lua_malloc_trim 0;
+    lua_package_path "$prefix/html/?.lua;;";
+--- config
+    location = /t {
+        content_by_lua_block {
+            require("foo")()
+        }
+        log_by_lua_block {
+            print("Hello from log")
+        }
+    }
+--- user_files
+>>> foo.lua
+local ffi = require "ffi"
+
+ffi.cdef[[
+    void *malloc(size_t sz);
+    void free(void *p);
+]]
+
+return function ()
+    local t = {}
+    for i = 1, 10 do
+        t[i] = ffi.C.malloc(1024 * 128)
+    end
+    for i = 1, 10 do
+        ffi.C.free(t[i])
+    end
+    ngx.say("ok")
+end
+
+--- request
+GET /t
+--- response_body
+ok
+--- grep_error_log eval: qr/malloc_trim\(\d+\) returned \d+/
+--- grep_error_log_out
+--- wait: 0.2
+--- error_log
+Hello from log
+malloc_trim() disabled
+--- no_error_log
+[error]
+
+
+
+=== TEST 8: malloc_trim() every 1 req
+--- http_config
+    lua_malloc_trim 1;
+--- config
+    location = /t {
+        return 200 "ok\n";
+    }
+
+    location = /main {
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+    }
+--- request
+GET /main
+--- response_body
+ok
+ok
+ok
+ok
+ok
+--- grep_error_log eval: qr/malloc_trim\(\d+\) returned \d+/
+--- grep_error_log_out
+malloc_trim(1) returned 0
+--- wait: 0.2
+--- no_error_log
+[error]

--- a/t/147-tcp-socket-timeouts.t
+++ b/t/147-tcp-socket-timeouts.t
@@ -1,0 +1,516 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua;
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 3 + 1);
+
+$ENV{TEST_NGINX_RESOLVER} ||= '8.8.8.8';
+
+#log_level 'warn';
+log_level 'debug';
+
+no_long_string();
+#no_diff();
+run_tests();
+
+__DATA__
+
+=== TEST 1: sanity
+--- config
+    server_tokens off;
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+
+            sock:settimeouts(150, 150, 150)  -- 150ms read timeout
+
+            local port = ngx.var.server_port
+            local ok, err = sock:connect("127.0.0.1", port)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            local req = "GET /foo HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send request: ", err)
+                return
+            end
+
+            while true do
+                local line, err, part = sock:receive()
+                if line then
+                    ngx.say("received: ", line)
+
+                else
+                    ngx.say("failed to receive a line: ", err, " [", part, "]")
+                    break
+                end
+            end
+
+            sock:close()
+        }
+    }
+
+    location /foo {
+        content_by_lua_block {
+            ngx.sleep(0.01) -- 10 ms
+            ngx.say("foo")
+        }
+        more_clear_headers Date;
+    }
+
+--- request
+GET /t
+--- response_body_like
+received: foo
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: read timeout
+--- config
+    server_tokens off;
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+
+            sock:settimeouts(150, 150, 2)  -- 2ms read timeout
+
+            local port = ngx.var.server_port
+            local ok, err = sock:connect("127.0.0.1", port)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            local req = "GET /foo HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send request: ", err)
+                return
+            end
+
+            while true do
+                local line, err, part = sock:receive()
+                if line then
+                    ngx.say("received: ", line)
+
+                else
+                    ngx.say("failed to receive a line: ", err, " [", part, "]")
+                    break
+                end
+            end
+
+            sock:close()
+        }
+    }
+
+    location /foo {
+        content_by_lua_block {
+            ngx.sleep(0.01) -- 10 ms
+            ngx.say("foo")
+        }
+        more_clear_headers Date;
+    }
+
+--- request
+GET /t
+--- response_body_like
+failed to receive a line: timeout \[\]
+--- error_log
+lua tcp socket read timed out
+
+
+
+=== TEST 3: send ok
+--- config
+    server_tokens off;
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+
+            sock:settimeouts(500, 500, 500)  -- 500ms timeout
+
+            local port = ngx.var.server_port
+            local ok, err = sock:connect("127.0.0.1", port)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            local data = string.rep("a", 8096) -- 8k
+            local num = 1024 -- total: 8M
+
+            local req = "POST /foo HTTP/1.0\r\nHost: localhost\r\nContent-Length: "
+                        .. #data * num .. "\r\nConnection: close\r\n\r\n"
+
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send request: ", err)
+                return
+            end
+
+            for i = 1, num do
+                local bytes, err = sock:send(data)
+                if not bytes then
+                    ngx.say("failed to send body: ", err)
+                    return
+                end
+            end
+
+            while true do
+                local line, err, part = sock:receive()
+                if line then
+                    ngx.say("received: ", line)
+
+                else
+                    ngx.say("failed to receive a line: ", err, " [", part, "]")
+                    break
+                end
+            end
+
+            sock:close()
+        }
+    }
+
+    location /foo {
+        content_by_lua_block {
+            local content_length = ngx.req.get_headers()["Content-Length"]
+
+            local sock = ngx.req.socket()
+
+            sock:settimeouts(500, 500, 500)
+
+            local chunk = 8096
+
+            for i = 1, content_length, chunk do
+                local data, err = sock:receive(chunk)
+                if not data then
+                    ngx.say("failed to receive chunk: ", err)
+                    return
+                end
+            end
+
+            ngx.say("got len: ", content_length)
+        }
+    }
+
+--- request
+GET /t
+--- response_body_like
+received: got len: 8290304
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: send timeout
+--- config
+    server_tokens off;
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+
+            sock:settimeouts(500, 500, 500)  -- 500ms timeout
+
+            local port = ngx.var.server_port
+            local ok, err = sock:connect("127.0.0.1", port)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            local data = string.rep("a", 8096) -- 8k
+            local num = 1024 -- total: 8M
+
+            local req = "POST /foo HTTP/1.0\r\nHost: localhost\r\nContent-Length: "
+                        .. #data * num .. "\r\nConnection: close\r\n\r\n"
+
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send request: ", err)
+                return
+            end
+
+            for i = 1, num do
+                local bytes, err = sock:send(data)
+                if not bytes then
+                    ngx.say("failed to send body: ", err)
+                    return
+                end
+            end
+
+            while true do
+                local line, err, part = sock:receive()
+                if line then
+                    ngx.say("received: ", line)
+
+                else
+                    ngx.say("failed to receive a line: ", err, " [", part, "]")
+                    break
+                end
+            end
+
+            sock:close()
+        }
+    }
+
+    location /foo {
+        content_by_lua_block {
+            local content_length = ngx.req.get_headers()["Content-Length"]
+
+            local sock = ngx.req.socket()
+
+            ngx.sleep(1)
+
+            sock:settimeouts(500, 500, 500)
+
+            local chunk = 8096
+
+            for i = 1, content_length, chunk do
+                local data, err = sock:receive(chunk)
+                if not data then
+                    ngx.say("failed to receive chunk: ", err)
+                    return
+                end
+            end
+
+            ngx.say("got len: ", content_length)
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+failed to send body: timeout
+--- error_log
+lua tcp socket write timed out
+
+
+
+=== TEST 5: connection timeout (tcp)
+--- config
+    resolver $TEST_NGINX_RESOLVER;
+    resolver_timeout 3s;
+    location /test {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+
+            sock:settimeouts(100, 100, 100)
+
+            local ok, err = sock:connect("agentzh.org", 12345)
+            ngx.say("connect: ", ok, " ", err)
+
+            local bytes
+            bytes, err = sock:send("hello")
+            ngx.say("send: ", bytes, " ", err)
+
+            local line
+            line, err = sock:receive()
+            ngx.say("receive: ", line, " ", err)
+
+            ok, err = sock:close()
+            ngx.say("close: ", ok, " ", err)
+        }
+    }
+--- request
+    GET /test
+--- response_body
+connect: nil timeout
+send: nil closed
+receive: nil closed
+close: nil closed
+--- error_log
+lua tcp socket connect timed out
+--- timeout: 10
+
+
+
+=== TEST 6: different timeout with duplex socket (settimeout)
+--- config
+    server_tokens off;
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+
+            sock:settimeouts(100, 100, 100)  -- 100ms timeout
+
+            local port = ngx.var.server_port
+            local ok, err = sock:connect("127.0.0.1", port)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            local data = string.rep("a", 4048) -- 4k
+            local num = 3
+
+            local req = "POST /foo HTTP/1.0\r\nHost: localhost\r\nContent-Length: "
+                        .. #data * num .. "\r\nConnection: close\r\n\r\n"
+
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send request: ", err)
+                return
+            end
+
+            for i = 1, num do
+                local bytes, err = sock:send(data)
+                if not bytes then
+                    ngx.log(ngx.ERR, "failed to send body: ", err)
+                    return
+                end
+                ngx.sleep(0.08) -- 20ms
+            end
+
+            while true do
+                local line, err, part = sock:receive()
+                if line then
+                    ngx.say("received: ", line)
+
+                else
+                    ngx.say("failed to receive a line: ", err, " [", part, "]")
+                    break
+                end
+            end
+
+            sock:close()
+        }
+    }
+
+    location /foo {
+        content_by_lua_block {
+            local content_length = ngx.req.get_headers()["Content-Length"]
+
+            local sock = ngx.req.socket(true)
+
+            local chunk = 4048
+
+            function read()
+                sock:settimeout(200) -- read: 200 ms
+
+                local data, err = sock:receive(content_length)
+                if not data then
+                    ngx.log(ngx.ERR, "failed to receive data: ", err)
+                    return
+                end
+            end
+
+            local co = ngx.thread.spawn(read)
+
+            sock:settimeout(10) -- send: 10ms
+            sock:send("ok\n")
+
+            local ok, err = ngx.thread.wait(co)
+            if not ok then
+                ngx.log(ngx.ERR, "failed to wait co: ", err)
+            end
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+received: ok
+failed to receive a line: closed []
+--- error_log
+lua tcp socket read timed out
+failed to receive data: timeout
+
+
+
+=== TEST 7: different timeout with duplex socket (settimeouts)
+--- config
+    server_tokens off;
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+
+            sock:settimeouts(100, 100, 100)  -- 100ms timeout
+
+            local port = ngx.var.server_port
+            local ok, err = sock:connect("127.0.0.1", port)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            local data = string.rep("a", 4048) -- 4k
+            local num = 3
+
+            local req = "POST /foo HTTP/1.0\r\nHost: localhost\r\nContent-Length: "
+                        .. #data * num .. "\r\nConnection: close\r\n\r\n"
+
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send request: ", err)
+                return
+            end
+
+            for i = 1, num do
+                local bytes, err = sock:send(data)
+                if not bytes then
+                    ngx.log(ngx.ERR, "failed to send body: ", err)
+                    return
+                end
+                ngx.sleep(0.08) -- 20ms
+            end
+
+            while true do
+                local line, err, part = sock:receive()
+                if line then
+                    ngx.say("received: ", line)
+
+                else
+                    ngx.say("failed to receive a line: ", err, " [", part, "]")
+                    break
+                end
+            end
+
+            sock:close()
+        }
+    }
+
+    location /foo {
+        content_by_lua_block {
+            local content_length = ngx.req.get_headers()["Content-Length"]
+
+            local sock = ngx.req.socket(true)
+
+            sock:settimeouts(0, 10, 200) -- send: 10ms, read: 200ms
+
+            local chunk = 4048
+
+            function read()
+                local data, err = sock:receive(content_length)
+                if not data then
+                    ngx.log(ngx.ERR, "failed to receive data: ", err)
+                    return
+                end
+            end
+
+            local co = ngx.thread.spawn(read)
+
+            sock:send("ok\n")
+
+            local ok, err = ngx.thread.wait(co)
+            if not ok then
+                ngx.log(ngx.ERR, "failed to wait co: ", err)
+            end
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+received: ok
+failed to receive a line: closed []
+--- no_error_log
+[error]

--- a/t/148-fake-shm-zone.t
+++ b/t/148-fake-shm-zone.t
@@ -1,0 +1,170 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use lib 'lib';
+use Test::Nginx::Socket::Lua;
+
+#worker_connections(1014);
+#master_process_enabled(1);
+#log_level('warn');
+
+#repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 3 - 1);
+
+#no_diff();
+no_long_string();
+#master_on();
+#workers(2);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: require test
+--- http_config
+    lua_fake_shm x1 1m;
+    lua_fake_shm x2 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local shm_zones = require("fake_shm_zones")
+            ngx.say(type(shm_zones))
+            local x1 = shm_zones.x1
+            ngx.say(type(x1))
+            local x2 = shm_zones.x2
+            ngx.say(type(x1))
+        }
+    }
+--- request
+GET /test
+--- response_body
+table
+table
+table
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: index shm_zone
+--- http_config
+    lua_fake_shm x1 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local shm_zones = require("fake_shm_zones")
+            local x1 = shm_zones.x1
+            ngx.say(type(x1))
+        }
+    }
+--- request
+GET /test
+--- response_body
+table
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: get_info
+--- http_config
+    lua_fake_shm x1 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local shm_zones = require("fake_shm_zones")
+            local name, size, isinit, isold
+            local x1 = shm_zones.x1
+
+            name, size, isinit, isold = x1:get_info()
+            ngx.say("name=", name)
+            ngx.say("size=", size)
+            ngx.say("isinit=", isinit)
+            ngx.say("isold=", isold)
+        }
+    }
+--- request
+GET /test
+--- response_body
+name=x1
+size=1048576
+isinit=true
+isold=false
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: multiply zones
+--- http_config
+    lua_fake_shm x1 1m;
+    lua_fake_shm x2 2m;
+    lua_fake_shm x3 3m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local shm_zones = require("fake_shm_zones")
+            local name, size, isinit, isold
+            local x1 = shm_zones.x1
+            local x2 = shm_zones.x2
+            local x3 = shm_zones.x3
+
+            name, size, isinit, isold = x1:get_info()
+            ngx.say("name=", name)
+            ngx.say("size=", size)
+            ngx.say("isinit=", isinit)
+            ngx.say("isold=", isold)
+
+            name, size, isinit, isold = x2:get_info()
+            ngx.say("name=", name)
+            ngx.say("size=", size)
+            ngx.say("isinit=", isinit)
+            ngx.say("isold=", isold)
+
+            name, size, isinit, isold = x3:get_info()
+            ngx.say("name=", name)
+            ngx.say("size=", size)
+            ngx.say("isinit=", isinit)
+            ngx.say("isold=", isold)
+        }
+    }
+--- request
+GET /test
+--- response_body
+name=x1
+size=1048576
+isinit=true
+isold=false
+name=x2
+size=2097152
+isinit=true
+isold=false
+name=x3
+size=3145728
+isinit=true
+isold=false
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: duplicate zones
+--- http_config
+    lua_fake_shm x1 1m;
+    lua_fake_shm x1 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local shm_zones = require("fake_shm_zones")
+            local x1 = shm_zones.x1
+            ngx.say("error")
+        }
+    }
+--- request
+GET /test
+--- request_body_unlike
+error
+--- must_die
+--- error_log
+lua_fake_shm "x1" is already defined as "x1"
+--- error_log
+[emerg]

--- a/t/149-hup-fake-shm-zone.t
+++ b/t/149-hup-fake-shm-zone.t
@@ -1,0 +1,91 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+our $SkipReason;
+
+BEGIN {
+    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
+        $SkipReason = "unavailable for the hup tests";
+
+    } else {
+        $ENV{TEST_NGINX_USE_HUP} = 1;
+        undef $ENV{TEST_NGINX_USE_STAP};
+    }
+}
+
+use lib 'lib';
+use Test::Nginx::Socket::Lua $SkipReason ? (skip_all => $SkipReason) : ();
+
+#worker_connections(1014);
+#master_process_enabled(1);
+#log_level('warn');
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 3);
+
+#no_diff();
+no_long_string();
+#master_on();
+#workers(2);
+
+no_shuffle();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: get_info, before HUP reload
+--- http_config
+    lua_fake_shm x1 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local shm_zones = require("fake_shm_zones")
+            local name, size, isinit, isold
+            local x1 = shm_zones.x1
+
+            name, size, isinit, isold = x1:get_info()
+            ngx.say("name=", name)
+            ngx.say("size=", size)
+            ngx.say("isinit=", isinit)
+            ngx.say("isold=", isold)
+        }
+    }
+--- request
+GET /test
+--- response_body
+name=x1
+size=1048576
+isinit=true
+isold=false
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: get_info, after HUP reload
+--- http_config
+    lua_fake_shm x1 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local shm_zones = require("fake_shm_zones")
+            local name, size, isinit, isold
+            local x1 = shm_zones.x1
+
+            name, size, isinit, isold = x1:get_info()
+            ngx.say("name=", name)
+            ngx.say("size=", size)
+            ngx.say("isinit=", isinit)
+            ngx.say("isold=", isold)
+        }
+    }
+--- request
+GET /test
+--- response_body
+name=x1
+size=1048576
+isinit=true
+isold=true
+--- no_error_log
+[error]

--- a/t/data/fake-shm-module/config
+++ b/t/data/fake-shm-module/config
@@ -1,0 +1,3 @@
+ngx_addon_name=ngx_http_lua_shm_fake_module
+HTTP_MODULES="$HTTP_MODULES ngx_http_lua_fake_shm_module"
+NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_lua_fake_shm_module.c"

--- a/t/data/fake-shm-module/ngx_http_lua_fake_shm_module.c
+++ b/t/data/fake-shm-module/ngx_http_lua_fake_shm_module.c
@@ -1,0 +1,294 @@
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+#include <nginx.h>
+
+
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
+
+
+#include "ngx_http_lua_api.h"
+
+
+static void *ngx_http_lua_fake_shm_create_main_conf(ngx_conf_t *cf);
+static ngx_int_t ngx_http_lua_fake_shm_init(ngx_conf_t *cf);
+
+static char *ngx_http_lua_fake_shm(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+static ngx_int_t ngx_http_lua_fake_shm_init_zone(ngx_shm_zone_t *shm_zone,
+    void *data);
+static int ngx_http_lua_fake_shm_preload(lua_State *L);
+static int ngx_http_lua_fake_shm_get_info(lua_State *L);
+
+
+typedef struct {
+    ngx_array_t     *shm_zones;
+} ngx_http_lua_fake_shm_main_conf_t;
+
+
+static ngx_command_t ngx_http_lua_fake_shm_cmds[] = {
+
+    { ngx_string("lua_fake_shm"),
+      NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE2,
+      ngx_http_lua_fake_shm,
+      0,
+      0,
+      NULL },
+
+    ngx_null_command
+};
+
+
+static ngx_http_module_t  ngx_http_lua_fake_shm_module_ctx = {
+    NULL,                                   /* preconfiguration */
+    ngx_http_lua_fake_shm_init,             /* postconfiguration */
+
+    ngx_http_lua_fake_shm_create_main_conf, /* create main configuration */
+    NULL,                                   /* init main configuration */
+
+    NULL,                                   /* create server configuration */
+    NULL,                                   /* merge server configuration */
+
+    NULL,                                   /* create location configuration */
+    NULL,                                   /* merge location configuration */
+};
+
+
+ngx_module_t  ngx_http_lua_fake_shm_module = {
+    NGX_MODULE_V1,
+    &ngx_http_lua_fake_shm_module_ctx, /* module context */
+    ngx_http_lua_fake_shm_cmds,        /* module directives */
+    NGX_HTTP_MODULE,                   /* module type */
+    NULL,                              /* init master */
+    NULL,                              /* init module */
+    NULL,                              /* init process */
+    NULL,                              /* init thread */
+    NULL,                              /* exit thread */
+    NULL,                              /* exit process */
+    NULL,                              /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+
+typedef struct {
+    ngx_str_t   name;
+    size_t      size;
+    ngx_int_t   isold;
+    ngx_int_t   isinit;
+} ngx_http_lua_fake_shm_ctx_t;
+
+
+static void *
+ngx_http_lua_fake_shm_create_main_conf(ngx_conf_t *cf)
+{
+    ngx_http_lua_fake_shm_main_conf_t *lfsmcf;
+
+    lfsmcf = ngx_pcalloc(cf->pool, sizeof(*lfsmcf));
+    if (lfsmcf == NULL) {
+        return NULL;
+    }
+
+    return lfsmcf;
+}
+
+
+static char *
+ngx_http_lua_fake_shm(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_http_lua_fake_shm_main_conf_t   *lfsmcf = conf;
+
+    ngx_str_t                   *value, name;
+    ngx_shm_zone_t              *zone;
+    ngx_shm_zone_t             **zp;
+    ngx_http_lua_fake_shm_ctx_t *ctx;
+    ssize_t                      size;
+
+    if (lfsmcf->shm_zones == NULL) {
+        lfsmcf->shm_zones = ngx_palloc(cf->pool, sizeof(ngx_array_t));
+        if (lfsmcf->shm_zones == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        if (ngx_array_init(lfsmcf->shm_zones, cf->pool, 2,
+                           sizeof(ngx_shm_zone_t *))
+            != NGX_OK)
+        {
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    value = cf->args->elts;
+
+    ctx = NULL;
+
+    if (value[1].len == 0) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "invalid lua fake_shm name \"%V\"", &value[1]);
+        return NGX_CONF_ERROR;
+    }
+
+    name = value[1];
+
+    size = ngx_parse_size(&value[2]);
+
+    if (size <= 8191) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "invalid lua fake_shm size \"%V\"", &value[2]);
+        return NGX_CONF_ERROR;
+    }
+
+    ctx = ngx_pcalloc(cf->pool, sizeof(ngx_http_lua_fake_shm_ctx_t));
+    if (ctx == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    ctx->name = name;
+    ctx->size = size;
+
+    zone = ngx_http_lua_shared_memory_add(cf, &name, (size_t) size,
+                                          &ngx_http_lua_fake_shm_module);
+    if (zone == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    if (zone->data) {
+        ctx = zone->data;
+
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "lua_fake_shm \"%V\" is already defined as "
+                           "\"%V\"", &name, &ctx->name);
+        return NGX_CONF_ERROR;
+    }
+
+    zone->init = ngx_http_lua_fake_shm_init_zone;
+    zone->data = ctx;
+
+    zp = ngx_array_push(lfsmcf->shm_zones);
+    if (zp == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    *zp = zone;
+
+    return NGX_CONF_OK;
+}
+
+
+static ngx_int_t
+ngx_http_lua_fake_shm_init_zone(ngx_shm_zone_t *shm_zone, void *data)
+{
+    ngx_http_lua_fake_shm_ctx_t  *octx = data;
+
+    ngx_http_lua_fake_shm_ctx_t  *ctx;
+
+    ctx = shm_zone->data;
+
+    if (octx) {
+        ctx->isold = 1;
+    }
+
+    ctx->isinit = 1;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_lua_fake_shm_init(ngx_conf_t *cf)
+{
+    ngx_http_lua_add_package_preload(cf, "fake_shm_zones",
+                                     ngx_http_lua_fake_shm_preload);
+    return NGX_OK;
+}
+
+
+static int
+ngx_http_lua_fake_shm_preload(lua_State *L)
+{
+    ngx_http_lua_fake_shm_main_conf_t *lfsmcf;
+    ngx_http_conf_ctx_t               *hmcf_ctx;
+    ngx_cycle_t                       *cycle;
+
+    ngx_uint_t                   i;
+    ngx_shm_zone_t             **zone;
+
+    lua_getglobal(L, "__ngx_cycle");
+    cycle = lua_touserdata(L, -1);
+    lua_pop(L, 1);
+
+    hmcf_ctx = (ngx_http_conf_ctx_t *) cycle->conf_ctx[ngx_http_module.index];
+    lfsmcf = hmcf_ctx->main_conf[ngx_http_lua_fake_shm_module.ctx_index];
+
+    if (lfsmcf->shm_zones != NULL) {
+        lua_createtable(L, 0, lfsmcf->shm_zones->nelts /* nrec */);
+
+        lua_createtable(L, 0 /* narr */, 2 /* nrec */); /* shared mt */
+
+        lua_pushcfunction(L, ngx_http_lua_fake_shm_get_info);
+        lua_setfield(L, -2, "get_info");
+
+        lua_pushvalue(L, -1); /* shared mt mt */
+        lua_setfield(L, -2, "__index"); /* shared mt */
+
+        zone = lfsmcf->shm_zones->elts;
+
+        for (i = 0; i < lfsmcf->shm_zones->nelts; i++) {
+            lua_pushlstring(L, (char *) zone[i]->shm.name.data,
+                            zone[i]->shm.name.len);
+
+            /* shared mt key */
+
+            lua_createtable(L, 1 /* narr */, 0 /* nrec */);
+                /* table of zone[i] */
+            lua_pushlightuserdata(L, zone[i]); /* shared mt key ud */
+            lua_rawseti(L, -2, 1); /* {zone[i]} */
+            lua_pushvalue(L, -3); /* shared mt key ud mt */
+            lua_setmetatable(L, -2); /* shared mt key ud */
+            lua_rawset(L, -4); /* shared mt */
+        }
+
+        lua_pop(L, 1); /* shared */
+
+    } else {
+        lua_newtable(L);    /* ngx.shared */
+    }
+
+    return 1;
+}
+
+
+static int
+ngx_http_lua_fake_shm_get_info(lua_State *L)
+{
+    ngx_int_t                    n;
+    ngx_shm_zone_t              *zone;
+    ngx_http_lua_fake_shm_ctx_t *ctx;
+
+    n = lua_gettop(L);
+
+    if (n != 1) {
+        return luaL_error(L, "expecting exactly one arguments, "
+                          "but only seen %d", n);
+    }
+
+    luaL_checktype(L, 1, LUA_TTABLE);
+
+    lua_rawgeti(L, 1, 1);
+    zone = lua_touserdata(L, -1);
+    lua_pop(L, 1);
+
+    if (zone == NULL) {
+        return luaL_error(L, "bad \"zone\" argument");
+    }
+
+    ctx = (ngx_http_lua_fake_shm_ctx_t *) zone->data;
+
+    lua_pushlstring(L, (char *) zone->shm.name.data, zone->shm.name.len);
+    lua_pushnumber(L, zone->shm.size);
+    lua_pushboolean(L, ctx->isinit);
+    lua_pushboolean(L, ctx->isold);
+
+    return 4;
+}

--- a/util/build.sh
+++ b/util/build.sh
@@ -51,6 +51,7 @@ time ngx-build $force $version \
                 --add-module=$root/../coolkit-nginx-module \
                 --add-module=$root/../redis2-nginx-module \
                 --add-module=$root/t/data/fake-module \
+                --add-module=$root/t/data/fake-shm-module \
                 --with-http_gunzip_module \
                 --with-http_dav_module \
           --with-select_module \


### PR DESCRIPTION
  Retry count would exceed the limit of proxty_next_upstream_tries when set_more_tries is called more than once in balancer_by_lua.

For example, the following config

```
daemon off;
master_process off;


events {
    worker_connections  1024;
}

http {
    lua_package_path "/usr/local/nginx/lua-resty-core/lib/?.lua;;";
    upstream backend {
        server 1.1.1.1:8080;
        balancer_by_lua_block {
            local balancer = require "ngx.balancer"
            balancer.set_more_tries(2)
            balancer.set_current_peer('127.0.0.1', '8080')
        }
    }

    server {
        listen      80;


        location / {
            proxy_pass http://backend;
            proxy_next_upstream_tries 5;
        }
    }
}
```

 As discribed in the maillist [https://groups.google.com/forum/#!topic/openresty/01LLxA4f4bk](https://groups.google.com/forum/#!topic/openresty/01LLxA4f4bk)
