### PR TITLE
Added ngx.resp.set_status_reason function to set a custom reason phrase

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2985,6 +2985,7 @@ Nginx API for Lua
 * [ngx.status](#ngxstatus)
 * [ngx.header.HEADER](#ngxheaderheader)
 * [ngx.resp.get_headers](#ngxrespget_headers)
+* [ngx.resp.set_status_reason](#ngxrespset_status_reason)
 * [ngx.req.is_internal](#ngxreqis_internal)
 * [ngx.req.start_time](#ngxreqstart_time)
 * [ngx.req.http_version](#ngxreqhttp_version)
@@ -4043,6 +4044,24 @@ Returns a Lua table holding all the current response headers for the current req
 This function has the same signature as [ngx.req.get_headers](#ngxreqget_headers) except getting response headers instead of request headers.
 
 This API was first introduced in the `v0.9.5` release.
+
+[Back to TOC](#nginx-api-for-lua)
+
+ngx.resp.set_status_reason
+--------------------------
+**syntax:** *ngx.resp.set_status_reason(status_code, status_reason)*
+
+**context:** *set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;*
+
+Sets the full status line in the response, allowing you to customize the HTTP reason phrase. This is especially useful if you want to implement custom error codes that are unknown by the core nginx binary. This clears the previous status of the request.
+
+Calling `ngx.resp.set_status_reason` after the response header is sent out has no effect but leaving an error message in your nginx's error log file:
+
+
+    attempt to call ngx.resp.set_status_reason after sending out response headers
+
+
+Note that reason does not exist in HTTP/2.
 
 [Back to TOC](#nginx-api-for-lua)
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -3342,6 +3342,21 @@ This function has the same signature as [[#ngx.req.get_headers|ngx.req.get_heade
 
 This API was first introduced in the <code>v0.9.5</code> release.
 
+== ngx.resp.set_status_reason ==
+'''syntax:''' ''ngx.resp.set_status_reason(status_code, status_reason)''
+
+'''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*''
+
+Sets the full status line in the response, allowing you to customize the HTTP reason phrase. This is especially useful if you want to implement custom error codes that are unknown by the core nginx binary. This clears the previous status of the request.
+
+Calling <code>ngx.resp.set_status_reason</code> after the response header is sent out has no effect but leaving an error message in your nginx's error log file:
+
+<geshi lang="text">
+attempt to call ngx.resp.set_status_reason after sending out response headers
+</geshi>
+
+Note that reason does not exist in HTTP/2.
+
 == ngx.req.is_internal ==
 '''syntax:''' ''is_internal = ngx.req.is_internal()''
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

Allows to set the reason for HTTP status codes unknown from the nginx
core. Given the current implementation of nginx, it is safer and more
convenient to set the status at the same time.

Currently setting the status to an unknown response code causes the reason to be empty:

```
content_by_lua '
    ngx.status = 876
    ngx.say("custom response")
';
```

Causes the response to be:

```
< HTTP/1.1 876
< Date: Fri, 16 Sep 2016 20:06:33 GMT
< Content-Type: text/plain
< Transfer-Encoding: chunked
< Connection: keep-alive
<
custom response
```

The use cases can be to implement some of the error codes unknown from nignx (e.g. [RFC6585](https://tools.ietf.org/html/rfc6585)) or completely custom HTTP response codes.

There is still two open questions in my mind:
- Should we add an optional parameter in `ngx.exit` too?
- Do we add the `resty.core` wrapper now or in another PR?
