### PR TITLE
feature: add support for building with BoringSSL

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -1299,8 +1299,8 @@ ngx_http_lua_socket_tcp_sslhandshake(lua_State *L)
 
 #ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
 
-                if (SSL_set_tlsext_host_name(c->ssl->connection, name.data)
-                    == 0)
+                if (SSL_set_tlsext_host_name(c->ssl->connection, 
+                                             (const char *) name.data) == 0)
                 {
                     lua_pushnil(L);
                     lua_pushliteral(L, "SSL_set_tlsext_host_name failed");


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

This should work with OpenSSL as well, since they cast the argument back
to (char *) in the macro.

Note that since BoringSSL doesn't implement OCSP, the ngx_lua OCSP support
is disabled when building with BoringSSL.
