### PR TITLE
New directive lua_malloc_trim

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1002,6 +1002,7 @@ Directives
 ==========
 
 * [lua_use_default_type](#lua_use_default_type)
+* [lua_malloc_trim](#lua_malloc_trim)
 * [lua_code_cache](#lua_code_cache)
 * [lua_regex_cache_max_entries](#lua_regex_cache_max_entries)
 * [lua_regex_match_limit](#lua_regex_match_limit)
@@ -1086,6 +1087,31 @@ Specifies whether to use the MIME type specified by the [default_type](http://ng
 This directive is turned on by default.
 
 This directive was first introduced in the `v0.9.1` release.
+
+[Back to TOC](#directives)
+
+lua_malloc_trim
+---------------
+**syntax:** *lua_malloc_trim &lt;request-count&gt;*
+
+**default:** *lua_malloc_trim 1000*
+
+**context:** *http*
+
+Asks the underlying `libc` runtime library to release its cached free memory back to the operating system every
+`N` requests processed by the NGINX core. By default, `N` is 1000. You can configure the request count
+by using your own numbers. Smaller numbers mean more frequent releases, which may introduce higher CPU time consumption and
+smaller memory footprint while larger numbers usually lead to less CPU time overhead and relatively larger memory footprint.
+Just tune the number for your own use cases.
+
+Configuring the argument to `0` essentially turns off the periodical memory trimming altogether.
+
+The current implementation uses an NGINX log phase handler to do the request counting. So the appearance of the
+[log_subrequest on](http://nginx.org/en/docs/http/ngx_http_core_module.html#log_subrequest) directives in `nginx.conf`
+may make the counting faster when subrequests are involved. By default, only "main requests" count.
+
+Note that this directive does *not* affect the memory allocated by LuaJIT's own allocator based on the `mmap`
+system call.
 
 [Back to TOC](#directives)
 

--- a/config
+++ b/config
@@ -519,6 +519,24 @@ CC_TEST_FLAGS="-Werror -Wall $CC_TEST_FLAGS"
 
 CC_TEST_FLAGS="$SAVED_CC_TEST_FLAGS"
 
+# ----------------------------------------
+
+ngx_feature="malloc_trim"
+ngx_feature_libs=
+ngx_feature_name="NGX_HTTP_LUA_HAVE_MALLOC_TRIM"
+ngx_feature_run=yes
+ngx_feature_incs="#include <malloc.h>
+#include <stdio.h>"
+ngx_feature_test="int rc = malloc_trim((size_t) 0); printf(\"%d\", rc);"
+SAVED_CC_TEST_FLAGS="$CC_TEST_FLAGS"
+CC_TEST_FLAGS="-Werror -Wall $CC_TEST_FLAGS"
+
+. auto/feature
+
+CC_TEST_FLAGS="$SAVED_CC_TEST_FLAGS"
+
+# ----------------------------------------
+
 if test -n "$ngx_module_link"; then
     ngx_module_type=HTTP_AUX_FILTER
     ngx_module_name=$ngx_addon_name

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -840,6 +840,32 @@ This directive is turned on by default.
 
 This directive was first introduced in the <code>v0.9.1</code> release.
 
+== lua_malloc_trim ==
+'''syntax:''' ''lua_malloc_trim <request-count>''
+
+'''default:''' ''lua_malloc_trim 1000''
+
+'''context:''' ''http''
+
+Asks the underlying <code>libc</code> runtime library to release its cached free memory back to the operating system every
+<code>N</code> requests processed by the NGINX core. By default, <code>N</code> is 1000. You can configure the request count
+by using your own numbers. Smaller numbers mean more frequent releases, which may introduce higher CPU time consumption and
+smaller memory footprint while larger numbers usually lead to less CPU time overhead and relatively larger memory footprint.
+Just tune the number for your own use cases.
+
+Configuring the argument to <code>0</code> essentially turns off the periodical memory trimming altogether.
+
+<geshi lang="nginx">
+    lua_malloc_trim 0;  # turn off trimming completely
+</geshi>
+
+The current implementation uses an NGINX log phase handler to do the request counting. So the appearance of the
+[http://nginx.org/en/docs/http/ngx_http_core_module.html#log_subrequest log_subrequest on] directives in <code>nginx.conf</code>
+may make the counting faster when subrequests are involved. By default, only "main requests" count.
+
+Note that this directive does *not* affect the memory allocated by LuaJIT's own allocator based on the <code>mmap</code>
+system call.
+
 == lua_code_cache ==
 '''syntax:''' ''lua_code_cache on | off''
 

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -193,6 +193,10 @@ struct ngx_http_lua_main_conf_s {
 
     ngx_http_lua_sema_mm_t         *sema_mm;
 
+    ngx_uint_t           malloc_trim_cycle;  /* a cycle is defined as the number
+                                                of reqeusts */
+    ngx_uint_t           malloc_trim_req_count;
+
     unsigned             requires_header_filter:1;
     unsigned             requires_body_filter:1;
     unsigned             requires_capture_filter:1;

--- a/src/ngx_http_lua_logby.c
+++ b/src/ngx_http_lua_logby.c
@@ -72,14 +72,14 @@ ngx_http_lua_log_handler(ngx_http_request_t *r)
 {
 #if NGX_HTTP_LUA_HAVE_MALLOC_TRIM
     ngx_uint_t                   trim_cycle, trim_nreq;
-#endif
     ngx_http_lua_main_conf_t    *lmcf;
+#endif
     ngx_http_lua_loc_conf_t     *llcf;
     ngx_http_lua_ctx_t          *ctx;
 
+#if NGX_HTTP_LUA_HAVE_MALLOC_TRIM
     lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
 
-#if NGX_HTTP_LUA_HAVE_MALLOC_TRIM
     trim_cycle = lmcf->malloc_trim_cycle;
 
     if (trim_cycle > 0) {

--- a/src/ngx_http_lua_logby.c
+++ b/src/ngx_http_lua_logby.c
@@ -27,7 +27,7 @@
 #include "ngx_http_lua_shdict.h"
 #include "ngx_http_lua_util.h"
 #include "ngx_http_lua_exception.h"
-#if NGX_HTTP_LUA_HAVE_MALLOC_TRIM
+#if (NGX_HTTP_LUA_HAVE_MALLOC_TRIM)
 #include <malloc.h>
 #endif
 
@@ -70,14 +70,14 @@ ngx_http_lua_log_by_lua_env(lua_State *L, ngx_http_request_t *r)
 ngx_int_t
 ngx_http_lua_log_handler(ngx_http_request_t *r)
 {
-#if NGX_HTTP_LUA_HAVE_MALLOC_TRIM
+#if (NGX_HTTP_LUA_HAVE_MALLOC_TRIM)
     ngx_uint_t                   trim_cycle, trim_nreq;
     ngx_http_lua_main_conf_t    *lmcf;
 #endif
     ngx_http_lua_loc_conf_t     *llcf;
     ngx_http_lua_ctx_t          *ctx;
 
-#if NGX_HTTP_LUA_HAVE_MALLOC_TRIM
+#if (NGX_HTTP_LUA_HAVE_MALLOC_TRIM)
     lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
 
     trim_cycle = lmcf->malloc_trim_cycle;
@@ -91,8 +91,12 @@ ngx_http_lua_log_handler(ngx_http_request_t *r)
         if (trim_nreq >= trim_cycle) {
             lmcf->malloc_trim_req_count = 0;
 
+#if (NGX_DEBUG)
             ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                            "malloc_trim(1) returned %d", malloc_trim(1));
+#else
+            (void) malloc_trim(1);
+#endif
         }
     }
 #   if (NGX_DEBUG)

--- a/src/ngx_http_lua_logby.c
+++ b/src/ngx_http_lua_logby.c
@@ -27,6 +27,9 @@
 #include "ngx_http_lua_shdict.h"
 #include "ngx_http_lua_util.h"
 #include "ngx_http_lua_exception.h"
+#if NGX_HTTP_LUA_HAVE_MALLOC_TRIM
+#include <malloc.h>
+#endif
 
 
 static ngx_int_t ngx_http_lua_log_by_chunk(lua_State *L, ngx_http_request_t *r);
@@ -67,8 +70,38 @@ ngx_http_lua_log_by_lua_env(lua_State *L, ngx_http_request_t *r)
 ngx_int_t
 ngx_http_lua_log_handler(ngx_http_request_t *r)
 {
+#if NGX_HTTP_LUA_HAVE_MALLOC_TRIM
+    ngx_uint_t                   trim_cycle, trim_nreq;
+#endif
+    ngx_http_lua_main_conf_t    *lmcf;
     ngx_http_lua_loc_conf_t     *llcf;
     ngx_http_lua_ctx_t          *ctx;
+
+    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
+
+#if NGX_HTTP_LUA_HAVE_MALLOC_TRIM
+    trim_cycle = lmcf->malloc_trim_cycle;
+
+    if (trim_cycle > 0) {
+
+        dd("cycle: %d", (int) trim_cycle);
+
+        trim_nreq = ++lmcf->malloc_trim_req_count;
+
+        if (trim_nreq >= trim_cycle) {
+            lmcf->malloc_trim_req_count = 0;
+
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "malloc_trim(1) returned %d", malloc_trim(1));
+        }
+    }
+#   if (NGX_DEBUG)
+    else {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "malloc_trim() disabled");
+    }
+#   endif
+#endif
 
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "lua log handler, uri:\"%V\" c:%ud", &r->uri,

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -1306,7 +1306,7 @@ ngx_http_lua_limit_data_segment(void)
 static char *
 ngx_http_lua_malloc_trim(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-#if NGX_HTTP_LUA_HAVE_MALLOC_TRIM
+#if (NGX_HTTP_LUA_HAVE_MALLOC_TRIM)
 
     ngx_int_t       nreqs;
     ngx_str_t      *value;

--- a/t/128-duplex-tcp-socket.t
+++ b/t/128-duplex-tcp-socket.t
@@ -357,7 +357,7 @@ F(ngx_http_lua_socket_tcp_finalize_write_part) {
 --- config
     server_tokens off;
     lua_socket_log_errors off;
-    resolver $TEST_NGINX_RESOLVER;
+    resolver $TEST_NGINX_RESOLVER ipv6=off;
     location /t {
         content_by_lua '
             local sock = ngx.socket.tcp()
@@ -390,7 +390,7 @@ F(ngx_http_lua_socket_tcp_finalize_write_part) {
             end
 
             sock:settimeout(300)
-            local ok, err = sock:connect("106.187.41.147", 12345)
+            local ok, err = sock:connect("106.184.1.99", 12345)
             ngx.say("connect: ", ok, " ", err)
 
             local ok, err = sock:close()

--- a/t/146-malloc-trim.t
+++ b/t/146-malloc-trim.t
@@ -1,0 +1,337 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua;
+
+#worker_connections(1014);
+#master_process_enabled(1);
+#log_level('warn');
+
+#repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 4 + 3);
+
+#no_diff();
+no_long_string();
+#master_on();
+#workers(2);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: malloc_trim() every 1 req, in subreq
+--- http_config
+    lua_malloc_trim 1;
+--- config
+    location = /t {
+        return 200 "ok\n";
+    }
+
+    location = /main {
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+    }
+--- request
+GET /main
+--- response_body
+ok
+ok
+ok
+ok
+ok
+--- grep_error_log eval: qr/malloc_trim\(\d+\) returned \d+/
+--- grep_error_log_out
+malloc_trim(1) returned 0
+--- wait: 0.2
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: malloc_trim() every 1 req, in subreq
+--- http_config
+    lua_malloc_trim 1;
+--- config
+    location = /t {
+        log_subrequest on;
+        return 200 "ok\n";
+    }
+
+    location = /main {
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+    }
+--- request
+GET /main
+--- response_body
+ok
+ok
+ok
+ok
+ok
+--- grep_error_log eval: qr/malloc_trim\(\d+\) returned \d+/
+--- grep_error_log_out
+malloc_trim(1) returned 0
+malloc_trim(1) returned 0
+malloc_trim(1) returned 0
+malloc_trim(1) returned 0
+malloc_trim(1) returned 0
+malloc_trim(1) returned 0
+--- wait: 0.2
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: malloc_trim() every 2 req, in subreq
+--- http_config
+    lua_malloc_trim 2;
+--- config
+    location = /t {
+        log_subrequest on;
+        return 200 "ok\n";
+    }
+
+    location = /main {
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+    }
+--- request
+GET /main
+--- response_body
+ok
+ok
+ok
+ok
+ok
+--- grep_error_log eval: qr/malloc_trim\(\d+\) returned \d+/
+--- grep_error_log_out
+malloc_trim(1) returned 0
+malloc_trim(1) returned 0
+malloc_trim(1) returned 0
+--- wait: 0.2
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: malloc_trim() every 3 req, in subreq
+--- http_config
+    lua_malloc_trim 3;
+--- config
+    location = /t {
+        log_subrequest on;
+        return 200 "ok\n";
+    }
+
+    location = /main {
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+    }
+--- request
+GET /main
+--- response_body
+ok
+ok
+ok
+ok
+ok
+--- grep_error_log eval: qr/malloc_trim\(\d+\) returned \d+/
+--- grep_error_log_out
+malloc_trim(1) returned 0
+malloc_trim(1) returned 0
+--- wait: 0.2
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: malloc_trim() every 2 req, in subreq, big memory usage
+--- http_config
+    lua_malloc_trim 2;
+    lua_package_path "$prefix/html/?.lua;;";
+--- config
+    location = /t {
+        log_subrequest on;
+        content_by_lua_block {
+            require("foo")()
+        }
+    }
+
+    location = /main {
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+    }
+--- user_files
+>>> foo.lua
+local ffi = require "ffi"
+
+ffi.cdef[[
+    void *malloc(size_t sz);
+    void free(void *p);
+]]
+
+return function ()
+    local t = {}
+    for i = 1, 10 do
+        t[i] = ffi.C.malloc(1024 * 128)
+    end
+    for i = 1, 10 do
+        ffi.C.free(t[i])
+    end
+    ngx.say("ok")
+end
+--- request
+GET /main
+--- response_body
+ok
+ok
+ok
+ok
+ok
+--- grep_error_log eval: qr/malloc_trim\(\d+\) returned \d+/
+--- grep_error_log_out
+malloc_trim(1) returned 1
+malloc_trim(1) returned 1
+malloc_trim(1) returned 1
+--- wait: 0.2
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: zero count means off
+--- http_config
+    lua_malloc_trim 0;
+    lua_package_path "$prefix/html/?.lua;;";
+--- config
+    location = /t {
+        content_by_lua_block {
+            require("foo")()
+        }
+    }
+--- user_files
+>>> foo.lua
+local ffi = require "ffi"
+
+ffi.cdef[[
+    void *malloc(size_t sz);
+    void free(void *p);
+]]
+
+return function ()
+    local t = {}
+    for i = 1, 10 do
+        t[i] = ffi.C.malloc(1024 * 128)
+    end
+    for i = 1, 10 do
+        ffi.C.free(t[i])
+    end
+    ngx.say("ok")
+end
+
+--- request
+GET /t
+--- response_body
+ok
+--- grep_error_log eval: qr/malloc_trim\(\d+\) returned \d+/
+--- grep_error_log_out
+--- wait: 0.2
+--- no_error_log
+malloc_trim() disabled
+[error]
+
+
+
+=== TEST 7: zero count means off, log_by_lua
+--- http_config
+    lua_malloc_trim 0;
+    lua_package_path "$prefix/html/?.lua;;";
+--- config
+    location = /t {
+        content_by_lua_block {
+            require("foo")()
+        }
+        log_by_lua_block {
+            print("Hello from log")
+        }
+    }
+--- user_files
+>>> foo.lua
+local ffi = require "ffi"
+
+ffi.cdef[[
+    void *malloc(size_t sz);
+    void free(void *p);
+]]
+
+return function ()
+    local t = {}
+    for i = 1, 10 do
+        t[i] = ffi.C.malloc(1024 * 128)
+    end
+    for i = 1, 10 do
+        ffi.C.free(t[i])
+    end
+    ngx.say("ok")
+end
+
+--- request
+GET /t
+--- response_body
+ok
+--- grep_error_log eval: qr/malloc_trim\(\d+\) returned \d+/
+--- grep_error_log_out
+--- wait: 0.2
+--- error_log
+Hello from log
+malloc_trim() disabled
+--- no_error_log
+[error]
+
+
+
+=== TEST 8: malloc_trim() every 1 req
+--- http_config
+    lua_malloc_trim 1;
+--- config
+    location = /t {
+        return 200 "ok\n";
+    }
+
+    location = /main {
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+        echo_location /t;
+    }
+--- request
+GET /main
+--- response_body
+ok
+ok
+ok
+ok
+ok
+--- grep_error_log eval: qr/malloc_trim\(\d+\) returned \d+/
+--- grep_error_log_out
+malloc_trim(1) returned 0
+--- wait: 0.2
+--- no_error_log
+[error]


### PR DESCRIPTION
feature: added new config directive "lua_malloc_trim N" to periodically call malloc_trim(1) every N requests when malloc_trim() is available.

By default, "lua_malloc_trim 1000" is configured.

This should fix the glibc oddity of holding too much freed memory when it fails to use brk() to allocate memory in the data segment (Linux only).