### PR TITLE
bugfix: Lua VM crash when using ngx.exec(), unsafe uri #905

### DIFF
--- a/src/ngx_http_lua_control.c
+++ b/src/ngx_http_lua_control.c
@@ -54,6 +54,7 @@ static int
 ngx_http_lua_ngx_exec(lua_State *L)
 {
     int                          n;
+    int                          rc;
     ngx_http_request_t          *r;
     ngx_http_lua_ctx_t          *ctx;
     ngx_str_t                    uri;
@@ -105,10 +106,11 @@ ngx_http_lua_ngx_exec(lua_State *L)
 
     ngx_http_lua_check_if_abortable(L, ctx);
 
-    if (ngx_http_parse_unsafe_uri(r, &uri, &args, &flags)
-        != NGX_OK)
-    {
-        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    rc = ngx_http_parse_unsafe_uri(r, &uri, &args, &flags);
+    if (rc != NGX_OK) {
+        dd("rc = %d", (int) rc);
+
+        return luaL_error(L, "unsafe uri in #1: %s", p);
     }
 
     if (n == 2) {

--- a/t/024-access/exec.t
+++ b/t/024-access/exec.t
@@ -349,3 +349,19 @@ hello
 --- response_body
 hello, bah
 
+
+
+=== TEST 16: github issue #905: unsafe uri
+--- config
+    location /read {
+        access_by_lua '
+            ngx.exec("/hi/../");
+        ';
+    }
+    location /hi {
+        echo "Hello";
+    }
+--- request
+GET /read
+--- response_body_like: 500 Internal Server Error
+--- error_code: 500


### PR DESCRIPTION
This PR is about to the issue #905 