### PR TITLE
[bugfix] Avoid the package.preload module not found while code cache off

### DIFF
--- a/src/ngx_http_lua_api.c
+++ b/src/ngx_http_lua_api.c
@@ -57,7 +57,8 @@ ngx_http_lua_add_package_preload(ngx_conf_t *cf, const char *package,
         lua_setfield(L, -2, package);
         lua_pop(L, 2);
 
-        return NGX_OK;
+        /* ensure store the package while lua_cache_off */
+        /* return NGX_OK; */
     }
 
     /* L == NULL */

--- a/t/150-fake-delayed-load.t
+++ b/t/150-fake-delayed-load.t
@@ -1,0 +1,56 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use lib 'lib';
+use Test::Nginx::Socket::Lua;
+
+#worker_connections(1014);
+#master_process_enabled(1);
+#log_level('warn');
+
+#repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 3 - 1);
+
+#no_diff();
+no_long_string();
+#master_on();
+#workers(2);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: lua code cache on
+--- http_config
+    lua_code_cache on;
+--- config
+    location = /cache_on {
+        content_by_lua_block {
+            local delayed_load = require("ngx.delayed_load")
+            ngx.say(type(delayed_load.get_function))
+        }
+    }
+--- request
+GET /cache_on
+--- response_body
+function
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: lua code cache off
+--- http_config
+    lua_code_cache off;
+--- config
+    location = /cache_off {
+        content_by_lua_block {
+            local delayed_load = require("ngx.delayed_load")
+            ngx.say(type(delayed_load.get_function))
+        }
+    }
+--- request
+GET /cache_off
+--- response_body
+function
+--- no_error_log
+[error]

--- a/t/150-fake-delayed-load.t
+++ b/t/150-fake-delayed-load.t
@@ -8,7 +8,7 @@ use Test::Nginx::Socket::Lua;
 
 #repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 3 - 1);
+plan tests => repeat_each() * (blocks() * 3);
 
 #no_diff();
 no_long_string();

--- a/t/data/fake-delayed-load-module/config
+++ b/t/data/fake-delayed-load-module/config
@@ -1,0 +1,3 @@
+ngx_addon_name="ngx_http_lua_fake_delayed_load_module"
+HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_lua_fake_delayed_load_module"
+NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_lua_fake_delayed_load_module.c"

--- a/t/data/fake-delayed-load-module/ngx_http_lua_fake_delayed_load_module.c
+++ b/t/data/fake-delayed-load-module/ngx_http_lua_fake_delayed_load_module.c
@@ -1,0 +1,78 @@
+/* Copyright (C) Jim Tan
+ *
+ * This fake_delayed_load delayed load module was used to reproduce
+ * a bug in ngx_lua's function ngx_http_lua_add_package_preload.
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+#include <nginx.h>
+
+
+#include "ngx_http_lua_api.h"
+
+
+static ngx_int_t ngx_http_lua_fake_delayed_load_init(ngx_conf_t *cf);
+static int ngx_http_lua_fake_delayed_load_preload(lua_State *L);
+static int ngx_http_lua_fake_delayed_load_function(lua_State * L);
+
+
+static ngx_http_module_t ngx_http_lua_fake_delayed_load_module_ctx = {
+    NULL,                                 /* preconfiguration */
+    ngx_http_lua_fake_delayed_load_init,  /* postconfiguration */
+
+    NULL,                                 /* create main configuration */
+    NULL,                                 /* init main configuration */
+
+    NULL,                                 /* create server configuration */
+    NULL,                                 /* merge server configuration */
+
+    NULL,                                 /* create location configuration */
+    NULL,                                 /* merge location configuration */
+};
+
+/* flow identify module struct */
+ngx_module_t  ngx_http_lua_fake_delayed_load_module = {
+    NGX_MODULE_V1,
+    &ngx_http_lua_fake_delayed_load_module_ctx,   /* module context */
+    NULL,                                         /* module directives */
+    NGX_HTTP_MODULE,                              /* module type */
+    NULL,                                         /* init master */
+    NULL,                                         /* init module */
+    NULL,                                         /* init process */
+    NULL,                                         /* init thread */
+    NULL,                                         /* exit thread */
+    NULL,                                         /* exit process */
+    NULL,                                         /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+
+static ngx_int_t
+ngx_http_lua_fake_delayed_load_init(ngx_conf_t *cf)
+{
+    ngx_http_lua_add_package_preload(cf, "ngx.delayed_load",
+                                     ngx_http_lua_fake_delayed_load_preload);
+    return NGX_OK;
+}
+
+
+static int
+ngx_http_lua_fake_delayed_load_preload(lua_State *L)
+{
+    lua_createtable(L, 0, 1);
+
+    lua_pushcfunction(L, ngx_http_lua_fake_delayed_load_function);
+    lua_setfield(L, -2, "get_function");
+
+    return 1;
+}
+
+
+static int
+ngx_http_lua_fake_delayed_load_function(lua_State * L)
+{
+    return 1;
+}

--- a/util/build.sh
+++ b/util/build.sh
@@ -52,6 +52,7 @@ time ngx-build $force $version \
                 --add-module=$root/../redis2-nginx-module \
                 --add-module=$root/t/data/fake-module \
                 --add-module=$root/t/data/fake-shm-module \
+                --add-module=$root/t/data/fake-delayed-load-module \
                 --with-http_gunzip_module \
                 --with-http_dav_module \
           --with-select_module \


### PR DESCRIPTION
Sorry, this pull request is the follow-up for [this](https://github.com/openresty/lua-nginx-module/pull/840), I try to add a test case in it, I hope it work :)