### PR TITLE
optimze: reduce the ngx.req.socket object size & reduce ngx.socket.udp object size.

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -2702,12 +2702,6 @@ ngx_http_lua_socket_tcp_settimeout(lua_State *L)
     }
 
     timeout = (ngx_int_t) lua_tonumber(L, 2);
-    lua_pushinteger(L, timeout);
-    lua_pushinteger(L, timeout);
-
-    lua_rawseti(L, 1, SOCKET_CONNECT_TIMEOUT_INDEX);
-    lua_rawseti(L, 1, SOCKET_SEND_TIMEOUT_INDEX);
-    lua_rawseti(L, 1, SOCKET_READ_TIMEOUT_INDEX);
 
     lua_rawgeti(L, 1, SOCKET_CTX_INDEX);
     u = lua_touserdata(L, -1);
@@ -2723,6 +2717,15 @@ ngx_http_lua_socket_tcp_settimeout(lua_State *L)
             u->send_timeout = u->conf->send_timeout;
             u->connect_timeout = u->conf->connect_timeout;
         }
+
+    } else {
+        lua_pop(L, 1);
+        lua_pushinteger(L, timeout);
+        lua_pushinteger(L, timeout);
+
+        lua_rawseti(L, 1, SOCKET_CONNECT_TIMEOUT_INDEX);
+        lua_rawseti(L, 1, SOCKET_SEND_TIMEOUT_INDEX);
+        lua_rawseti(L, 1, SOCKET_READ_TIMEOUT_INDEX);
     }
 
     return 0;
@@ -2748,10 +2751,6 @@ ngx_http_lua_socket_tcp_settimeouts(lua_State *L)
     send_timeout = (ngx_int_t) lua_tonumber(L, 3);
     read_timeout = (ngx_int_t) lua_tonumber(L, 4);
 
-    lua_rawseti(L, 1, SOCKET_READ_TIMEOUT_INDEX);
-    lua_rawseti(L, 1, SOCKET_SEND_TIMEOUT_INDEX);
-    lua_rawseti(L, 1, SOCKET_CONNECT_TIMEOUT_INDEX);
-
     lua_rawgeti(L, 1, SOCKET_CTX_INDEX);
     u = lua_touserdata(L, -1);
 
@@ -2776,6 +2775,13 @@ ngx_http_lua_socket_tcp_settimeouts(lua_State *L)
         } else {
             u->read_timeout = u->conf->read_timeout;
         }
+
+    } else {
+        lua_pop(L, 1);
+
+        lua_rawseti(L, 1, SOCKET_READ_TIMEOUT_INDEX);
+        lua_rawseti(L, 1, SOCKET_SEND_TIMEOUT_INDEX);
+        lua_rawseti(L, 1, SOCKET_CONNECT_TIMEOUT_INDEX);
     }
 
     return 0;
@@ -4316,7 +4322,7 @@ ngx_http_lua_req_socket(lua_State *L)
         r->request_body = rb;
     }
 
-    lua_createtable(L, 3 /* narr */, 1 /* nrec */); /* the object */
+    lua_createtable(L, 1 /* narr */, 1 /* nrec */); /* the object */
 
     if (raw) {
         lua_pushlightuserdata(L, &ngx_http_lua_raw_req_socket_metatable_key);

--- a/src/ngx_http_lua_socket_udp.c
+++ b/src/ngx_http_lua_socket_udp.c
@@ -143,7 +143,7 @@ ngx_http_lua_socket_udp(lua_State *L)
                                | NGX_HTTP_LUA_CONTEXT_TIMER
                                | NGX_HTTP_LUA_CONTEXT_SSL_CERT);
 
-    lua_createtable(L, 3 /* narr */, 1 /* nrec */);
+    lua_createtable(L, 2 /* narr */, 1 /* nrec */);
     lua_pushlightuserdata(L, &ngx_http_lua_socket_udp_metatable_key);
     lua_rawget(L, LUA_REGISTRYINDEX);
     lua_setmetatable(L, -2);

--- a/t/147-tcp-socket-timeouts.t
+++ b/t/147-tcp-socket-timeouts.t
@@ -532,3 +532,89 @@ received: ok
 failed to receive a line: closed []
 --- no_error_log
 [error]
+
+
+
+=== TEST 8: settimeouts on ngx.req.socket
+--- config
+    server_tokens off;
+    location = /t {
+        #set $port 5000;
+        set $port $TEST_NGINX_SERVER_PORT;
+
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            local port = ngx.var.port
+            local ok, err = sock:connect("127.0.0.1", port)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            local req = "GET /mysock HTTP/1.1\r\nUpgrade: mysock\r\nHost: localhost\r\nConnection: close\r\n\r\nhello"
+            -- req = "OK"
+
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send request: ", err)
+                return
+            end
+
+            local reader = sock:receiveuntil("\r\n\r\n")
+            local data, err, partial = reader()
+            if not data then
+                ngx.say("no response header found")
+                return
+            end
+
+            local msg, err = sock:receive()
+            if not msg then
+                ngx.say("failed to receive: ", err)
+                return
+            end
+
+            ngx.say("msg: ", msg)
+
+            ok, err = sock:close()
+            if not ok then
+                ngx.say("failed to close socket: ", err)
+                return
+            end
+        }
+    }
+
+    location = /mysock {
+        content_by_lua_block {
+            ngx.status = 101
+            ngx.send_headers()
+            ngx.flush(true)
+            ngx.req.read_body()
+            local sock, err = ngx.req.socket(true)
+            if not sock then
+                ngx.log(ngx.ERR, "server: failed to get raw req socket: ", err)
+                return
+            end
+
+            sock:settimeouts(100, 100, 100)
+
+            local data, err = sock:receive(5)
+            if not data then
+                ngx.log(ngx.ERR, "server: failed to receive: ", err)
+                return
+            end
+
+            local bytes, err = sock:send("req.socket size: " .. table.maxn(sock) .. "\n")
+            if not bytes then
+                ngx.log(ngx.ERR, "server: failed to send: ", err)
+                return
+            end
+        }
+        more_clear_headers Date;
+    }
+
+--- request
+GET /t
+--- response_body
+msg: req.socket size: 1
+--- no_error_log
+[error]


### PR DESCRIPTION
Seems we only need to save the `timeout` values to the `ngx_http_lua_socket_tcp_upstream_t u` for the connected `request socket`.
And the `udp socket` don't have to save the key for keepalive.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
