### PR TITLE
codestyle: for get the index of the top element in the stack from lua

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -376,12 +376,14 @@ ngx_http_lua_inject_req_socket_api(lua_State *L)
 static int
 ngx_http_lua_socket_tcp(lua_State *L)
 {
+    int                      n;
     ngx_http_request_t      *r;
     ngx_http_lua_ctx_t      *ctx;
 
-    if (lua_gettop(L) != 0) {
-        return luaL_error(L, "expecting zero arguments, but got %d",
-                          lua_gettop(L));
+    n = lua_gettop(L);
+
+    if (n != 0) {
+        return luaL_error(L, "expecting zero arguments, but got %d", n);
     }
 
     r = ngx_http_lua_get_req(L);
@@ -438,6 +440,7 @@ ngx_http_lua_socket_tcp_connect(lua_State *L)
     ngx_http_lua_socket_tcp_upstream_t      *u;
 
     n = lua_gettop(L);
+
     if (n != 2 && n != 3 && n != 4) {
         return luaL_error(L, "ngx.socket connect: expecting 2, 3, or 4 "
                           "arguments (including the object), but seen %d", n);
@@ -1211,6 +1214,7 @@ ngx_http_lua_socket_tcp_sslhandshake(lua_State *L)
     /* Lua function arguments: self [,session] [,host] [,verify] */
 
     n = lua_gettop(L);
+
     if (n < 1 || n > 5) {
         return luaL_error(L, "ngx.socket connect: expecting 1 ~ 5 "
                           "arguments (including the object), but seen %d", n);
@@ -1715,6 +1719,7 @@ ngx_http_lua_socket_tcp_receive(lua_State *L)
     ngx_http_lua_co_ctx_t               *coctx;
 
     n = lua_gettop(L);
+
     if (n != 1 && n != 2) {
         return luaL_error(L, "expecting 1 or 2 arguments "
                           "(including the object), but got %d", n);
@@ -2329,6 +2334,7 @@ success:
 static int
 ngx_http_lua_socket_tcp_send(lua_State *L)
 {
+    int                                  n;
     ngx_int_t                            rc;
     ngx_http_request_t                  *r;
     u_char                              *p;
@@ -2347,9 +2353,11 @@ ngx_http_lua_socket_tcp_send(lua_State *L)
 
     /* TODO: add support for the optional "i" and "j" arguments */
 
-    if (lua_gettop(L) != 2) {
+    n = lua_gettop(L);
+
+    if (n != 2) {
         return luaL_error(L, "expecting 2 arguments (including the object), "
-                          "but got %d", lua_gettop(L));
+                          "but got %d", n);
     }
 
     r = ngx_http_lua_get_req(L);
@@ -2629,12 +2637,15 @@ ngx_http_lua_socket_tcp_receive_retval_handler(ngx_http_request_t *r,
 static int
 ngx_http_lua_socket_tcp_close(lua_State *L)
 {
+    int                                  n;
     ngx_http_request_t                  *r;
     ngx_http_lua_socket_tcp_upstream_t  *u;
 
-    if (lua_gettop(L) != 1) {
+    n = lua_gettop(L);
+
+    if (n != 1) {
         return luaL_error(L, "expecting 1 argument "
-                          "(including the object) but seen %d", lua_gettop(L));
+                          "(including the object) but seen %d", n);
     }
 
     r = ngx_http_lua_get_req(L);
@@ -2695,6 +2706,7 @@ ngx_http_lua_socket_tcp_settimeout(lua_State *L)
     ngx_http_lua_socket_tcp_upstream_t  *u;
 
     n = lua_gettop(L);
+
     if (n != 2) {
         return luaL_error(L, "ngx.socket settimout: expecting 2 arguments "
                           "(including the object) but seen %d", n);
@@ -2733,10 +2745,10 @@ ngx_http_lua_socket_tcp_settimeouts(lua_State *L)
 {
     int                     n;
     ngx_int_t               connect_timeout, send_timeout, read_timeout;
-
     ngx_http_lua_socket_tcp_upstream_t  *u;
 
     n = lua_gettop(L);
+
     if (n != 4) {
         return luaL_error(L, "ngx.socket settimout: expecting 4 arguments "
                           "(including the object) but seen %d", n);
@@ -3606,6 +3618,7 @@ ngx_http_lua_socket_tcp_receiveuntil(lua_State *L)
     ngx_http_lua_socket_compiled_pattern_t     *cp;
 
     n = lua_gettop(L);
+
     if (n != 2 && n != 3) {
         return luaL_error(L, "expecting 2 or 3 arguments "
                           "(including the object), but got %d", n);
@@ -3698,6 +3711,7 @@ ngx_http_lua_socket_receiveuntil_iterator(lua_State *L)
     ngx_http_lua_socket_compiled_pattern_t     *cp;
 
     n = lua_gettop(L);
+
     if (n > 1) {
         return luaL_error(L, "expecting 0 or 1 arguments, "
                           "but seen %d", n);
@@ -4176,8 +4190,7 @@ ngx_http_lua_req_socket(lua_State *L)
         lua_pop(L, 1);
 
     } else {
-        return luaL_error(L, "expecting zero arguments, but got %d",
-                          n);
+        return luaL_error(L, "expecting zero arguments, but got %d", n);
     }
 
     r = ngx_http_lua_get_req(L);
@@ -4423,11 +4436,14 @@ ngx_http_lua_req_socket_rev_handler(ngx_http_request_t *r)
 static int
 ngx_http_lua_socket_tcp_getreusedtimes(lua_State *L)
 {
+    int                                    n;
     ngx_http_lua_socket_tcp_upstream_t    *u;
 
-    if (lua_gettop(L) != 1) {
+    n = lua_gettop(L);
+
+    if (n != 1) {
         return luaL_error(L, "expecting 1 argument "
-                          "(including the object), but got %d", lua_gettop(L));
+                          "(including the object), but got %d", n);
     }
 
     luaL_checktype(L, 1, LUA_TTABLE);
@@ -4472,6 +4488,7 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
     ngx_http_lua_socket_pool_item_t     *items, *item;
 
     n = lua_gettop(L);
+
     if (n < 1 || n > 3) {
         return luaL_error(L, "expecting 1 to 3 arguments "
                           "(including the object), but got %d", n);

--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -2695,10 +2695,9 @@ ngx_http_lua_socket_tcp_settimeout(lua_State *L)
     ngx_http_lua_socket_tcp_upstream_t  *u;
 
     n = lua_gettop(L);
-
     if (n != 2) {
         return luaL_error(L, "ngx.socket settimout: expecting 2 arguments "
-                          "(including the object) but seen %d", lua_gettop(L));
+                          "(including the object) but seen %d", n);
     }
 
     timeout = (ngx_int_t) lua_tonumber(L, 2);
@@ -2738,10 +2737,9 @@ ngx_http_lua_socket_tcp_settimeouts(lua_State *L)
     ngx_http_lua_socket_tcp_upstream_t  *u;
 
     n = lua_gettop(L);
-
     if (n != 4) {
         return luaL_error(L, "ngx.socket settimout: expecting 4 arguments "
-                          "(including the object) but seen %d", lua_gettop(L));
+                          "(including the object) but seen %d", n);
     }
 
     connect_timeout = (ngx_int_t) lua_tonumber(L, 2);
@@ -4179,7 +4177,7 @@ ngx_http_lua_req_socket(lua_State *L)
 
     } else {
         return luaL_error(L, "expecting zero arguments, but got %d",
-                          lua_gettop(L));
+                          n);
     }
 
     r = ngx_http_lua_get_req(L);
@@ -4474,7 +4472,6 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
     ngx_http_lua_socket_pool_item_t     *items, *item;
 
     n = lua_gettop(L);
-
     if (n < 1 || n > 3) {
         return luaL_error(L, "expecting 1 to 3 arguments "
                           "(including the object), but got %d", n);


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

Hello @agentzh .

When i'm reading the codebase I have noticed that when we want to get the index of the top element in the stack from lua `lua_gettop(L);` for check lua number of arguments (It's common operate), some code like [ngx_http_lua_shdict.c#L463](https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_shdict.c#L463) but other like [ngx_http_lua_socket_tcp.c#L2744](https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_socket_tcp.c#L2744).

By the way, there are some similar questions in other files. Now the PR just change the [lua_socket_tcp.c](https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_socket_tcp.c)

How do you think of this :) 
