### PR TITLE
Implement ngx.shared.DICT.decr method

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3103,6 +3103,7 @@ Nginx API for Lua
 * [ngx.shared.DICT.replace](#ngxshareddictreplace)
 * [ngx.shared.DICT.delete](#ngxshareddictdelete)
 * [ngx.shared.DICT.incr](#ngxshareddictincr)
+* [ngx.shared.DICT.decr](#ngxshareddictdecr)
 * [ngx.shared.DICT.lpush](#ngxshareddictlpush)
 * [ngx.shared.DICT.rpush](#ngxshareddictrpush)
 * [ngx.shared.DICT.lpop](#ngxshareddictlpop)
@@ -6109,6 +6110,7 @@ The resulting object `dict` has the following methods:
 * [replace](#ngxshareddictreplace)
 * [delete](#ngxshareddictdelete)
 * [incr](#ngxshareddictincr)
+* [decr](#ngxshareddictdecr)
 * [lpush](#ngxshareddictlpush)
 * [rpush](#ngxshareddictrpush)
 * [lpop](#ngxshareddictlpop)
@@ -6374,6 +6376,25 @@ This method was first introduced in the `v0.3.1rc22` release.
 The optional `init` parameter was first added in the `v0.10.6` release.
 
 See also [ngx.shared.DICT](#ngxshareddict).
+
+[Back to TOC](#nginx-api-for-lua)
+
+ngx.shared.DICT.decr
+--------------------
+**syntax:** *newval, err, forcible? = ngx.shared.DICT:decr(key, value, init?)*
+
+**context:** *init_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;*
+
+Similar to [ngx.shared.DICT.incr](#ngxshareddictincr), but decrements the (numerical) value for `key` in the shm-based dictionary [ngx.shared.DICT](#ngxshareddict) by the step value `value`. Returns the new resulting number if the operation is successfully completed or `nil` and an error message otherwise.
+
+Additionally, existing values cannot be decremented below 0.
+
+When the key does not exist or has already expired in the shared dictionary,
+
+1. if the `init` argument is not specified or takes the value `nil`, this method will return `nil` and the error string `"not found"`, or
+1. if the `init` argument takes a number value, this method will create a new `key` with the value `init - value`, unless the result of `init - value` is less than 0, in which case this method will return nil and the error string `"cannot initialize decr below zero"`
+
+All other behaviors are identical to [ngx.shared.DICT.incr](#ngxshareddictincr).
 
 [Back to TOC](#nginx-api-for-lua)
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -5116,6 +5116,7 @@ The resulting object <code>dict</code> has the following methods:
 * [[#ngx.shared.DICT.replace|replace]]
 * [[#ngx.shared.DICT.delete|delete]]
 * [[#ngx.shared.DICT.incr|incr]]
+* [[#ngx.shared.DICT.decr|decr]]
 * [[#ngx.shared.DICT.lpush|lpush]]
 * [[#ngx.shared.DICT.rpush|rpush]]
 * [[#ngx.shared.DICT.lpop|lpop]]
@@ -5348,6 +5349,22 @@ This method was first introduced in the <code>v0.3.1rc22</code> release.
 The optional `init` parameter was first added in the <code>v0.10.6</code> release.
 
 See also [[#ngx.shared.DICT|ngx.shared.DICT]].
+
+== ngx.shared.DICT.decr ==
+'''syntax:''' ''newval, err, forcible? = ngx.shared.DICT:decr(key, value, init?)''
+
+'''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
+
+Similar to [[#ngx.shared.DICT.incr|ngx.shared.DICT.incr]], but decrements the (numerical) value for <code>key</code> in the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]] by the step value <code>value</code>. Returns the new resulting number if the operation is successfully completed or <code>nil</code> and an error message otherwise.
+
+Additionally, existing values cannot be decremented below 0.
+
+When the key does not exist or has already expired in the shared dictionary,
+
+# if the <code>init</code> argument is not specified or takes the value <code>nil</code>, this method will return <code>nil</code> and the error string <code>"not found"</code>, or
+# if the <code>init</code> argument takes a number value, this method will create a new <code>key</code> with the value <code>init - value</code>, unless the result of <code>init - value</code> is less than 0, in which case this method will return nil and the error string <code>"cannot initialize decr below zero"</code>
+
+All other behaviors are identical to [[#ngx.shared.DICT.incr|ngx.shared.DICT.incr]].
 
 == ngx.shared.DICT.lpush ==
 '''syntax:''' ''length, err = ngx.shared.DICT:lpush(key, value)''

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -336,7 +336,7 @@ ngx_http_lua_inject_shdict_api(ngx_http_lua_main_conf_t *lmcf, lua_State *L)
         lua_createtable(L, 0, lmcf->shdict_zones->nelts /* nrec */);
                 /* ngx.shared */
 
-        lua_createtable(L, 0 /* narr */, 18 /* nrec */); /* shared mt */
+        lua_createtable(L, 0 /* narr */, 19 /* nrec */); /* shared mt */
 
         lua_pushcfunction(L, ngx_http_lua_shdict_get);
         lua_setfield(L, -2, "get");
@@ -1367,7 +1367,8 @@ ngx_http_lua_shdict_incr_helper(lua_State *L, int flags)
         if (flags == NGX_HTTP_LUA_SHDICT_INCR) {
             /* add value */
             num = value + init;
-        } else /* decr */ {
+
+        } else  { /* decr */
             num = init - value;
 
             if (num < 0) {
@@ -1426,7 +1427,8 @@ ngx_http_lua_shdict_incr_helper(lua_State *L, int flags)
 
     if (flags == NGX_HTTP_LUA_SHDICT_INCR) {
         num += value;
-    } else /* decr */ {
+
+    } else  { /* decr */
         num -= value;
 
         if (num < 0) {
@@ -2721,7 +2723,8 @@ ngx_http_lua_ffi_shdict_incr(ngx_shm_zone_t *zone, int op, u_char *key,
         if (op == NGX_HTTP_LUA_SHDICT_INCR) {
             /* add value */
             num = *value + init;
-        } else /* decr */ {
+
+        } else  { /* decr */
             num = init - *value;
 
             if (num < 0) {
@@ -2777,7 +2780,8 @@ ngx_http_lua_ffi_shdict_incr(ngx_shm_zone_t *zone, int op, u_char *key,
 
     if (op == NGX_HTTP_LUA_SHDICT_INCR) {
         num += *value;
-    } else /* decr */ {
+
+    } else { /* decr */
         num -= *value;
 
         if (num < 0) {

--- a/t/043-shdict.t
+++ b/t/043-shdict.t
@@ -2479,13 +2479,13 @@ lua_shared_dict "dogs" is already defined as "dogs"
     lua_shared_dict dogs 1m;
 --- config
     location = /test {
-        content_by_lua '
+        content_by_lua_block {
             local dogs = ngx.shared.dogs
             dogs:set("foo", 32)
             local res, err = dogs:decr("foo", 17)
             ngx.say("decr: ", res, " ", err)
             ngx.say("foo = ", dogs:get("foo"))
-        ';
+        }
     }
 --- request
 GET /test
@@ -2502,13 +2502,13 @@ foo = 15
     lua_shared_dict dogs 1m;
 --- config
     location = /test {
-        content_by_lua '
+        content_by_lua_block {
             local dogs = ngx.shared.dogs
             dogs:set("bah", 32)
             local res, err = dogs:decr("foo", 2)
             ngx.say("decr: ", res, " ", err)
             ngx.say("foo = ", dogs:get("foo"))
-        ';
+        }
     }
 --- request
 GET /test
@@ -2525,19 +2525,16 @@ foo = nil
     lua_shared_dict dogs 1m;
 --- config
     location = /test {
-        content_by_lua '
+        content_by_lua_block {
             local dogs = ngx.shared.dogs
             dogs:set("bar", 3, 0.001)
             dogs:set("baz", 2, 0.001)
             dogs:set("foo", 32, 0.001)
-            ngx.location.capture("/sleep/0.002")
+            ngx.sleep(0.002)
             local res, err = dogs:decr("foo", 17)
             ngx.say("decr: ", res, " ", err)
             ngx.say("foo = ", dogs:get("foo"))
-        ';
-    }
-    location ~ ^/sleep/(.+) {
-        echo_sleep $1;
+        }
     }
 --- request
 GET /test
@@ -2554,13 +2551,13 @@ foo = nil
     lua_shared_dict dogs 1m;
 --- config
     location = /test {
-        content_by_lua '
+        content_by_lua_block {
             local dogs = ngx.shared.dogs
             dogs:set("foo", 32)
             local res, err = dogs:decr("foo", 0)
             ngx.say("decr: ", res, " ", err)
             ngx.say("foo = ", dogs:get("foo"))
-        ';
+        }
     }
 --- request
 GET /test
@@ -2577,13 +2574,13 @@ foo = 32
     lua_shared_dict dogs 1m;
 --- config
     location = /test {
-        content_by_lua '
+        content_by_lua_block {
             local dogs = ngx.shared.dogs
             dogs:set("foo", 32)
             local res, err = dogs:decr("foo", 0.14)
             ngx.say("decr: ", res, " ", err)
             ngx.say("foo = ", dogs:get("foo"))
-        ';
+        }
     }
 --- request
 GET /test
@@ -2600,13 +2597,13 @@ foo = 31.86
     lua_shared_dict dogs 1m;
 --- config
     location = /test {
-        content_by_lua '
+        content_by_lua_block {
             local dogs = ngx.shared.dogs
             dogs:set("foo", 32)
             local res, err = dogs:decr("foo", -0.14)
             ngx.say("decr: ", res, " ", err)
             ngx.say("foo = ", dogs:get("foo"))
-        ';
+        }
     }
 --- request
 GET /test
@@ -2623,13 +2620,13 @@ foo = 32
     lua_shared_dict dogs 1m;
 --- config
     location = /test {
-        content_by_lua '
+        content_by_lua_block {
             local dogs = ngx.shared.dogs
             dogs:set("foo", 32)
             local res, err = dogs:decr("foo", 33)
             ngx.say("decr: ", res, " ", err)
             ngx.say("foo = ", dogs:get("foo"))
-        ';
+        }
     }
 --- request
 GET /test
@@ -2646,13 +2643,13 @@ foo = 32
     lua_shared_dict dogs 1m;
 --- config
     location = /test {
-        content_by_lua '
+        content_by_lua_block {
             local dogs = ngx.shared.dogs
             dogs:set("foo", true)
             local res, err = dogs:decr("foo", -0.14)
             ngx.say("decr: ", res, " ", err)
             ngx.say("foo = ", dogs:get("foo"))
-        ';
+        }
     }
 --- request
 GET /test

--- a/t/062-count.t
+++ b/t/062-count.t
@@ -283,7 +283,7 @@ n = 5
 --- request
 GET /test
 --- response_body
-n = 18
+n = 19
 --- no_error_log
 [error]
 

--- a/t/146-shdict-decr-init.t
+++ b/t/146-shdict-decr-init.t
@@ -1,0 +1,248 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use lib 'lib';
+use Test::Nginx::Socket::Lua;
+
+#worker_connections(1014);
+#master_process_enabled(1);
+#log_level('warn');
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 3 + 0);
+
+#no_diff();
+no_long_string();
+#master_on();
+#workers(2);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: decr key with init (key exists)
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+            dogs:set("foo", 32)
+            local res, err = dogs:decr("foo", 17, 1)
+            ngx.say("decr: ", res, " ", err)
+            ngx.say("foo = ", dogs:get("foo"))
+        }
+    }
+--- request
+GET /test
+--- response_body
+decr: 15 nil
+foo = 15
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: decr key with init (key not exists)
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+            dogs:flush_all()
+            dogs:set("bah", 32)
+            local res, err = dogs:decr("foo", 1, 10502)
+            ngx.say("decr: ", res, " ", err)
+            ngx.say("foo = ", dogs:get("foo"))
+        }
+    }
+--- request
+GET /test
+--- response_body
+decr: 10501 nil
+foo = 10501
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: decr key with init (key expired and size not matched)
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+            for i = 1, 20 do
+                dogs:set("bar" .. i, i, 0.001)
+            end
+            dogs:set("foo", "32", 0.001)
+            ngx.location.capture("/sleep/0.002")
+            local res, err = dogs:decr("foo", 1, 10502)
+            ngx.say("decr: ", res, " ", err)
+            ngx.say("foo = ", dogs:get("foo"))
+        }
+    }
+    location ~ ^/sleep/(.+) {
+        echo_sleep $1;
+    }
+--- request
+GET /test
+--- response_body
+decr: 10501 nil
+foo = 10501
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: decr key with init (key expired and size matched)
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+            for i = 1, 20 do
+                dogs:set("bar" .. i, i, 0.001)
+            end
+            dogs:set("foo", 32, 0.001)
+            ngx.location.capture("/sleep/0.002")
+            local res, err = dogs:decr("foo", 1, 10502)
+            ngx.say("decr: ", res, " ", err)
+            ngx.say("foo = ", dogs:get("foo"))
+        }
+    }
+    location ~ ^/sleep/(.+) {
+        echo_sleep $1;
+    }
+--- request
+GET /test
+--- response_body
+decr: 10501 nil
+foo = 10501
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: decr key with init (forcibly override other valid entries)
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+            dogs:flush_all()
+            local long_prefix = string.rep("1234567890", 100)
+            for i = 1, 1000 do
+                local success, err, forcible = dogs:set(long_prefix .. i, i)
+                if forcible then
+                    dogs:delete(long_prefix .. i)
+                    break
+                end
+            end
+            local res, err, forcible = dogs:decr(long_prefix .. "bar", 1, 10502)
+            ngx.say("decr: ", res, " ", err, " ", forcible)
+            local res, err, forcible = dogs:decr(long_prefix .. "foo", 1, 10502)
+            ngx.say("decr: ", res, " ", err, " ", forcible)
+            ngx.say("foo = ", dogs:get(long_prefix .. "foo"))
+        }
+    }
+--- request
+GET /test
+--- response_body
+decr: 10501 nil false
+decr: 10501 nil true
+foo = 10501
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: decr key without init (no forcible returned)
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+            dogs:set("foo", 1)
+            local res, err, forcible = dogs:decr("foo", 1)
+            ngx.say("decr: ", res, " ", err, " ", forcible)
+            ngx.say("foo = ", dogs:get("foo"))
+        }
+    }
+--- request
+GET /test
+--- response_body
+decr: 0 nil nil
+foo = 0
+--- no_error_log
+[error]
+
+
+
+=== TEST 7: decr key (original value is not number)
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+            dogs:set("foo", true)
+            local res, err = dogs:decr("foo", 1, 0)
+            ngx.say("decr: ", res, " ", err)
+            ngx.say("foo = ", dogs:get("foo"))
+        }
+    }
+--- request
+GET /test
+--- response_body
+decr: nil not a number
+foo = true
+--- no_error_log
+[error]
+
+
+
+=== TEST 8: init is not number
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+            local res, err, forcible = dogs:decr("foo", 1, "bar")
+            ngx.say("decr: ", res, " ", err, " ", forcible)
+            ngx.say("foo = ", dogs:get("foo"))
+        }
+    }
+--- request
+GET /test
+--- error_code: 500
+--- response_body_like: 500 Internal Server Error
+--- error_log
+number expected, got string
+
+
+
+=== TEST 9: init below 0
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+            local res, err = dogs:decr("foo", 2, 1)
+            ngx.say("decr: ", res, " ", err)
+            ngx.say("foo = ", dogs:get("foo"))
+        }
+    }
+--- request
+GET /test
+--- response_body
+decr: nil cannot initialize decr below zero
+foo = nil
+--- no_error_log
+[error]

--- a/t/151-shdict-decr-init.t
+++ b/t/151-shdict-decr-init.t
@@ -1,19 +1,11 @@
 # vim:set ft= ts=4 sw=4 et fdm=marker:
-use lib 'lib';
 use Test::Nginx::Socket::Lua;
-
-#worker_connections(1014);
-#master_process_enabled(1);
-#log_level('warn');
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 3 + 0);
+plan tests => repeat_each() * (blocks() * 3);
 
-#no_diff();
 no_long_string();
-#master_on();
-#workers(2);
 
 run_tests();
 
@@ -77,14 +69,11 @@ foo = 10501
                 dogs:set("bar" .. i, i, 0.001)
             end
             dogs:set("foo", "32", 0.001)
-            ngx.location.capture("/sleep/0.002")
+            ngx.sleep(0.002)
             local res, err = dogs:decr("foo", 1, 10502)
             ngx.say("decr: ", res, " ", err)
             ngx.say("foo = ", dogs:get("foo"))
         }
-    }
-    location ~ ^/sleep/(.+) {
-        echo_sleep $1;
     }
 --- request
 GET /test
@@ -107,14 +96,11 @@ foo = 10501
                 dogs:set("bar" .. i, i, 0.001)
             end
             dogs:set("foo", 32, 0.001)
-            ngx.location.capture("/sleep/0.002")
+            ngx.sleep(0.002)
             local res, err = dogs:decr("foo", 1, 10502)
             ngx.say("decr: ", res, " ", err)
             ngx.say("foo = ", dogs:get("foo"))
         }
-    }
-    location ~ ^/sleep/(.+) {
-        echo_sleep $1;
     }
 --- request
 GET /test


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

Implement a counterpart to ngx.shared.DICT.incr that decrements
the numeric value at a given key, with an optional init. In addition,
decr() cannot receive a negative value, cannot decrement past 0,
and cannot initialize a value less than zero.

See #826
for more details and initial proposal.
