### PR TITLE
ffi_write new API: Update ngx_http_lua_output.c

### DIFF
--- a/src/ngx_http_lua_output.c
+++ b/src/ngx_http_lua_output.c
@@ -802,4 +802,100 @@ ngx_http_lua_flush_cleanup(void *data)
     ctx->flushing_coros--;
 }
 
+#ifndef NGX_LUA_NO_FFI_API
+int
+ngx_http_lua_ffi_write(ngx_http_request_t *r, const char* str, size_t offset, size_t len)
+{
+    ngx_http_lua_ctx_t          *ctx;
+    ngx_uint_t                  size;
+    ngx_buf_t                   *b;
+    ngx_chain_t                 *cl;
+    ngx_int_t                   rc;
+    const char*                 str_sub;
+    u_char                      err[128];
+    size_t                      errlen;
+
+    errlen = 64;
+
+    if (r == NULL) {
+        return NGX_HTTP_LUA_FFI_NO_REQUEST;
+    }
+
+    if (str == NULL) {
+        return NGX_HTTP_LUA_FFI_NULL_STRING;
+    }
+
+    size = ngx_strlen(str);
+
+    if (len == 0 || size == 0 || offset > size - 1) {
+        return NGX_HTTP_LUA_FFI_BAD_RANGE;
+    }
+
+    if (offset + len > size) {
+        len = size - offset;
+    }
+
+    str_sub = str + offset;
+
+    if (r->connection->fd == (ngx_socket_t) -1) {
+        return NGX_HTTP_LUA_FFI_BAD_CONTEXT;
+    }
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+
+    if (ctx == NULL) {
+        return NGX_HTTP_LUA_FFI_NO_REQ_CTX;
+    }
+
+    rc = ngx_http_lua_ffi_check_context(ctx,
+                    NGX_HTTP_LUA_CONTEXT_REWRITE
+                    | NGX_HTTP_LUA_CONTEXT_ACCESS
+                    | NGX_HTTP_LUA_CONTEXT_CONTENT,
+                    &err[0], &errlen);
+
+    if (rc != NGX_OK) {
+        return NGX_HTTP_LUA_FFI_BAD_CONTEXT;
+    }
+
+    if (ctx->acquired_raw_req_socket) {
+        return NGX_HTTP_LUA_FFI_RAW_SOCKET;
+    }
+
+    if (r->header_only) {
+        ctx->eof = 1;
+        return NGX_HTTP_LUA_FFI_HEADER_ONLY;
+    }
+
+    if (ctx->eof) {
+        return NGX_HTTP_LUA_FFI_EOF;
+    }
+
+    ctx->seen_body_data = 1;
+
+    cl = ngx_http_lua_chain_get_free_buf(r->connection->log, r->pool,
+            &ctx->free_bufs, len);
+
+    if (cl == NULL) {
+        return NGX_HTTP_LUA_FFI_NO_MEMORY;
+    }
+
+    b = cl->buf;
+    b->last = ngx_copy(b->last, (u_char *) str_sub, len);
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+            "lua ffi_write response");
+
+    rc = ngx_http_lua_send_chain_link(r, ctx, cl);
+
+    if (rc == NGX_ERROR || rc >= NGX_HTTP_SPECIAL_RESPONSE) {
+        return NGX_HTTP_LUA_FFI_OUTPUT_ERROR;
+    }
+
+    dd("downstream write: %d, buf len: %d", (int) rc,
+            (int) (b->last - b->pos));
+
+    return NGX_OK;
+}
+#endif /* NGX_LUA_NO_FFI_API */
+
 /* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/src/ngx_http_lua_output.c
+++ b/src/ngx_http_lua_output.c
@@ -802,30 +802,31 @@ ngx_http_lua_flush_cleanup(void *data)
     ctx->flushing_coros--;
 }
 
+
 #ifndef NGX_LUA_NO_FFI_API
 int
-ngx_http_lua_ffi_write(ngx_http_request_t *r, const char* str, size_t offset, size_t len)
+ngx_http_lua_ffi_write(ngx_http_request_t *r, const char *buf, size_t offset, size_t len)
 {
     ngx_http_lua_ctx_t          *ctx;
-    ngx_uint_t                  size;
+    ngx_uint_t                   size;
     ngx_buf_t                   *b;
     ngx_chain_t                 *cl;
-    ngx_int_t                   rc;
-    const char*                 str_sub;
-    u_char                      err[128];
-    size_t                      errlen;
-
+    ngx_int_t                    rc;
+    const char                  *str_sub;
+    u_char                       err[128];
+    size_t                       errlen;
+    
     errlen = 64;
 
     if (r == NULL) {
         return NGX_HTTP_LUA_FFI_NO_REQUEST;
     }
 
-    if (str == NULL) {
+    if (buf == NULL) {
         return NGX_HTTP_LUA_FFI_NULL_STRING;
     }
 
-    size = ngx_strlen(str);
+    size = ngx_strlen(buf);
 
     if (len == 0 || size == 0 || offset > size - 1) {
         return NGX_HTTP_LUA_FFI_BAD_RANGE;
@@ -835,7 +836,7 @@ ngx_http_lua_ffi_write(ngx_http_request_t *r, const char* str, size_t offset, si
         len = size - offset;
     }
 
-    str_sub = str + offset;
+    str_sub = buf + offset;
 
     if (r->connection->fd == (ngx_socket_t) -1) {
         return NGX_HTTP_LUA_FFI_BAD_CONTEXT;
@@ -873,7 +874,7 @@ ngx_http_lua_ffi_write(ngx_http_request_t *r, const char* str, size_t offset, si
     ctx->seen_body_data = 1;
 
     cl = ngx_http_lua_chain_get_free_buf(r->connection->log, r->pool,
-            &ctx->free_bufs, len);
+                                         &ctx->free_bufs, len);
 
     if (cl == NULL) {
         return NGX_HTTP_LUA_FFI_NO_MEMORY;

--- a/src/ngx_http_lua_output.c
+++ b/src/ngx_http_lua_output.c
@@ -805,7 +805,8 @@ ngx_http_lua_flush_cleanup(void *data)
 
 #ifndef NGX_LUA_NO_FFI_API
 int
-ngx_http_lua_ffi_write(ngx_http_request_t *r, const char *buf, size_t offset, size_t len)
+ngx_http_lua_ffi_write(ngx_http_request_t *r, const char *buf, size_t offset, 
+                       size_t len)
 {
     ngx_http_lua_ctx_t          *ctx;
     ngx_uint_t                   size;


### PR DESCRIPTION
ffi_write new API function.

This new FFI API function is used to print a string buffer on the client output starting from a given offset and ending at given length. This avoids the overhead of creating another string in the lua land.

See https://github.com/openresty/lua-nginx-module/issues/938 for more details.
