### PR TITLE
Fix build compatibility with BoringSSL.

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -1335,7 +1335,7 @@ ngx_http_lua_socket_tcp_sslhandshake(lua_State *L)
 #ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
 
                 if (SSL_set_tlsext_host_name(c->ssl->connection,
-                                             (char *)name.data)
+                                             (char *) name.data)
                     == 0)
                 {
                     lua_pushnil(L);

--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -1334,7 +1334,8 @@ ngx_http_lua_socket_tcp_sslhandshake(lua_State *L)
 
 #ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
 
-                if (SSL_set_tlsext_host_name(c->ssl->connection, name.data)
+                if (SSL_set_tlsext_host_name(c->ssl->connection,
+                                             (char *)name.data)
                     == 0)
                 {
                     lua_pushnil(L);

--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -1129,7 +1129,11 @@ ngx_http_lua_ffi_set_cert(ngx_http_request_t *r,
 
 #   else
 
+#ifdef OPENSSL_IS_BORINGSSL
+    size_t             i;
+#else
     int                i;
+#endif
     X509              *x509 = NULL;
     ngx_ssl_conn_t    *ssl_conn;
     STACK_OF(X509)    *chain = cdata;


### PR DESCRIPTION
There are two issues that occur when lua-nginx-module is compiled against BoringSSL. They are:
+ |SSL_set_tlsext_host_name| changing from a macro that internally casts name to a char* to a function that expects a char*, and
+ |sk_X509_num| returning a size_t and no longer an int.

The first issue is fixed by changing the caller of |SSL_set_tlsext_host_name|. This is identical to the fix applied in nginx/nginx@9b8b33b.

The second issue is fixed by changing variable `i` to be a size_t rather than an int when built against BoringSSL, i.e. when OPENSSL_IS_BORINGSSL is defined.

This change only addresses build failures and warnings and does not attempt to address missing features or correctness.

I hereby granted the copyright of the changes in this pull request to the authors of this lua-nginx-module project.