### PR TITLE
feat: prevent calling ngx.exit() with invalid values

### DIFF
--- a/t/005-exit.t
+++ b/t/005-exit.t
@@ -723,3 +723,82 @@ GET /t
 --- response_body
 --- no_error_log
 [error]
+
+
+
+=== TEST 25: accepts NGX_OK
+--- config
+    location = /t {
+        content_by_lua_block {
+            ngx.exit(ngx.OK)
+        }
+    }
+--- request
+GET /t
+--- response_body
+--- no_error_log
+[error]
+
+
+
+=== TEST 26: accepts NGX_ERROR
+--- config
+    location = /t {
+        content_by_lua_block {
+            ngx.exit(ngx.ERROR)
+        }
+    }
+--- request
+GET /t
+--- error_code:
+--- response_body
+--- no_error_log
+[error]
+
+
+
+=== TEST 27: accepts NGX_DECLINED
+--- config
+    location = /t {
+        content_by_lua_block {
+            ngx.exit(ngx.DECLINED)
+        }
+    }
+--- request
+GET /t
+--- error_code:
+--- response_body
+--- no_error_log
+[error]
+
+
+
+=== TEST 28: refuses NGX_AGAIN
+--- config
+    location = /t {
+        content_by_lua_block {
+            ngx.exit(ngx.AGAIN)
+        }
+    }
+--- request
+GET /t
+--- error_code: 500
+--- response_body_like: 500 Internal Server Error
+--- error_log eval
+qr/\[error\] .*? bad argument #1 to 'exit' \(does not accept NGX_AGAIN or NGX_DONE\)/
+
+
+
+=== TEST 29: refuses NGX_DONE
+--- config
+    location = /t {
+        content_by_lua_block {
+            ngx.exit(ngx.DONE)
+        }
+    }
+--- request
+GET /t
+--- error_code: 500
+--- response_body_like: 500 Internal Server Error
+--- error_log eval
+qr/\[error\] .*? bad argument #1 to 'exit' \(does not accept NGX_AGAIN or NGX_DONE\)/


### PR DESCRIPTION
Should we enforce this? The documentation specifically states that `ngx.exit()` cannot be called with `NGX_AGAIN` and `NGX_DONE`, yet, we allow users to do so, and it seems it simply makes the request hang.

* add a check to the `ngx.exit()` argument
* add tests to enforce new behavior
* add tests to enforce documented behavior