### PR TITLE
move init_by_lua to init_module phase, ensure all shdict has inited

### DIFF
--- a/src/ngx_http_lua_api.c
+++ b/src/ngx_http_lua_api.c
@@ -159,8 +159,6 @@ ngx_http_lua_shared_memory_init(ngx_shm_zone_t *shm_zone, void *data)
     ngx_shm_zone_t              *ozone;
     void                        *odata;
 
-    ngx_int_t                    rc;
-    volatile ngx_cycle_t        *saved_cycle;
     ngx_http_lua_main_conf_t    *lmcf;
     ngx_http_lua_shm_zone_ctx_t *ctx;
     ngx_shm_zone_t              *zone;
@@ -193,22 +191,6 @@ ngx_http_lua_shared_memory_init(ngx_shm_zone_t *shm_zone, void *data)
     dd("lmcf->lua: %p", lmcf->lua);
 
     lmcf->shm_zones_inited++;
-
-    if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts
-        && lmcf->init_handler)
-    {
-        saved_cycle = ngx_cycle;
-        ngx_cycle = ctx->cycle;
-
-        rc = lmcf->init_handler(ctx->log, lmcf, lmcf->lua);
-
-        ngx_cycle = saved_cycle;
-
-        if (rc != NGX_OK) {
-            /* an error happened */
-            return NGX_ERROR;
-        }
-    }
 
     return NGX_OK;
 }

--- a/src/ngx_http_lua_api.c
+++ b/src/ngx_http_lua_api.c
@@ -146,8 +146,6 @@ ngx_http_lua_shared_memory_add(ngx_conf_t *cf, ngx_str_t *name, size_t size,
     zone->init = ngx_http_lua_shared_memory_init;
     zone->data = ctx;
 
-    lmcf->requires_shm = 1;
-
     return &ctx->zone;
 }
 

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -205,7 +205,6 @@ struct ngx_http_lua_main_conf_s {
     unsigned             requires_rewrite:1;
     unsigned             requires_access:1;
     unsigned             requires_log:1;
-    unsigned             requires_shm:1;
 };
 
 

--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -147,8 +147,6 @@ ngx_http_lua_shared_dict(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     *zp = zone;
 
-    lmcf->requires_shm = 1;
-
     return NGX_CONF_OK;
 }
 

--- a/src/ngx_http_lua_initby.c
+++ b/src/ngx_http_lua_initby.c
@@ -22,10 +22,7 @@ ngx_http_lua_init_module(ngx_cycle_t *cycle)
 
     lmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_lua_module);
 
-    if (lmcf == NULL
-        || lmcf->init_handler == NULL
-        || lmcf->lua == NULL)
-    {
+    if (lmcf == NULL || lmcf->init_handler == NULL || lmcf->lua == NULL) {
         return NGX_OK;
     }
 

--- a/src/ngx_http_lua_initby.c
+++ b/src/ngx_http_lua_initby.c
@@ -14,6 +14,38 @@
 
 
 ngx_int_t
+ngx_http_lua_init_module(ngx_cycle_t *cycle)
+{
+    ngx_int_t                   rc;
+    ngx_http_lua_main_conf_t   *lmcf;
+    volatile ngx_cycle_t       *saved_cycle;
+
+    lmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_lua_module);
+
+    if (lmcf == NULL
+        || lmcf->init_handler == NULL
+        || lmcf->lua == NULL)
+    {
+        return NGX_OK;
+    }
+
+    saved_cycle = ngx_cycle;
+    ngx_cycle = cycle;
+
+    rc = lmcf->init_handler(cycle->log, lmcf, lmcf->lua);
+
+    ngx_cycle = saved_cycle;
+
+    if (rc != NGX_OK) {
+        /* an error happened */
+        return NGX_ERROR;
+    }
+
+    return NGX_OK;
+}
+
+
+ngx_int_t
 ngx_http_lua_init_by_inline(ngx_log_t *log, ngx_http_lua_main_conf_t *lmcf,
     lua_State *L)
 {

--- a/src/ngx_http_lua_initby.h
+++ b/src/ngx_http_lua_initby.h
@@ -17,6 +17,8 @@ ngx_int_t ngx_http_lua_init_by_inline(ngx_log_t *log,
 ngx_int_t ngx_http_lua_init_by_file(ngx_log_t *log,
     ngx_http_lua_main_conf_t *lmcf, lua_State *L);
 
+ngx_int_t ngx_http_lua_init_module(ngx_cycle_t *cycle);
+
 
 #endif /* _NGX_HTTP_LUA_INITBY_H_INCLUDED_ */
 

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -814,7 +814,6 @@ ngx_http_lua_create_main_conf(ngx_conf_t *cf)
      *      lmcf->requires_rewrite = 0;
      *      lmcf->requires_access = 0;
      *      lmcf->requires_log = 0;
-     *      lmcf->requires_shm = 0;
      */
 
     lmcf->pool = cf->pool;

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -618,7 +618,7 @@ ngx_module_t ngx_http_lua_module = {
     ngx_http_lua_cmds,          /*  module directives */
     NGX_HTTP_MODULE,            /*  module type */
     NULL,                       /*  init master */
-    NULL,                       /*  init module */
+    ngx_http_lua_init_module,   /*  init module */
     ngx_http_lua_init_worker,   /*  init process */
     NULL,                       /*  init thread */
     NULL,                       /*  exit thread */
@@ -635,7 +635,6 @@ ngx_http_lua_init(ngx_conf_t *cf)
     ngx_int_t                   rc;
     ngx_array_t                *arr;
     ngx_http_handler_pt        *h;
-    volatile ngx_cycle_t       *saved_cycle;
     ngx_http_core_main_conf_t  *cmcf;
     ngx_http_lua_main_conf_t   *lmcf;
 #ifndef NGX_LUA_NO_FFI_API
@@ -743,20 +742,6 @@ ngx_http_lua_init(ngx_conf_t *cf)
             ngx_conf_log_error(NGX_LOG_ERR, cf, 0,
                                "failed to initialize Lua VM");
             return NGX_ERROR;
-        }
-
-        if (!lmcf->requires_shm && lmcf->init_handler) {
-            saved_cycle = ngx_cycle;
-            ngx_cycle = cf->cycle;
-
-            rc = lmcf->init_handler(cf->log, lmcf, lmcf->lua);
-
-            ngx_cycle = saved_cycle;
-
-            if (rc != NGX_OK) {
-                /* an error happened */
-                return NGX_ERROR;
-            }
         }
 
         dd("Lua VM initialized!");


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

can we move init_by_lua to ngx_http_lua_module's init_module phase,  ensure all shdict has inited. in this way, we can use third part shdict without initialize in ngx_http_lua_module.
