### PR TITLE
function declartion and extern variable postion

### DIFF
--- a/src/ngx_http_lua_ssl.h
+++ b/src/ngx_http_lua_ssl.h
@@ -12,6 +12,8 @@
 
 
 #if (NGX_HTTP_SSL)
+
+
 typedef struct {
     ngx_connection_t        *connection; /* original true connection */
     ngx_http_request_t      *request;    /* fake request */
@@ -31,13 +33,15 @@ typedef struct {
     unsigned                 entered_cert_handler:1;
     unsigned                 entered_sess_fetch_handler:1;
 } ngx_http_lua_ssl_ctx_t;
-#endif
 
 
 ngx_int_t ngx_http_lua_ssl_init(ngx_log_t *log);
 
 
 extern int ngx_http_lua_ssl_ctx_index;
+
+
+#endif
 
 
 #endif  /* _NGX_HTTP_LUA_SSL_H_INCLUDED_ */


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

The [ngx_http_lua_ssl_init defination](https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_ssl.c#L20) and [ngx_http_lua_ssl_ctx_index defination](https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_ssl.c#L20) is in the 
`#if (NGX_HTTP_SSL)` block.
So The [ngx_http_lua_ssl_init declartion](https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_ssl.h#L37) and [extern ngx_http_lua_ssl_ctx_index delcartion](https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_ssl.h#L40) also should be in the `#if (NGX_HTTP_SSL)` block, even if it do not impact compile.
