### PR TITLE
Redo of doc edits to fit agentzh’s quirky setup

### DIFF
--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -520,13 +520,26 @@ instead of the old deprecated form:
 
 Here is the reason: by design, the global environment has exactly the same lifetime as the Nginx request handler associated with it. Each request handler has its own set of Lua global variables and that is the idea of request isolation. The Lua module is actually loaded by the first Nginx request handler and is cached by the <code>require()</code> built-in in the <code>package.loaded</code> table for later reference, and the <code>module()</code> builtin used by some Lua modules has the side effect of setting a global variable to the loaded module table. But this global variable will be cleared at the end of the request handler,  and every subsequent request handler all has its own (clean) global environment. So one will get Lua exception for accessing the <code>nil</code> value.
 
-Generally, use of Lua global variables is a really really bad idea in the context of ngx_lua because
+The use of Lua global variables is a generally inadvisable in the ngx_lua context as:
 
-# misuse of Lua globals has very bad side effects for concurrent requests when these variables are actually supposed to be local only,
-# Lua global variables require Lua table look-up in the global environment (which is just a Lua table), which is computationally expensive, and
+# the misuse of Lua globals has detrimental side effects on concurrent requests when such variables should instead be local in scope,
+# Lua global variables require Lua table look-ups in the global environment which is computationally expensive, and
 # some Lua global variable references may include typing errors which make such difficult to debug.
 
-It is therefore *highly* recommended to always declare such as "local" within an appropriate scope instead.
+It is therefore *highly* recommended to always declare such within an appropriate local scope instead.
+
+<geshi lang="lua">
+    -- Avoid
+    foo = 123
+    -- Recomended
+    local foo = 123
+
+    -- Avoid
+    function foo() return 123 end
+    -- Recomended
+    local function foo() return 123 end
+</geshi>
+
 
 To find all instances of Lua global variables in your Lua code, run the [https://github.com/openresty/nginx-devel-utils/blob/master/lua-releng lua-releng tool] across all <code>.lua</code> source files:
 <geshi lang="text">
@@ -565,7 +578,7 @@ will not work as expected.
 
 == Cosockets Not Available Everywhere ==
 
-Due the internal limitations in the nginx core, the cosocket API is disabled in the following contexts: [[#set_by_lua|set_by_lua*]], [[#log_by_lua|log_by_lua*]], [[#header_filter_by_lua|header_filter_by_lua*]], and [[#body_filter_by_lua|body_filter_by_lua]].
+Due to internal limitations in the nginx core, the cosocket API is disabled in the following contexts: [[#set_by_lua|set_by_lua*]], [[#log_by_lua|log_by_lua*]], [[#header_filter_by_lua|header_filter_by_lua*]], and [[#body_filter_by_lua|body_filter_by_lua]].
 
 The cosockets are currently also disabled in the [[#init_by_lua|init_by_lua*]] and [[#init_worker_by_lua|init_worker_by_lua*]] directive contexts but we may add support for these contexts in the future because there is no limitation in the nginx core (or the limitation might be worked around).
 
@@ -575,7 +588,7 @@ There exists a work-around, however, when the original context does *not* need t
 
 '''NOTE''' Following the <code>v0.9.17</code> release, this pitfall can be avoided by using the <code>*_by_lua_block {}</code> configuration directives.
 
-PCRE sequences such as <code>\d</code>, <code>\s</code>, or <code>\w</code>, require special attention because in string literals, the backslash character, <code>\</code>, is stripped out by both the Lua language parser and by the Nginx config file parser before processing if not within a <code>*_by_lua_block {}</code> directive. So the following snippet will not work as expected:
+PCRE sequences such as <code>\d</code>, <code>\s</code>, or <code>\w</code>, require special attention because in string literals, the backslash character, <code>\</code>, is stripped out by both the Lua language parser and by the nginx config file parser before processing if not within a <code>*_by_lua_block {}</code> directive. So the following snippet will not work as expected:
 
 <geshi lang="nginx">
     # nginx.conf
@@ -4387,14 +4400,14 @@ an asynchronous operation and will return immediately. This behavior may change 
 
 Explicitly specify the end of the response output stream. In the case of HTTP 1.1 chunked encoded output, it will just trigger the Nginx core to send out the "last chunk".
 
-When you disable the HTTP 1.1 keep-alive feature for your downstream connections, you can rely on descent HTTP clients to close the connection actively for you when you call this method. This trick can be used do back-ground jobs without letting the HTTP clients to wait on the connection, as in the following example:
+When you disable the HTTP 1.1 keep-alive feature for your downstream connections, you can rely on well written HTTP clients to close the connection actively for you when you call this method. This trick can be used do back-ground jobs without letting the HTTP clients to wait on the connection, as in the following example:
 
 <geshi lang="nginx">
     location = /async {
         keepalive_timeout 0;
         content_by_lua_block {
             ngx.say("got the task!")
-            ngx.eof()  -- a descent HTTP client will close the connection at this point
+            ngx.eof()  -- well written HTTP clients will close the connection at this point
             -- access MySQL, PostgreSQL, Redis, Memcached, and etc here...
         }
     }
@@ -5454,7 +5467,7 @@ Fetch a list of the keys from the dictionary, up to <code><max_count></code>.
 
 By default, only the first 1024 keys (if any) are returned. When the <code><max_count></code> argument is given the value <code>0</code>, then all the keys will be returned even there is more than 1024 keys in the dictionary.
 
-'''CAUTION''' Avoid calling this method on dictionaries with a very large number of keys as this method may lock the dictionary for a significant amount of time while blocking nginx worker processes that are trying to access the dictionary.
+'''CAUTION''' Avoid calling this method on dictionaries with a very large number of keys as it may lock the dictionary for significant amount of time and block Nginx worker processes trying to access the dictionary.
 
 This feature was first introduced in the <code>v0.7.3</code> release.
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -594,7 +594,7 @@ PCRE sequences such as <code>\d</code>, <code>\s</code>, or <code>\w</code>, req
     # nginx.conf
     ? location /test {
     ?     content_by_lua '
-    ?         local regex = "\d+"  -- THIS IS WRONG OUTSIDE A *_by_lua_block DIRECTIVE!!
+    ?         local regex = "\d+"  -- THIS IS WRONG OUTSIDE OF A *_by_lua_block DIRECTIVE
     ?         local m = ngx.re.match("hello, 1234", regex)
     ?         if m then ngx.say(m[0]) else ngx.say("not matched!") end
     ?     ';
@@ -670,7 +670,7 @@ Within external script files, PCRE sequences presented as long-bracketed Lua str
     -- evaluates to "1234"
 </geshi>
 
-As noted earlier, PCRE sequences presented within <code>*_by_lua_block {}</code> directives, available following the <code>v0.9.17</code> release, do not require modification.
+As noted earlier, PCRE sequences presented within <code>*_by_lua_block {}</code> directives (available following the <code>v0.9.17</code> release) do not require modification.
 
 <geshi lang="nginx">
     # nginx.conf

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -237,14 +237,14 @@ Build the source with this module:
 
 == Building as a dynamic module ==
 
-Starting from NGINX 1.9.11, you can also compile this module as a dynamic module, by using the `--add-dynamic-module=PATH` option instead of `--add-module=PATH` on the
-`./configure` command line above. And then you can explicitly load the module in your `nginx.conf` via the [load_module](http://nginx.org/en/docs/ngx_core_module.html#load_module)
+Starting from NGINX 1.9.11, you can also compile this module as a dynamic module, by using the <code>--add-dynamic-module=PATH</code> option instead of <code>--add-module=PATH</code> on the
+<code>./configure</code> command line above. And then you can explicitly load the module in your <code>nginx.conf</code> via the [load_module](http://nginx.org/en/docs/ngx_core_module.html#load_module)
 directive, for example,
 
-```nginx
+<geshi lang="nginx">
 load_module /path/to/modules/ndk_http_module.so;  # assuming NDK is built as a dynamic module too
 load_module /path/to/modules/ngx_http_lua_module.so;
-```
+</geshi>
 
 == C Macro Configurations ==
 
@@ -573,9 +573,9 @@ There exists a work-around, however, when the original context does *not* need t
 
 == Special Escaping Sequences ==
 
-'''NOTE''' Following the `v0.9.17` release, this pitfall can be avoided by using the `*_by_lua_block {}` configuration directives.
+'''NOTE''' Following the <code>v0.9.17</code> release, this pitfall can be avoided by using the <code>*_by_lua_block {}</code> configuration directives.
 
-PCRE sequences such as <code>\d</code>, <code>\s</code>, or <code>\w</code>, require special attention because in string literals, the backslash character, <code>\</code>, is stripped out by both the Lua language parser and by the Nginx config file parser before processing if not within a `*_by_lua_block {}` directive. So the following snippet will not work as expected:
+PCRE sequences such as <code>\d</code>, <code>\s</code>, or <code>\w</code>, require special attention because in string literals, the backslash character, <code>\</code>, is stripped out by both the Lua language parser and by the Nginx config file parser before processing if not within a <code>*_by_lua_block {}</code> directive. So the following snippet will not work as expected:
 
 <geshi lang="nginx">
     # nginx.conf
@@ -657,7 +657,7 @@ Within external script files, PCRE sequences presented as long-bracketed Lua str
     -- evaluates to "1234"
 </geshi>
 
-As noted earlier, PCRE sequences presented within `*_by_lua_block {}` directives, available following the `v0.9.17` release, do not require modification.
+As noted earlier, PCRE sequences presented within <code>*_by_lua_block {}</code> directives, available following the <code>v0.9.17</code> release, do not require modification.
 
 <geshi lang="nginx">
     # nginx.conf
@@ -785,7 +785,7 @@ To run specific test files:
     prove -I/path/to/test-nginx/lib t/002-content.t t/003-errors.t
 </geshi>
 
-To run a specific test block in a particular test file, add the line <code>--- ONLY</code> to the test block you want to run, and then use the `prove` utility to run that <code>.t</code> file.
+To run a specific test block in a particular test file, add the line <code>--- ONLY</code> to the test block you want to run, and then use the <code>prove</code> utility to run that <code>.t</code> file.
 
 There are also various testing modes based on mockeagain, valgrind, and etc. Refer to the [http://search.cpan.org/perldoc?Test::Nginx Test::Nginx documentation] for more details for various advanced testing modes. See also the test reports for the Nginx test cluster running on Amazon EC2: http://qa.openresty.org.
 
@@ -931,7 +931,7 @@ The default number of entries allowed is 1024 and when this limit is reached, ne
     2011/08/27 23:18:26 [warn] 31997#0: *1 lua exceeding regex cache max entries (1024), ...
 </geshi>
 
-If you are using the `ngx.re.*` implementation of [lua-resty-core](https://github.com/openresty/lua-resty-core) by loading the `resty.core.regex` module (or just the `resty.core` module), then an LRU cache is used for the regex cache being used here.
+If you are using the <code>ngx.re.*</code> implementation of [lua-resty-core](https://github.com/openresty/lua-resty-core) by loading the <code>resty.core.regex</code> module (or just the <code>resty.core</code> module), then an LRU cache is used for the regex cache being used here.
 
 Do not activate the <code>o</code> option for regular expressions (and/or <code>replace</code> string arguments for [[#ngx.re.sub|ngx.re.sub]] and [[#ngx.re.gsub|ngx.re.gsub]]) that are generated ''on the fly'' and give rise to infinite variations to avoid hitting the specified limit.
 
@@ -1055,7 +1055,7 @@ This directive was first introduced in the <code>v0.5.5</code> release.
 
 Similar to the [[#init_by_lua|init_by_lua]] directive except that this directive inlines
 the Lua source directly
-inside a pair of curly braces (`{}`) instead of in an NGINX string literal (which requires
+inside a pair of curly braces (<code>{}</code>) instead of in an NGINX string literal (which requires
 special character escaping).
 
 For instance,
@@ -1135,7 +1135,7 @@ This directive was first introduced in the <code>v0.9.5</code> release.
 
 Similar to the [[#init_worker_by_lua|init_worker_by_lua]] directive except that this directive inlines
 the Lua source directly
-inside a pair of curly braces (`{}`) instead of in an NGINX string literal (which requires
+inside a pair of curly braces (<code>{}</code>) instead of in an NGINX string literal (which requires
 special character escaping).
 
 For instance,
@@ -1227,7 +1227,7 @@ This directive requires the [https://github.com/simpl/ngx_devel_kit ngx_devel_ki
 Similar to the [[#set_by_lua|set_by_lua]] directive except that
 
 # this directive inlines the Lua source directly
-inside a pair of curly braces (`{}`) instead of in an NGINX string literal (which requires
+inside a pair of curly braces (<code>{}</code>) instead of in an NGINX string literal (which requires
 special character escaping), and
 # this directive does not support extra arguments after the Lua script as in [[#set_by_lua|set_by_lua]].
 
@@ -1287,7 +1287,7 @@ Do not use this directive and other content handler directives in the same locat
 
 Similar to the [[#content_by_lua|content_by_lua]] directive except that this directive inlines
 the Lua source directly
-inside a pair of curly braces (`{}`) instead of in an NGINX string literal (which requires
+inside a pair of curly braces (<code>{}</code>) instead of in an NGINX string literal (which requires
 special character escaping).
 
 For instance,
@@ -1459,7 +1459,7 @@ The <code>rewrite_by_lua</code> code will always run at the end of the <code>rew
 
 Similar to the [[#rewrite_by_lua|rewrite_by_lua]] directive except that this directive inlines
 the Lua source directly
-inside a pair of curly braces (`{}`) instead of in an NGINX string literal (which requires
+inside a pair of curly braces (<code>{}</code>) instead of in an NGINX string literal (which requires
 special character escaping).
 
 For instance,
@@ -1575,7 +1575,7 @@ of NGINX.
 
 Similar to the [[#access_by_lua|access_by_lua]] directive except that this directive inlines
 the Lua source directly
-inside a pair of curly braces (`{}`) instead of in an NGINX string literal (which requires
+inside a pair of curly braces (<code>{}</code>) instead of in an NGINX string literal (which requires
 special character escaping).
 
 For instance,
@@ -1648,7 +1648,7 @@ This directive was first introduced in the <code>v0.2.1rc20</code> release.
 
 Similar to the [[#header_filter_by_lua|header_filter_by_lua]] directive except that this directive inlines
 the Lua source directly
-inside a pair of curly braces (`{}`) instead of in an NGINX string literal (which requires
+inside a pair of curly braces (<code>{}</code>) instead of in an NGINX string literal (which requires
 special character escaping).
 
 For instance,
@@ -1770,7 +1770,7 @@ This directive was first introduced in the <code>v0.5.0rc32</code> release.
 
 Similar to the [[#body_filter_by_lua|body_filter_by_lua]] directive except that this directive inlines
 the Lua source directly
-inside a pair of curly braces (`{}`) instead of in an NGINX string literal (which requires
+inside a pair of curly braces (<code>{}</code>) instead of in an NGINX string literal (which requires
 special character escaping).
 
 For instance,
@@ -1870,7 +1870,7 @@ This directive was first introduced in the <code>v0.5.0rc31</code> release.
 
 Similar to the [[#log_by_lua|log_by_lua]] directive except that this directive inlines
 the Lua source directly
-inside a pair of curly braces (`{}`) instead of in an NGINX string literal (which requires
+inside a pair of curly braces (<code>{}</code>) instead of in an NGINX string literal (which requires
 special character escaping).
 
 For instance,
@@ -2663,7 +2663,7 @@ Setting <code>ngx.var.Foo</code> to a <code>nil</code> value will unset the <cod
 
 to prevent (temporary) memory leaking within the current request's lifetime. Another way of caching the result is to use the [[#ngx.ctx|ngx.ctx]] table.
 
-Undefined NGINX variables are evaluated to `nil` while uninitialized (but defined) NGINX variables are evaluated to an empty Lua string.
+Undefined NGINX variables are evaluated to <code>nil</code> while uninitialized (but defined) NGINX variables are evaluated to an empty Lua string.
 
 This API requires a relatively expensive metamethod call and it is recommended to avoid using it on hot code paths.
 
@@ -2891,7 +2891,7 @@ Because of the metamethod magic, never "local" the <code>ngx.ctx</code> table ou
 local _M = {}
 
 -- the following line is bad since ngx.ctx is a per-request
--- data while this `ctx` variable is on the Lua module level
+-- data while this <code>ctx</code> variable is on the Lua module level
 -- and thus is per-nginx-worker.
 local ctx = ngx.ctx
 
@@ -2915,7 +2915,7 @@ end
 return _M
 </geshi>
 
-That is, let the caller pass the `ctx` table explicitly via a function argument.
+That is, let the caller pass the <code>ctx</code> table explicitly via a function argument.
 
 == ngx.location.capture ==
 '''syntax:''' ''res = ngx.location.capture(uri, options?)''
@@ -5352,7 +5352,7 @@ The <code>value</code> argument and <code>init</code> argument can be any valid 
 
 This method was first introduced in the <code>v0.3.1rc22</code> release.
 
-The optional `init` parameter was first added in the <code>v0.10.6</code> release.
+The optional <code>init</code> parameter was first added in the <code>v0.10.6</code> release.
 
 See also [[#ngx.shared.DICT|ngx.shared.DICT]].
 
@@ -5733,7 +5733,7 @@ session userdata returned by a previous <code>sslhandshake</code>
 call for exactly the same target. For short-lived connections, reusing SSL
 sessions can usually speed up the handshake by one order by magnitude but it
 is not so useful if the connection pool is enabled. This argument defaults to
-`nil`. If this argument takes the boolean `false` value, no SSL session
+<code>nil</code>. If this argument takes the boolean <code>false</code> value, no SSL session
 userdata would return by this call and only a Lua boolean will be returned as
 the first return value; otherwise the current SSL session will
 always be returned as the first argument in case of successes.
@@ -5746,7 +5746,7 @@ also used to validate the server name specified in the server certificate sent f
 the remote.
 
 The optional <code>ssl_verify</code> argument takes a Lua boolean value to
-control whether to perform SSL verification. When set to `true`, the server
+control whether to perform SSL verification. When set to <code>true</code>, the server
 certificate will be verified according to the CA certificates specified by
 the [[#lua_ssl_trusted_certificate|lua_ssl_trusted_certificate]] directive.
 You may also need to adjust the [[#lua_ssl_verify_depth|lua_ssl_verify_depth]]
@@ -6490,8 +6490,8 @@ This directive was first introduced in the <code>v0.9.20</code> release.
 
 '''context:''' ''set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, init_by_lua*, init_worker_by_lua*''
 
-This string field indicates the current NGINX subsystem the current Lua environment is based on. For this module, this field always takes the string value `"http"`. For
-[https://github.com/openresty/stream-lua-nginx-module#readme ngx_stream_lua_module], however, this field takes the value `"stream"`.
+This string field indicates the current NGINX subsystem the current Lua environment is based on. For this module, this field always takes the string value <code>"http"</code>. For
+[https://github.com/openresty/stream-lua-nginx-module#readme ngx_stream_lua_module], however, this field takes the value <code>"stream"</code>.
 
 This field was first introduced in the <code>0.10.1</code>.
 
@@ -6572,7 +6572,7 @@ This API was first introduced in the <code>0.9.5</code> release.
 
 Returns the total number of the Nginx worker processes (i.e., the value configured
 by the [http://nginx.org/en/docs/ngx_core_module.html#worker_processes worker_processes]
-directive in `nginx.conf`).
+directive in <code>nginx.conf</code>).
 
 This API was first introduced in the <code>0.9.20</code> release.
 
@@ -6584,11 +6584,11 @@ This API was first introduced in the <code>0.9.20</code> release.
 
 Returns the ordinal number of the current Nginx worker processes (starting from number 0).
 
-So if the total number of workers is `N`, then this method may return a number between 0
-and `N - 1` (inclusive).
+So if the total number of workers is <code>N</code>, then this method may return a number between 0
+and <code>N - 1</code> (inclusive).
 
 This function returns meaningful values only for NGINX 1.9.1+. With earlier versions of NGINX, it
-always returns `nil`.
+always returns <code>nil</code>.
 
 See also [[#ngx.worker.count|ngx.worker.count]].
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -96,7 +96,7 @@ This document describes ngx_lua [https://github.com/openresty/lua-nginx-module/t
         }
 
         # use nginx var in code path
-        # WARNING: contents in nginx var must be carefully filtered,
+        # CAUTION: contents in nginx var must be carefully filtered,
         # otherwise there'll be great security risk!
         location ~ ^/app/([-_a-zA-Z0-9/]+) {
             set $path $1;
@@ -523,12 +523,12 @@ Here is the reason: by design, the global environment has exactly the same lifet
 Generally, use of Lua global variables is a really really bad idea in the context of ngx_lua because
 
 # misuse of Lua globals has very bad side effects for concurrent requests when these variables are actually supposed to be local only,
-# Lua global variables require Lua table look-up in the global environment (which is just a Lua table), which is kinda expensive, and
-# some Lua global variable references are just typos, which are hard to debug.
+# Lua global variables require Lua table look-up in the global environment (which is just a Lua table), which is use nginx var in code pat expensive, and
+# some Lua global variable references may include typing errors which make such difficult to debug.
 
-It's *highly* recommended to always declare them via "local" in the scope that is reasonable.
+It is therefore *highly* recommended to always declare such as "local" within an appropriate scope instead.
 
-To find out all the uses of Lua global variables in your Lua code, you can run the [https://github.com/openresty/nginx-devel-utils/blob/master/lua-releng lua-releng tool] across all your .lua source files:
+To find all instances of Lua global variables in your Lua code, run the [https://github.com/openresty/nginx-devel-utils/blob/master/lua-releng lua-releng tool] across all <code>.lua</code> source files:
 <geshi lang="text">
 $ lua-releng
 Checking use of Lua global variables in file lib/foo/bar.lua ...
@@ -565,24 +565,23 @@ will not work as expected.
 
 == Cosockets Not Available Everywhere ==
 
-Due the internal limitations in the nginx core, the cosocket API are disabled in the following contexts: [[#set_by_lua|set_by_lua*]], [[#log_by_lua|log_by_lua*]], [[#header_filter_by_lua|header_filter_by_lua*]], and [[#body_filter_by_lua|body_filter_by_lua]].
+Due the internal limitations in the nginx core, the cosocket API is disabled in the following contexts: [[#set_by_lua|set_by_lua*]], [[#log_by_lua|log_by_lua*]], [[#header_filter_by_lua|header_filter_by_lua*]], and [[#body_filter_by_lua|body_filter_by_lua]].
 
 The cosockets are currently also disabled in the [[#init_by_lua|init_by_lua*]] and [[#init_worker_by_lua|init_worker_by_lua*]] directive contexts but we may add support for these contexts in the future because there is no limitation in the nginx core (or the limitation might be worked around).
 
-There exists a work-around, however, when the original context does *not* need to wait for the cosocket results. That is, creating a 0-delay timer via the [[#ngx.timer.at|ngx.timer.at]] API and do the cosocket results in the timer handler, which runs asynchronously as to the original context creating the timer.
+There exists a work-around, however, when the original context does *not* need to wait for the cosocket results. That is, creating a zero-delay timer via the [[#ngx.timer.at|ngx.timer.at]] API and do the cosocket results in the timer handler, which runs asynchronously as to the original context creating the timer.
 
 == Special Escaping Sequences ==
 
-'''WARNING''' We no longer suffer from this pitfall since the introduction of the
-<code>*_by_lua_block {}</code> configuration directives.
+'''NOTE''' Following the `v0.9.17` release, this pitfall can be avoided by using the `*_by_lua_block {}` configuration directives.
 
-PCRE sequences such as <code>\d</code>, <code>\s</code>, or <code>\w</code>, require special attention because in string literals, the backslash character, <code>\</code>, is stripped out by both the Lua language parser and by the Nginx config file parser before processing. So the following snippet will not work as expected:
+PCRE sequences such as <code>\d</code>, <code>\s</code>, or <code>\w</code>, require special attention because in string literals, the backslash character, <code>\</code>, is stripped out by both the Lua language parser and by the Nginx config file parser before processing if not within a `*_by_lua_block {}` directive. So the following snippet will not work as expected:
 
 <geshi lang="nginx">
     # nginx.conf
     ? location /test {
     ?     content_by_lua '
-    ?         local regex = "\d+"  -- THIS IS WRONG!!
+    ?         local regex = "\d+"  -- THIS IS WRONG OUTSIDE A *_by_lua_block DIRECTIVE!!
     ?         local m = ngx.re.match("hello, 1234", regex)
     ?         if m then ngx.say(m[0]) else ngx.say("not matched!") end
     ?     ';
@@ -658,6 +657,21 @@ Within external script files, PCRE sequences presented as long-bracketed Lua str
     -- evaluates to "1234"
 </geshi>
 
+As noted earlier, PCRE sequences presented within `*_by_lua_block {}` directives, available following the `v0.9.17` release, do not require modification.
+
+<geshi lang="nginx">
+    # nginx.conf
+    location /test {
+        content_by_lua_block {
+            local regex = "\d+"
+            local m = ngx.re.match("hello, 1234", regex)
+            if m then ngx.say(m[0]) else ngx.say("not matched!") end
+        }
+    }
+    # evaluates to "1234"
+</geshi>
+
+
 == Mixing with SSI Not Supported ==
 
 Mixing SSI with ngx_lua in the same Nginx request is not supported at all. Just use ngx_lua exclusively. Everything you can do with SSI can be done atop ngx_lua anyway and it can be more efficient when using ngx_lua.
@@ -716,7 +730,7 @@ servers in Lua. For example,
 
 = Changes =
 
-The changes of every release of this module can be obtained from the OpenResty bundle's change logs:
+The changes made in every release of this module are listed in the change logs of the OpenResty bundle:
 
 http://openresty.org/#Changes
 
@@ -833,7 +847,7 @@ how the result will be used. Below is a diagram showing the order in which direc
 
 '''context:''' ''http, server, location, location if''
 
-Specifies whether to use the MIME type specified by the [http://nginx.org/en/docs/http/ngx_http_core_module.html#default_type default_type] directive for the default value of the <code>Content-Type</code> response header. If you do not want a default <code>Content-Type</code> response header for your Lua request handlers, then turn this directive off.
+Specifies whether to use the MIME type specified by the [http://nginx.org/en/docs/http/ngx_http_core_module.html#default_type default_type] directive for the default value of the <code>Content-Type</code> response header. Deactivate this directive if a default <code>Content-Type</code> response header for Lua request handlers is not desired.
 
 This directive is turned on by default.
 
@@ -898,7 +912,7 @@ Apache <code>mod_lua</code> module (yet).
 
 Disabling the Lua code cache is strongly
 discouraged for production use and should only be used during
-development as it has a significant negative impact on overall performance. For example, the performance a "hello world" Lua example can drop by an order of magnitude after disabling the Lua code cache.
+development as it has a significant negative impact on overall performance. For example, the performance of a "hello world" Lua example can drop by an order of magnitude after disabling the Lua code cache.
 
 == lua_regex_cache_max_entries ==
 '''syntax:''' ''lua_regex_cache_max_entries <num>''
@@ -972,8 +986,7 @@ As from the <code>v0.5.0rc29</code> release, the special notation <code>$prefix<
 
 '''phase:''' ''loading-config''
 
-'''WARNING''' Since the <code>v0.9.17</code> release, use of this directive is ''discouraged'';
-use the new [[#init_by_lua_block|init_by_lua_block]] directive instead.
+'''NOTE''' Use of this directive is ''discouraged'' following the <code>v0.9.17</code> release. Use the [[#init_by_lua_block|init_by_lua_block]] directive instead.
 
 Runs the Lua code specified by the argument <code><lua-script-str></code> on the global Lua VM level when the Nginx master process (if any) is loading the Nginx config file.
 
@@ -1077,7 +1090,7 @@ This directive was first introduced in the <code>v0.5.5</code> release.
 
 '''phase:''' ''starting-worker''
 
-'''WARNING''' Since the <code>v0.9.17</code> release, use of this directive is ''discouraged''; use the new [[#init_worker_by_lua_block|init_worker_by_lua_block]] directive instead.
+'''NOTE''' Use of this directive is ''discouraged'' following the <code>v0.9.17</code> release. Use the [[#init_worker_by_lua_block|init_worker_by_lua_block]] directive instead.
 
 Runs the specified Lua code upon every Nginx worker process's startup when the master process is enabled. When the master process is disabled, this hook will just run after [[#init_by_lua|init_by_lua*]].
 
@@ -1155,7 +1168,7 @@ This directive was first introduced in the <code>v0.9.5</code> release.
 
 '''phase:''' ''rewrite''
 
-'''WARNING''' Since the <code>v0.9.17</code> release, use of this directive is ''discouraged''; use the new [[#set_by_lua_block|set_by_lua_block]] directive instead.
+'''NOTE''' Use of this directive is ''discouraged'' following the <code>v0.9.17</code> release. Use the [[#set_by_lua_block|set_by_lua_block]] directive instead.
 
 Executes code specified in <code><lua-script-str></code> with optional input arguments <code>$arg1 $arg2 ...</code>, and returns string output to <code>$res</code>.
 The code in <code><lua-script-str></code> can make [[#Nginx API for Lua|API calls]] and can retrieve input arguments from the <code>ngx.arg</code> table (index starts from <code>1</code> and increases sequentially).
@@ -1257,8 +1270,7 @@ This directive requires the [https://github.com/simpl/ngx_devel_kit ngx_devel_ki
 
 '''phase:''' ''content''
 
-'''WARNING''' Since the <code>v0.9.17</code> release, use of this directive is ''discouraged'';
-use the new [[#content_by_lua_block|content_by_lua_block]] directive instead.
+'''NOTE''' Use of this directive is ''discouraged'' following the <code>v0.9.17</code> release. Use the [[#content_by_lua_block|content_by_lua_block]] directive instead.
 
 Acts as a "content handler" and executes Lua code string specified in <code><lua-script-str></code> for every request.
 The Lua code may make [[#Nginx API for Lua|API calls]] and is executed as a new spawned coroutine in an independent global environment (i.e. a sandbox).
@@ -1310,7 +1322,7 @@ switching [[#lua_code_cache|lua_code_cache]] <code>off</code> in <code>nginx.con
 Nginx variables are supported in the file path for dynamic dispatch, for example:
 
 <geshi lang="nginx">
-    # WARNING: contents in nginx var must be carefully filtered,
+    # CAUTION: contents in nginx var must be carefully filtered,
     # otherwise there'll be great security risk!
     location ~ ^/app/([-_a-zA-Z0-9/]+) {
         set $path $1;
@@ -1328,8 +1340,7 @@ But be very careful about malicious user inputs and always carefully validate or
 
 '''phase:''' ''rewrite tail''
 
-'''WARNING''' Since the <code>v0.9.17</code> release, use of this directive is ''discouraged'';
-use the new [[#rewrite_by_lua_block|rewrite_by_lua_block]] directive instead.
+'''NOTE''' Use of this directive is ''discouraged'' following the <code>v0.9.17</code> release. Use the [[#rewrite_by_lua_block|rewrite_by_lua_block]] directive instead.
 
 Acts as a rewrite phase handler and executes Lua code string specified in <code><lua-script-str></code> for every request.
 The Lua code may make [[#Nginx API for Lua|API calls]] and is executed as a new spawned coroutine in an independent global environment (i.e. a sandbox).
@@ -1489,8 +1500,7 @@ Nginx variables are supported in the file path for dynamic dispatch just as in [
 
 '''phase:''' ''access tail''
 
-'''WARNING''' Since the <code>v0.9.17</code> release, use of this directive is ''discouraged'';
-use the new [[#access_by_lua_block|access_by_lua_block]] directive instead.
+'''NOTE''' Use of this directive is ''discouraged'' following the <code>v0.9.17</code> release. Use the [[#access_by_lua_block|access_by_lua_block]] directive instead.
 
 Acts as an access phase handler and executes Lua code string specified in <code><lua-script-str></code> for every request.
 The Lua code may make [[#Nginx API for Lua|API calls]] and is executed as a new spawned coroutine in an independent global environment (i.e. a sandbox).
@@ -1606,8 +1616,7 @@ Nginx variables are supported in the file path for dynamic dispatch just as in [
 
 '''phase:''' ''output-header-filter''
 
-'''WARNING''' Since the <code>v0.9.17</code> release, use of this directive is ''discouraged'';
-use the new [[#header_filter_by_lua_block|header_filter_by_lua_block]] directive instead.
+'''NOTE''' Use of this directive is ''discouraged'' following the <code>v0.9.17</code> release. Use the [[#header_filter_by_lua_block|header_filter_by_lua_block]] directive instead.
 
 Uses Lua code specified in <code><lua-script-str></code> to define an output header filter.
 
@@ -1674,8 +1683,7 @@ This directive was first introduced in the <code>v0.2.1rc20</code> release.
 
 '''phase:''' ''output-body-filter''
 
-'''WARNING''' Since the <code>v0.9.17</code> release, use of this directive is ''discouraged'';
-use the new [[#body_filter_by_lua_block|body_filter_by_lua_block]] directive instead.
+'''NOTE''' Use of this directive is ''discouraged'' following the <code>v0.9.17</code> release. Use the [[#body_filter_by_lua_block|body_filter_by_lua_block]] directive instead.
 
 Uses Lua code specified in <code><lua-script-str></code> to define an output body filter.
 
@@ -1797,8 +1805,7 @@ This directive was first introduced in the <code>v0.5.0rc32</code> release.
 
 '''phase:''' ''log''
 
-'''WARNING''' Since the <code>v0.9.17</code> release, use of this directive is ''discouraged'';
-use the new [[#log_by_lua_block|log_by_lua_block]] directive instead.
+'''NOTE''' Use of this directive is ''discouraged'' following the <code>v0.9.17</code> release. Use the [[#log_by_lua_block|log_by_lua_block]] directive instead.
 
 Runs the Lua source code inlined as the <code><lua-script-str></code> at the <code>log</code> request processing phase. This does not replace the current access logs, but runs before.
 
@@ -2487,7 +2494,7 @@ This directive was first introduced in the <code>v0.5.0rc32</code> release.
 
 This directive controls whether to check for premature client connection abortion.
 
-When this directive is turned on, the ngx_lua module will monitor the premature connection close event on the downstream connections. And when there is such an event, it will call the user Lua function callback (registered by [[#ngx.on_abort|ngx.on_abort]]) or just stop and clean up all the Lua "light threads" running in the current request's request handler when there is no user callback function registered.
+When this directive is on, the ngx_lua module will monitor the premature connection close event on the downstream connections and when there is such an event, it will call the user Lua function callback (registered by [[#ngx.on_abort|ngx.on_abort]]) or just stop and clean up all the Lua "light threads" running in the current request's request handler when there is no user callback function registered.
 
 According to the current implementation, however, if the client closes the connection before the Lua code finishes reading the request body data via [[#ngx.req.socket|ngx.req.socket]], then ngx_lua will neither stop all the running "light threads" nor call the user callback (if [[#ngx.on_abort|ngx.on_abort]] has been called). Instead, the reading operation on [[#ngx.req.socket|ngx.req.socket]] will just return the error message "client aborted" as the second return value (the first return value is surely <code>nil</code>).
 
@@ -2647,7 +2654,7 @@ Setting <code>ngx.var.Foo</code> to a <code>nil</code> value will unset the <cod
     ngx.var.args = nil
 </geshi>
 
-'''WARNING''' When reading from an Nginx variable, Nginx will allocate memory in the per-request memory pool which is freed only at request termination. So when you need to read from an Nginx variable repeatedly in your Lua code, cache the Nginx variable value to your own Lua variable, for example,
+'''CAUTION''' When reading from an Nginx variable, Nginx will allocate memory in the per-request memory pool which is freed only at request termination. So when you need to read from an Nginx variable repeatedly in your Lua code, cache the Nginx variable value to your own Lua variable, for example,
 
 <geshi lang="lua">
     local val = ngx.var.some_var
@@ -5447,7 +5454,7 @@ Fetch a list of the keys from the dictionary, up to <code><max_count></code>.
 
 By default, only the first 1024 keys (if any) are returned. When the <code><max_count></code> argument is given the value <code>0</code>, then all the keys will be returned even there is more than 1024 keys in the dictionary.
 
-'''WARNING''' Be careful when calling this method on dictionaries with a really huge number of keys. This method may lock the dictionary for quite a while and block all the nginx worker processes that are trying to access the dictionary.
+'''CAUTION''' Avoid calling this method on dictionaries with a very large number of keys as this method may lock the dictionary for a significant amount of time while blocking nginx worker processes that are trying to access the dictionary.
 
 This feature was first introduced in the <code>v0.7.3</code> release.
 
@@ -6150,7 +6157,7 @@ Then it will generate the output
     4
 </geshi>
 
-"Light threads" are mostly useful for doing concurrent upstream requests in a single Nginx request handler, kinda like a generalized version of [[#ngx.location.capture_multi|ngx.location.capture_multi]] that can work with all the [[#Nginx API for Lua|Nginx API for Lua]]. The following example demonstrates parallel requests to MySQL, Memcached, and upstream HTTP services in a single Lua handler, and outputting the results in the order that they actually return (very much like the Facebook BigPipe model):
+"Light threads" are mostly useful for making concurrent upstream requests in a single Nginx request handler, much like a generalized version of [[#ngx.location.capture_multi|ngx.location.capture_multi]] that can work with all the [[#Nginx API for Lua|Nginx API for Lua]]. The following example demonstrates parallel requests to MySQL, Memcached, and upstream HTTP services in a single Lua handler, and outputting the results in the order that they actually return (similar to Facebook's BigPipe model):
 
 <geshi lang="lua">
     -- query mysql, memcached, and a remote http service at the same time,

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -523,7 +523,7 @@ Here is the reason: by design, the global environment has exactly the same lifet
 Generally, use of Lua global variables is a really really bad idea in the context of ngx_lua because
 
 # misuse of Lua globals has very bad side effects for concurrent requests when these variables are actually supposed to be local only,
-# Lua global variables require Lua table look-up in the global environment (which is just a Lua table), which is use nginx var in code pat expensive, and
+# Lua global variables require Lua table look-up in the global environment (which is just a Lua table), which is computationally expensive, and
 # some Lua global variable references may include typing errors which make such difficult to debug.
 
 It is therefore *highly* recommended to always declare such as "local" within an appropriate scope instead.


### PR DESCRIPTION
- Instances of “Warning” changed to more appropriate terms such as “Note” or “Caution”
- Removed informal terms such as “kinda”
- Converted several markdown backticks to mediawiki format

I hereby grant the copyright of the changes in this pull request
to the authors of the lua-nginx-module project.
