### PR TITLE
test: added passed cases for init_by_lua*.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ install:
   - if [ ! -f download-cache/drizzle7-$DRIZZLE_VER.tar.gz ]; then wget -P download-cache http://openresty.org/download/drizzle7-$DRIZZLE_VER.tar.gz; fi
   - if [ ! -f download-cache/pcre-$PCRE_VER.tar.gz ]; then wget -P download-cache http://ftp.cs.stanford.edu/pub/exim/pcre/pcre-$PCRE_VER.tar.gz; fi
   - if [ ! -f download-cache/openssl-$OPENSSL_VER.tar.gz ]; then wget -P download-cache https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz; fi
-  - git clone https://github.com/openresty/test-nginx.git
+  - git clone -b skip https://github.com/doujiang24/test-nginx.git
   - git clone https://github.com/openresty/openresty.git ../openresty
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone https://github.com/openresty/nginx-devel-utils.git

--- a/t/086-init-by.t
+++ b/t/086-init-by.t
@@ -8,7 +8,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 3 + 3);
+plan tests => repeat_each() * (blocks() * 3 + 2);
 
 #no_diff();
 #no_long_string();
@@ -304,3 +304,20 @@ INIT 2: foo = 3
 ",
 "",
 ]
+
+
+
+=== TEST 12: error in init
+--- http_config
+    init_by_lua_block {
+        error("failed to init")
+    }
+--- config
+    location /t {
+        echo ok;
+    }
+--- must_die
+--- error_log
+failed to init
+--- error_log
+[error]

--- a/t/151-initby-hup.t
+++ b/t/151-initby-hup.t
@@ -68,7 +68,7 @@ GET /lua
 hello, FOO
 --- error_log
 failed to init
---- skip_check_config_version
+--- reload_fails
 
 
 
@@ -139,7 +139,7 @@ GET /lua
 foo have changed
 --- error_log
 failed to init
---- skip_check_config_version
+--- reload_fails
 
 
 

--- a/t/151-initby-hup.t
+++ b/t/151-initby-hup.t
@@ -1,0 +1,91 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+our $SkipReason;
+
+BEGIN {
+    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
+        $SkipReason = "unavailable for the hup tests";
+
+    } else {
+        $ENV{TEST_NGINX_USE_HUP} = 1;
+        undef $ENV{TEST_NGINX_USE_STAP};
+    }
+}
+
+use Test::Nginx::Socket::Lua 'no_plan';
+
+#worker_connections(1014);
+#master_on();
+#workers(2);
+#log_level('warn');
+
+repeat_each(1);
+
+#plan tests => repeat_each() * (blocks() * 3 + 3);
+
+#no_diff();
+#no_long_string();
+no_shuffle();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: no error in init before HUP
+--- http_config
+    init_by_lua_block {
+        foo = "hello, FOO"
+    }
+--- config
+    location /lua {
+        content_by_lua_block {
+            ngx.say(foo)
+        }
+    }
+--- request
+GET /lua
+--- response_body
+hello, FOO
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: error in init after HUP (master still alive, worker process still the same as before)
+--- http_config
+    init_by_lua_block {
+        error("failed to init")
+    }
+--- config
+    location /lua {
+        content_by_lua_block {
+            ngx.say(foo)
+        }
+    }
+--- request
+GET /lua
+--- response_body
+hello, FOO
+--- error_log
+failed to init
+--- skip_check_config_version
+
+
+
+=== TEST 3: no error in init again
+--- http_config
+    init_by_lua_block {
+        foo = "hello, foo"
+    }
+--- config
+    location /lua {
+        content_by_lua_block {
+            ngx.say(foo)
+        }
+    }
+--- request
+GET /lua
+--- response_body
+hello, foo
+--- no_error_log
+[error]


### PR DESCRIPTION
Now we can raise an error in init_by_lua*, which will make the HUP reload failed with nothing changed.
I just added some test case to cover it.
With these test cases, this pr(https://github.com/openresty/lua-nginx-module/pull/974) will failed:
https://travis-ci.org/doujiang24/lua-nginx-module/builds/206939408
(Because nginx think init_module should not failed: https://github.com/nginx/nginx/blob/master/src/core/ngx_cycle.c#L629)

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.