### PR TITLE
bugfix: lacking the fix from #936 in the C API for lua-resty-core #1031.

### DIFF
--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -1298,11 +1298,28 @@ ngx_http_lua_ffi_get_resp_header(ngx_http_request_t *r,
     ngx_uint_t           i;
     ngx_table_elt_t     *h;
     ngx_list_part_t     *part;
+    ngx_http_lua_ctx_t  *ctx;
+    ngx_int_t            rc;
 
     ngx_http_lua_loc_conf_t     *llcf;
 
     if (r->connection->fd == (ngx_socket_t) -1) {
         return NGX_HTTP_LUA_FFI_BAD_CONTEXT;
+    }
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+    if (ctx == NULL) {
+        // *errmsg = "no ctx found";
+        return NGX_ERROR;
+    }
+
+    if (!ctx->headers_set) {
+        rc = ngx_http_lua_set_content_type(r);
+        if (rc != NGX_OK) {
+            // *errmsg = "failed to set default content type";
+            return NGX_ERROR;
+        }
+        ctx->headers_set = 1;
     }
 
     llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);

--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -1299,7 +1299,6 @@ ngx_http_lua_ffi_get_resp_header(ngx_http_request_t *r,
     ngx_table_elt_t     *h;
     ngx_list_part_t     *part;
     ngx_http_lua_ctx_t  *ctx;
-    ngx_int_t            rc;
 
     ngx_http_lua_loc_conf_t     *llcf;
 
@@ -1309,16 +1308,16 @@ ngx_http_lua_ffi_get_resp_header(ngx_http_request_t *r,
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
     if (ctx == NULL) {
-        // *errmsg = "no ctx found";
+        /* *errmsg = "no ctx found"; */
         return NGX_ERROR;
     }
 
     if (!ctx->headers_set) {
-        rc = ngx_http_lua_set_content_type(r);
-        if (rc != NGX_OK) {
-            // *errmsg = "failed to set default content type";
+        if (ngx_http_lua_set_content_type(r) != NGX_OK) {
+            /* *errmsg = "failed to set default content type"; */
             return NGX_ERROR;
         }
+
         ctx->headers_set = 1;
     }
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
`ngx_http_lua_ffi_get_resp_header` no `errmsg` parameter yet , so just return `NGX_ERROR`.
I passed the test cases in my MBP, @agentzh please try in your side.