### PR TITLE
Remove unused NGX_HTTP_LUA_HAVE_CONSTRUCTOR check

### DIFF
--- a/config
+++ b/config
@@ -486,6 +486,10 @@ ngx_feature_test="int rc = malloc_trim((size_t) 0); printf(\"%d\", rc);"
 SAVED_CC_TEST_FLAGS="$CC_TEST_FLAGS"
 CC_TEST_FLAGS="-Werror -Wall $CC_TEST_FLAGS"
 
+. auto/feature
+
+CC_TEST_FLAGS="$SAVED_CC_TEST_FLAGS"
+
 # ----------------------------------------
 
 if test -n "$ngx_module_link"; then

--- a/config
+++ b/config
@@ -472,24 +472,6 @@ ngx_feature_test='setsockopt(1, SOL_SOCKET, SO_PASSCRED, NULL, 0);'
 
 . auto/feature
 
-ngx_feature="__attribute__(constructor)"
-ngx_feature_libs=
-ngx_feature_name="NGX_HTTP_LUA_HAVE_CONSTRUCTOR"
-ngx_feature_run=yes
-ngx_feature_incs="#include <stdlib.h>
-int a = 2;
-__attribute__((constructor))
-static void foo(void)
-{
-    a = 0;
-}
-"
-ngx_feature_test="exit(a);"
-SAVED_CC_TEST_FLAGS="$CC_TEST_FLAGS"
-CC_TEST_FLAGS="-Werror -Wall $CC_TEST_FLAGS"
-
-. auto/feature
-
 CC_TEST_FLAGS="$SAVED_CC_TEST_FLAGS"
 
 # ----------------------------------------

--- a/config
+++ b/config
@@ -486,10 +486,6 @@ ngx_feature_test="int rc = malloc_trim((size_t) 0); printf(\"%d\", rc);"
 SAVED_CC_TEST_FLAGS="$CC_TEST_FLAGS"
 CC_TEST_FLAGS="-Werror -Wall $CC_TEST_FLAGS"
 
-. auto/feature
-
-CC_TEST_FLAGS="$SAVED_CC_TEST_FLAGS"
-
 # ----------------------------------------
 
 if test -n "$ngx_module_link"; then


### PR DESCRIPTION
Since mmap(sbrk(0)) has been removed, this config check is not needed.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
