### PR TITLE
add delay_list to tag delay init_by_lua or not

### DIFF
--- a/src/api/ngx_http_lua_api.h
+++ b/src/api/ngx_http_lua_api.h
@@ -49,6 +49,11 @@ ngx_shm_zone_t *ngx_http_lua_find_zone(u_char *name_data, size_t name_len);
 ngx_shm_zone_t *ngx_http_lua_shared_memory_add(ngx_conf_t *cf, ngx_str_t *name,
     size_t size, void *tag);
 
+ngx_int_t ngx_http_lua_delay_list_register(ngx_conf_t *cf,
+    void *tag);
+
+ngx_int_t ngx_http_lua_delay_init_phase();
+
 
 #endif /* _NGX_HTTP_LUA_API_H_INCLUDED_ */
 

--- a/src/api/ngx_http_lua_api.h
+++ b/src/api/ngx_http_lua_api.h
@@ -49,10 +49,10 @@ ngx_shm_zone_t *ngx_http_lua_find_zone(u_char *name_data, size_t name_len);
 ngx_shm_zone_t *ngx_http_lua_shared_memory_add(ngx_conf_t *cf, ngx_str_t *name,
     size_t size, void *tag);
 
-ngx_int_t ngx_http_lua_delay_list_register(ngx_conf_t *cf,
+ngx_int_t ngx_http_lua_delay_init_declare(ngx_conf_t *cf,
     void *tag);
 
-ngx_int_t ngx_http_lua_delay_init_phase();
+ngx_int_t ngx_http_lua_delay_init_handler();
 
 
 #endif /* _NGX_HTTP_LUA_API_H_INCLUDED_ */

--- a/src/ngx_http_lua_api.c
+++ b/src/ngx_http_lua_api.c
@@ -198,8 +198,7 @@ ngx_http_lua_shared_memory_init(ngx_shm_zone_t *shm_zone, void *data)
 
     lmcf->shm_zones_inited++;
 
-    if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts)
-    {
+    if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts) {
         saved_cycle = ngx_cycle;
         ngx_cycle = ctx->cycle;
 
@@ -275,11 +274,13 @@ ngx_http_lua_delay_init_handler()
     lmcf->delay_init_counter++;
 
     if (lmcf->delay_init->nelts > lmcf->delay_init_counter) {
-        return NGX_ERROR;
+        return NGX_OK;
     }
 
     if (lmcf->delay_init->nelts < lmcf->delay_init_counter) {
-        return NGX_OK;
+        ngx_log_error(NGX_LOG_ERR, lmcf->cycle->log, 0,
+                      "\"ngx_http_lua_delay_init_handler\" run too much times");
+        return NGX_ERROR;
     }
 
     /* lmcf->delay_init->nelts == lmcf->delay_init_counter */

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -21,6 +21,8 @@
 #include <lualib.h>
 #include <lauxlib.h>
 
+#include "api/ngx_http_lua_api.h"
+
 
 #if !defined(nginx_version) || (nginx_version < 1006000)
 #error at least nginx 1.6.0 is required but found an older version
@@ -176,6 +178,9 @@ struct ngx_http_lua_main_conf_s {
 
     ngx_array_t         *preload_hooks; /* of ngx_http_lua_preload_hook_t */
 
+    ngx_array_t         *delay_list; /* of void* */
+    unsigned             delay_list_inited;
+
     ngx_flag_t           postponed_to_rewrite_phase_end;
     ngx_flag_t           postponed_to_access_phase_end;
 
@@ -211,7 +216,6 @@ struct ngx_http_lua_main_conf_s {
     unsigned             requires_rewrite:1;
     unsigned             requires_access:1;
     unsigned             requires_log:1;
-    unsigned             requires_shm:1;
 };
 
 

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -179,7 +179,7 @@ struct ngx_http_lua_main_conf_s {
     ngx_array_t         *preload_hooks; /* of ngx_http_lua_preload_hook_t */
 
     ngx_array_t         *delay_init; /* of void* */
-    unsigned             delay_init_counter;
+    ngx_uint_t           delay_init_counter;
 
     ngx_flag_t           postponed_to_rewrite_phase_end;
     ngx_flag_t           postponed_to_access_phase_end;

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -178,8 +178,8 @@ struct ngx_http_lua_main_conf_s {
 
     ngx_array_t         *preload_hooks; /* of ngx_http_lua_preload_hook_t */
 
-    ngx_array_t         *delay_list; /* of void* */
-    unsigned             delay_list_inited;
+    ngx_array_t         *delay_init; /* of void* */
+    unsigned             delay_init_counter;
 
     ngx_flag_t           postponed_to_rewrite_phase_end;
     ngx_flag_t           postponed_to_access_phase_end;

--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -147,8 +147,6 @@ ngx_http_lua_shared_dict(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     *zp = zone;
 
-    lmcf->requires_shm = 1;
-
     return NGX_CONF_OK;
 }
 

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -743,8 +743,8 @@ ngx_http_lua_init(ngx_conf_t *cf)
         }
 
         if (lmcf->init_handler
-            && (!lmcf->delay_list
-                || lmcf->delay_list->nelts == lmcf->delay_list_inited))
+            && (!lmcf->delay_init
+                || lmcf->delay_init->nelts == lmcf->delay_init_counter))
         {
             saved_cycle = ngx_cycle;
             ngx_cycle = cf->cycle;
@@ -823,8 +823,8 @@ ngx_http_lua_create_main_conf(ngx_conf_t *cf)
      *      lmcf->shm_zones_inited = 0;
      *      lmcf->shdict_zones = NULL;
      *      lmcf->preload_hooks = NULL;
-     *      lmcf->delay_list = NULL;
-     *      lmcf->delay_list_inited = 0;
+     *      lmcf->delay_init = NULL;
+     *      lmcf->delay_init_counter = 0;
      *      lmcf->requires_header_filter = 0;
      *      lmcf->requires_body_filter = 0;
      *      lmcf->requires_capture_filter = 0;

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -742,7 +742,10 @@ ngx_http_lua_init(ngx_conf_t *cf)
             return NGX_ERROR;
         }
 
-        if (!lmcf->requires_shm && lmcf->init_handler) {
+        if (lmcf->init_handler
+            && (!lmcf->delay_list
+                || lmcf->delay_list->nelts == lmcf->delay_list_inited))
+        {
             saved_cycle = ngx_cycle;
             ngx_cycle = cf->cycle;
 
@@ -820,13 +823,14 @@ ngx_http_lua_create_main_conf(ngx_conf_t *cf)
      *      lmcf->shm_zones_inited = 0;
      *      lmcf->shdict_zones = NULL;
      *      lmcf->preload_hooks = NULL;
+     *      lmcf->delay_list = NULL;
+     *      lmcf->delay_list_inited = 0;
      *      lmcf->requires_header_filter = 0;
      *      lmcf->requires_body_filter = 0;
      *      lmcf->requires_capture_filter = 0;
      *      lmcf->requires_rewrite = 0;
      *      lmcf->requires_access = 0;
      *      lmcf->requires_log = 0;
-     *      lmcf->requires_shm = 0;
      */
 
     lmcf->pool = cf->pool;

--- a/t/152-fake-delay-init-lua.t
+++ b/t/152-fake-delay-init-lua.t
@@ -1,0 +1,106 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use lib 'lib';
+use Test::Nginx::Socket::Lua;
+
+#worker_connections(1014);
+#master_process_enabled(1);
+#log_level('warn');
+
+#repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 8);
+
+#no_diff();
+no_long_string();
+#master_on();
+#workers(2);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: delay init_by_lua by only fake_delay_init_lua
+--- http_config
+    lua_fake_delay_shm x1 1m;
+    lua_fake_delay_shm x2 2m;
+    init_by_lua_block {
+        local shm_zones = require("fake_delay_init_lua")
+        local name, size
+
+        local x1 = shm_zones.x1
+        name, size = x1:get_info()
+        ngx.log(ngx.ERR, type(x1))
+        ngx.log(ngx.ERR, "name=", name)
+        ngx.log(ngx.ERR, "size=", size)
+
+        local x2 = shm_zones.x2
+        name, size = x2:get_info()
+        ngx.log(ngx.ERR, type(x1))
+        ngx.log(ngx.ERR, "name=", name)
+        ngx.log(ngx.ERR, "size=", size)
+    }
+--- config
+    location = /test {
+        content_by_lua_block {
+            ngx.say("hello")
+        }
+    }
+--- request
+GET /test
+--- response_body
+hello
+--- error_log
+table
+name=x1
+size=1048576
+table
+name=x2
+size=2097152
+
+
+
+=== TEST 2: delay by lua_shared_dict and fake_delay_init_lua
+--- http_config
+    lua_fake_delay_shm x1 1m;
+    lua_fake_delay_shm x2 2m;
+
+    lua_shared_dict dogs 1m;
+
+    init_by_lua_block {
+        local shm_zones = require("fake_delay_init_lua")
+        local name, size
+
+        local x1 = shm_zones.x1
+        name, size = x1:get_info()
+        ngx.log(ngx.ERR, type(x1))
+        ngx.log(ngx.ERR, "name=", name)
+        ngx.log(ngx.ERR, "size=", size)
+
+        local x2 = shm_zones.x2
+        name, size = x2:get_info()
+        ngx.log(ngx.ERR, type(x1))
+        ngx.log(ngx.ERR, "name=", name)
+        ngx.log(ngx.ERR, "size=", size)
+
+        local dogs = ngx.shared.dogs
+        dogs:set("foo", "hello, FOO")
+    }
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+            local foo = dogs:get("foo")
+            ngx.say(foo)
+        }
+    }
+--- request
+GET /test
+--- response_body
+hello, FOO
+--- error_log
+table
+name=x1
+size=1048576
+table
+name=x2
+size=2097152

--- a/t/data/fake-delay-init-lua-module/config
+++ b/t/data/fake-delay-init-lua-module/config
@@ -1,0 +1,3 @@
+ngx_addon_name="ngx_http_lua_fake_delay_init_lua_module"
+HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_lua_fake_delay_init_lua_module"
+NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_lua_fake_delay_init_lua_module.c"

--- a/t/data/fake-delay-init-lua-module/ngx_http_lua_fake_delay_init_lua_module.c
+++ b/t/data/fake-delay-init-lua-module/ngx_http_lua_fake_delay_init_lua_module.c
@@ -1,0 +1,322 @@
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+#include <nginx.h>
+
+
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
+
+
+#include "ngx_http_lua_api.h"
+
+
+static void *ngx_http_lua_fake_delay_init_lua_create_main_conf(ngx_conf_t *cf);
+static ngx_int_t ngx_http_lua_fake_delay_init_lua_init(ngx_conf_t *cf);
+
+static char *ngx_http_lua_fake_delay_init_lua(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf);
+static ngx_int_t ngx_http_lua_fake_delay_init_lua_init_zone(
+    ngx_shm_zone_t *shm_zone, void *data);
+static int ngx_http_lua_fake_delay_init_lua_preload(lua_State *L);
+static int ngx_http_lua_fake_delay_init_lua_get_info(lua_State *L);
+
+
+typedef struct {
+    ngx_array_t     *shm_zones;
+    ngx_uint_t       shm_zone_inited;
+} ngx_http_lua_fake_delay_init_lua_main_conf_t;
+
+
+static ngx_command_t ngx_http_lua_fake_delay_init_lua_cmds[] = {
+
+    { ngx_string("lua_fake_delay_shm"),
+      NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE2,
+      ngx_http_lua_fake_delay_init_lua,
+      0,
+      0,
+      NULL },
+
+    ngx_null_command
+};
+
+
+static ngx_http_module_t  ngx_http_lua_fake_delay_init_lua_module_ctx = {
+    NULL,                                   /* preconfiguration */
+    ngx_http_lua_fake_delay_init_lua_init,  /* postconfiguration */
+
+    /* create main configuration */
+    ngx_http_lua_fake_delay_init_lua_create_main_conf,
+    NULL,                                   /* init main configuration */
+
+    NULL,                                   /* create server configuration */
+    NULL,                                   /* merge server configuration */
+
+    NULL,                                   /* create location configuration */
+    NULL,                                   /* merge location configuration */
+};
+
+
+ngx_module_t  ngx_http_lua_fake_delay_init_lua_module = {
+    NGX_MODULE_V1,
+    &ngx_http_lua_fake_delay_init_lua_module_ctx, /* module context */
+    ngx_http_lua_fake_delay_init_lua_cmds,        /* module directives */
+    NGX_HTTP_MODULE,                   /* module type */
+    NULL,                              /* init master */
+    NULL,                              /* init module */
+    NULL,                              /* init process */
+    NULL,                              /* init thread */
+    NULL,                              /* exit thread */
+    NULL,                              /* exit process */
+    NULL,                              /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+
+typedef struct {
+    ngx_str_t   name;
+    size_t      size;
+
+    ngx_http_lua_fake_delay_init_lua_main_conf_t *lfdilcf;
+    volatile ngx_cycle_t                         *cycle;
+} ngx_http_lua_fake_delay_init_lua_ctx_t;
+
+
+static void *
+ngx_http_lua_fake_delay_init_lua_create_main_conf(ngx_conf_t *cf)
+{
+    ngx_http_lua_fake_delay_init_lua_main_conf_t *lfdilcf;
+
+    /*
+     * shm_zone_inited = 0
+     */
+    lfdilcf = ngx_pcalloc(cf->pool, sizeof(*lfdilcf));
+    if (lfdilcf == NULL) {
+        return NULL;
+    }
+
+    return lfdilcf;
+}
+
+
+static char *
+ngx_http_lua_fake_delay_init_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf)
+{
+    ngx_http_lua_fake_delay_init_lua_main_conf_t   *lfdilcf = conf;
+    ngx_http_lua_fake_delay_init_lua_ctx_t         *ctx;
+
+    ngx_str_t                   *value, name;
+    ngx_shm_zone_t              *zone;
+    ngx_shm_zone_t             **zp;
+    ssize_t                      size;
+    ngx_int_t                    rc;
+
+    if (lfdilcf->shm_zones == NULL) {
+        lfdilcf->shm_zones = ngx_palloc(cf->pool, sizeof(ngx_array_t));
+        if (lfdilcf->shm_zones == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        if (ngx_array_init(lfdilcf->shm_zones, cf->pool, 2,
+                           sizeof(ngx_shm_zone_t *))
+            != NGX_OK)
+        {
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    value = cf->args->elts;
+
+    ctx = NULL;
+
+    if (value[1].len == 0) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "invalid lua fake_delay_shm name \"%V\"", &value[1]);
+        return NGX_CONF_ERROR;
+    }
+
+    name = value[1];
+
+    size = ngx_parse_size(&value[2]);
+
+    if (size <= 8191) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "invalid lua fake_delay_shm size \"%V\"", &value[2]);
+        return NGX_CONF_ERROR;
+    }
+
+    ctx = ngx_pcalloc(cf->pool,
+                      sizeof(ngx_http_lua_fake_delay_init_lua_ctx_t));
+    if (ctx == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    ctx->name = name;
+    ctx->size = size;
+    ctx->lfdilcf = lfdilcf;
+    ctx->cycle = cf->cycle;
+
+    zone = ngx_shared_memory_add(cf, &name, (size_t) size,
+                                 &ngx_http_lua_fake_delay_init_lua_module);
+    if (zone == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    if (zone->data) {
+        ctx = zone->data;
+
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "lua_fake_shm \"%V\" is already defined as "
+                           "\"%V\"", &name, &ctx->name);
+        return NGX_CONF_ERROR;
+    }
+
+    zone->init = ngx_http_lua_fake_delay_init_lua_init_zone;
+    zone->data = ctx;
+
+    zp = ngx_array_push(lfdilcf->shm_zones);
+    if (zp == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    *zp = zone;
+
+    rc = ngx_http_lua_delay_init_declare(cf,
+             &ngx_http_lua_fake_delay_init_lua_module);
+    if (rc == NGX_ERROR) {
+        return NGX_CONF_ERROR;
+    }
+
+    return NGX_CONF_OK;
+}
+
+
+/*
+ * must run after init_by_lua
+ */
+static ngx_int_t
+ngx_http_lua_fake_delay_init_lua_init_zone(ngx_shm_zone_t *shm_zone,
+    void *data)
+{
+    ngx_http_lua_fake_delay_init_lua_main_conf_t   *lfdilcf;
+    ngx_http_lua_fake_delay_init_lua_ctx_t         *ctx;
+    ngx_int_t                                       rc;
+    volatile ngx_cycle_t                           *saved_cycle;
+
+    ctx = shm_zone->data;
+
+    lfdilcf = ctx->lfdilcf;
+
+    lfdilcf->shm_zone_inited++;
+    if (lfdilcf->shm_zone_inited == lfdilcf->shm_zones->nelts){
+        saved_cycle = ngx_cycle;
+        ngx_cycle = ctx->cycle;
+
+        rc = ngx_http_lua_delay_init_handler();
+
+        ngx_cycle = saved_cycle;
+
+        if (rc != NGX_OK) {
+            return NGX_ERROR;
+        }
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_lua_fake_delay_init_lua_init(ngx_conf_t *cf)
+{
+    ngx_http_lua_add_package_preload(cf, "fake_delay_init_lua",
+        ngx_http_lua_fake_delay_init_lua_preload);
+    return NGX_OK;
+}
+
+
+static int
+ngx_http_lua_fake_delay_init_lua_preload(lua_State *L)
+{
+    ngx_http_lua_fake_delay_init_lua_main_conf_t *lfdilcf;
+    ngx_http_conf_ctx_t               *hmcf_ctx;
+    ngx_cycle_t                       *cycle;
+
+    ngx_uint_t                   i;
+    ngx_shm_zone_t             **zone;
+
+    lua_getglobal(L, "__ngx_cycle");
+    cycle = lua_touserdata(L, -1);
+    lua_pop(L, 1);
+
+    hmcf_ctx = (ngx_http_conf_ctx_t *) cycle->conf_ctx[ngx_http_module.index];
+    lfdilcf =
+        hmcf_ctx->main_conf[ngx_http_lua_fake_delay_init_lua_module.ctx_index];
+
+    if (lfdilcf->shm_zones != NULL) {
+        lua_createtable(L, 0, lfdilcf->shm_zones->nelts /* nrec */);
+
+        lua_createtable(L, 0 /* narr */, 2 /* nrec */); /* shared mt */
+
+        lua_pushcfunction(L, ngx_http_lua_fake_delay_init_lua_get_info);
+        lua_setfield(L, -2, "get_info");
+
+        lua_pushvalue(L, -1); /* shared mt mt */
+        lua_setfield(L, -2, "__index"); /* shared mt */
+
+        zone = lfdilcf->shm_zones->elts;
+
+        for (i = 0; i < lfdilcf->shm_zones->nelts; i++) {
+            lua_pushlstring(L, (char *) zone[i]->shm.name.data,
+                            zone[i]->shm.name.len);
+
+            /* shared mt key */
+
+            lua_createtable(L, 1 /* narr */, 0 /* nrec */);
+                /* table of zone[i] */
+            lua_pushlightuserdata(L, zone[i]); /* shared mt key ud */
+            lua_rawseti(L, -2, 1); /* {zone[i]} */
+            lua_pushvalue(L, -3); /* shared mt key ud mt */
+            lua_setmetatable(L, -2); /* shared mt key ud */
+            lua_rawset(L, -4); /* shared mt */
+        }
+
+        lua_pop(L, 1); /* shared */
+
+    } else {
+        lua_newtable(L);    /* ngx.shared */
+    }
+
+    return 1;
+}
+
+
+static int
+ngx_http_lua_fake_delay_init_lua_get_info(lua_State *L)
+{
+    ngx_int_t                    n;
+    ngx_shm_zone_t              *zone;
+
+    n = lua_gettop(L);
+
+    if (n != 1) {
+        return luaL_error(L, "expecting exactly one arguments, "
+                          "but only seen %d", n);
+    }
+
+    luaL_checktype(L, 1, LUA_TTABLE);
+
+    lua_rawgeti(L, 1, 1);
+    zone = lua_touserdata(L, -1);
+    lua_pop(L, 1);
+
+    if (zone == NULL) {
+        return luaL_error(L, "bad \"zone\" argument");
+    }
+
+    lua_pushlstring(L, (char *) zone->shm.name.data, zone->shm.name.len);
+    lua_pushnumber(L, zone->shm.size);
+
+    return 2;
+}

--- a/util/build.sh
+++ b/util/build.sh
@@ -53,6 +53,7 @@ time ngx-build $force $version \
                 --add-module=$root/t/data/fake-module \
                 --add-module=$root/t/data/fake-shm-module \
                 --add-module=$root/t/data/fake-delayed-load-module \
+                --add-module=$root/t/data/fake-delay-init-lua-module \
                 --with-http_gunzip_module \
                 --with-http_dav_module \
           --with-select_module \


### PR DESCRIPTION
Some time we need to delayed execution of init_by_lua. For example, a third party module using `ngx_shm_zone_t`, and also want to be able to use this module in init_by_lua.
So I think we should provide a init_by_lua to the other third party module for callback.

