### PR TITLE
feature: support of non-preemptive time slicing when running CPU intensive Lua code.

### DIFF
--- a/src/ngx_http_lua_sleep.c
+++ b/src/ngx_http_lua_sleep.c
@@ -92,6 +92,9 @@ ngx_http_lua_ngx_sleep(lua_State *L)
         ngx_add_timer(&coctx->sleep, (ngx_msec_t) delay);
     }
 
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "lua ready to sleep for %d ms", delay);
+
     return lua_yield(L, 0);
 }
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

Note that the `delayed` field is not being used by the `coctx->sleep` event and we reuse it for keeping track of whether at least one event loop has passed.

Need to be used with: https://github.com/openresty/openresty/pull/252

Test config:

```
location = / { 
    root   html;
    index  index.html index.htm;
    content_by_lua_block {
        local t = ngx.thread.spawn(function()
            for i=1,500000000 do
                if i % 100000 == 0 then
                    ngx.sleep(0)
                end 

                a = math.random()
            end 
        end)
        for i=1,500000000 do
            if i % 100000 == 0 then
                ngx.sleep(0)
            end 

            if i == 100000000 then
                ngx.thread.kill(t)
            end 

            a = math.random()
        end 
        ngx.say('it works!')
    }
}
```

Before the patch, curl `/` in one terminal while curl `/404` in another window, `/404` will not return until `/` finished.

After the patch, curl `/404` is always responsible even if `/` is running at the same time.