### PR TITLE
Prevent segfault while calling srv.ssl_cert_handle

### DIFF
--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -298,8 +298,14 @@ ngx_http_lua_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
 
     c->log->action = "loading SSL certificate by lua";
 
-    rc = lscf->srv.ssl_cert_handler(r, lscf, L);
-
+    if (lscf->srv.ssl_cert_handler) {
+        rc = lscf->srv.ssl_cert_handler(r, lscf, L);
+    } else {
+        ngx_ssl_error(NGX_LOG_ALERT, c->log, 0,
+                      "srv.ssl_cert_handler is null");
+        goto failed;
+    }
+    
     if (rc >= NGX_OK || rc == NGX_ERROR) {
         cctx->done = 1;
 


### PR DESCRIPTION
In some cases lscf->srv.ssl_cert_handler may be null pointer. Probably it's caused by some https clients which do something wrong during ssl handshake.
In any case we should not call null pointer function.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
