### PR TITLE
add lua_ssl_certificate for server to certificate client

### DIFF
--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -249,6 +249,9 @@ typedef struct {
     ngx_uint_t              ssl_verify_depth;
     ngx_str_t               ssl_trusted_certificate;
     ngx_str_t               ssl_crl;
+    ngx_str_t               ssl_certificate;
+    ngx_str_t               ssl_certificate_key;
+    ngx_array_t            *ssl_passwords;
 #endif
 
     ngx_flag_t              force_read_body; /* whether force request body to

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -43,6 +43,8 @@ static char *ngx_http_lua_merge_loc_conf(ngx_conf_t *cf, void *parent,
 static ngx_int_t ngx_http_lua_init(ngx_conf_t *cf);
 static char *ngx_http_lua_lowat_check(ngx_conf_t *cf, void *post, void *data);
 #if (NGX_HTTP_SSL)
+static char *ngx_http_lua_ssl_password_file(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf);
 static ngx_int_t ngx_http_lua_set_ssl(ngx_conf_t *cf,
     ngx_http_lua_loc_conf_t *llcf);
 #endif
@@ -571,6 +573,28 @@ static ngx_command_t ngx_http_lua_cmds[] = {
       offsetof(ngx_http_lua_loc_conf_t, ssl_crl),
       NULL },
 
+    { ngx_string("lua_ssl_certificate"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_lua_loc_conf_t, ssl_certificate),
+      NULL },
+
+    { ngx_string("lua_ssl_certificate_key"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_lua_loc_conf_t, ssl_certificate_key),
+      NULL },
+
+    { ngx_string("lua_ssl_password_file"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_http_lua_ssl_password_file,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      NULL },
+
+
 #endif  /* NGX_HTTP_SSL */
 
      { ngx_string("lua_malloc_trim"),
@@ -1059,6 +1083,8 @@ ngx_http_lua_create_loc_conf(ngx_conf_t *cf)
      *      conf->ssl_ciphers = { 0, NULL };
      *      conf->ssl_trusted_certificate = { 0, NULL };
      *      conf->ssl_crl = { 0, NULL };
+     *      conf->ssl_certificate = { 0, NULL };
+     *      conf->ssl_certificate_key = { 0, NULL };
      */
 
     conf->force_read_body    = NGX_CONF_UNSET;
@@ -1080,6 +1106,7 @@ ngx_http_lua_create_loc_conf(ngx_conf_t *cf)
 
 #if (NGX_HTTP_SSL)
     conf->ssl_verify_depth = NGX_CONF_UNSET_UINT;
+    conf->ssl_passwords = NGX_CONF_UNSET_PTR;
 #endif
 
     return conf;
@@ -1152,6 +1179,12 @@ ngx_http_lua_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
                              prev->ssl_trusted_certificate, "");
     ngx_conf_merge_str_value(conf->ssl_crl, prev->ssl_crl, "");
 
+    ngx_conf_merge_str_value(conf->ssl_certificate,
+                             prev->ssl_certificate, "");
+    ngx_conf_merge_str_value(conf->ssl_certificate_key,
+                             prev->ssl_certificate_key, "");
+    ngx_conf_merge_ptr_value(conf->ssl_passwords, prev->ssl_passwords, NULL);
+
     if (ngx_http_lua_set_ssl(cf, conf) != NGX_OK) {
         return NGX_CONF_ERROR;
     }
@@ -1220,6 +1253,24 @@ ngx_http_lua_set_ssl(ngx_conf_t *cf, ngx_http_lua_loc_conf_t *llcf)
     cln->handler = ngx_ssl_cleanup_ctx;
     cln->data = llcf->ssl;
 
+    if (llcf->ssl_certificate.len) {
+
+        if (llcf->ssl_certificate_key.len == 0) {
+            ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                          "no \"lua_ssl_certificate_key\" is defined "
+                          "for certificate \"%V\"", &llcf->ssl_certificate);
+            return NGX_ERROR;
+        }
+
+        if (ngx_ssl_certificate(cf, llcf->ssl, &llcf->ssl_certificate,
+                                &llcf->ssl_certificate_key, llcf->ssl_passwords)
+            != NGX_OK)
+        {
+                 return NGX_ERROR;
+        }
+    }
+
+
     if (SSL_CTX_set_cipher_list(llcf->ssl->ctx,
                                 (const char *) llcf->ssl_ciphers.data)
         == 0)
@@ -1259,6 +1310,29 @@ ngx_http_lua_set_ssl(ngx_conf_t *cf, ngx_http_lua_loc_conf_t *llcf)
     }
 
     return NGX_OK;
+}
+
+
+static char *
+ngx_http_lua_ssl_password_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_http_lua_loc_conf_t *llcf = conf;
+
+    ngx_str_t  *value;
+
+    if (llcf->ssl_passwords != NGX_CONF_UNSET_PTR) {
+        return "is duplicate";
+    }
+
+    value = cf->args->elts;
+
+    llcf->ssl_passwords = ngx_ssl_read_password_file(cf, &value[1]);
+
+    if (llcf->ssl_passwords == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    return NGX_CONF_OK;
 }
 
 #endif  /* NGX_HTTP_SSL */


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
I have add lua_ssl_certificate ported from [proxy_module](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_certificate), and try to solve problem like [here](https://github.com/openresty/lua-nginx-module/issues/534). When use ngx.tcp.socket, we can send our certificate to server to pass verification. we have use like this in our private module, is it suitable?
If it is suitable, I will add more test cases~
