### PR TITLE
controll enter body filter or not by lua code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ install:
   - git clone https://github.com/openresty/rds-json-nginx-module.git ../rds-json-nginx-module
   - git clone https://github.com/openresty/srcache-nginx-module.git ../srcache-nginx-module
   - git clone https://github.com/openresty/redis2-nginx-module.git ../redis2-nginx-module
-  - git clone https://github.com/openresty/lua-resty-core.git ../lua-resty-core
+  - git clone -b skip_body_filter https://github.com/rainingmaster/lua-resty-core.git ../lua-resty-core
   - git clone -b v2.1-agentzh https://github.com/openresty/luajit2.git
 
 before_script:

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -339,6 +339,7 @@ typedef struct {
     ngx_flag_t                       log_socket_errors;
     ngx_flag_t                       check_client_abort;
     ngx_flag_t                       use_default_type;
+    ngx_flag_t                       enter_body_filter_default;
 } ngx_http_lua_loc_conf_t;
 
 
@@ -551,6 +552,7 @@ typedef struct ngx_http_lua_ctx_s {
     unsigned         acquired_raw_req_socket:1;  /* whether a raw req socket
                                                     is acquired */
     unsigned         seen_body_data:1;
+    unsigned         enter_body_filter:1;
 } ngx_http_lua_ctx_t;
 
 

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -401,6 +401,14 @@ static ngx_command_t ngx_http_lua_cmds[] = {
       0,
       (void *) ngx_http_lua_body_filter_file },
 
+    { ngx_string("enter_body_filter_default"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+                        |NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_lua_loc_conf_t, enter_body_filter_default),
+      NULL },
+
     { ngx_string("balancer_by_lua_block"),
       NGX_HTTP_UPS_CONF|NGX_CONF_BLOCK|NGX_CONF_NOARGS,
       ngx_http_lua_balancer_by_lua_block,
@@ -1085,6 +1093,7 @@ ngx_http_lua_create_loc_conf(ngx_conf_t *cf)
 
     conf->transform_underscores_in_resp_headers = NGX_CONF_UNSET;
     conf->log_socket_errors = NGX_CONF_UNSET;
+    conf->enter_body_filter_default  = NGX_CONF_UNSET;
 
 #if (NGX_HTTP_SSL)
     conf->ssl_verify_depth = NGX_CONF_UNSET_UINT;
@@ -1197,6 +1206,9 @@ ngx_http_lua_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
                          prev->transform_underscores_in_resp_headers, 1);
 
     ngx_conf_merge_value(conf->log_socket_errors, prev->log_socket_errors, 1);
+
+    ngx_conf_merge_value(conf->enter_body_filter_default,
+                         prev->enter_body_filter_default, 1);
 
     return NGX_CONF_OK;
 }

--- a/src/ngx_http_lua_util.h
+++ b/src/ngx_http_lua_util.h
@@ -259,11 +259,16 @@ void ngx_http_lua_cleanup_free(ngx_http_request_t *r,
 static ngx_inline void
 ngx_http_lua_init_ctx(ngx_http_request_t *r, ngx_http_lua_ctx_t *ctx)
 {
+    ngx_http_lua_loc_conf_t     *llcf;
+
     ngx_memzero(ctx, sizeof(ngx_http_lua_ctx_t));
     ctx->ctx_ref = LUA_NOREF;
     ctx->entry_co_ctx.co_ref = LUA_NOREF;
     ctx->resume_handler = ngx_http_lua_wev_handler;
     ctx->request = r;
+
+    llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
+    ctx->enter_body_filter = llcf->enter_body_filter_default;
 }
 
 

--- a/t/082-body-filter.t
+++ b/t/082-body-filter.t
@@ -837,3 +837,99 @@ GET /lua
 --- ignore_response
 --- error_log
 API disabled in the context of body_filter_by_lua*
+
+
+
+=== TEST 27: enter_body_filter off
+--- http_config
+    enter_body_filter_default off;
+
+--- config
+    location = /t {
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+        body_filter_by_lua_block {
+            ngx.log(ngx.ERR, "in body filter")
+        }
+    }
+--- request
+    GET /t
+--- response_body
+ok
+--- no_error_log
+[error]
+
+
+
+=== TEST 28: enter_body_filter on
+--- http_config
+    enter_body_filter_default on;
+
+--- config
+    location = /t {
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+        body_filter_by_lua_block {
+            ngx.log(ngx.ERR, "in body filter")
+        }
+    }
+--- request
+    GET /t
+--- response_body
+ok
+--- error_log
+in body filter
+
+
+
+=== TEST 29: skip body-filter phase by lua
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;;";
+    enter_body_filter_default on;
+
+--- config
+    location = /t {
+        content_by_lua_block {
+            local b = require "ngx.bodyfilter"
+
+            b.skip_body_filter(true)
+            ngx.say("ok")
+        }
+        body_filter_by_lua_block {
+            ngx.log(ngx.ERR, "in body filter")
+        }
+    }
+--- request
+    GET /t
+--- response_body
+ok
+--- no_error_log
+[error]
+
+
+
+=== TEST 30: enter body-filter phase by lua
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;;";
+    enter_body_filter_default off;
+
+--- config
+    location = /t {
+        content_by_lua_block {
+            local b = require "ngx.bodyfilter"
+
+            b.skip_body_filter(false)
+            ngx.say("ok")
+        }
+        body_filter_by_lua_block {
+            ngx.log(ngx.ERR, "in body filter")
+        }
+    }
+--- request
+    GET /t
+--- response_body
+ok
+--- error_log
+in body filter


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

We got a problem in our progress: when we just want to use `body filter` in some special cases(maybe these case not only related to the domain name, but with the details of per request, we need to use lua code to judge in the actual situation), we have to run `body filter` in every request, and make some preparations for the lua execution environment like [these](https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_bodyfilterby.c#L51), which is useless in some request.

We want to have a [switch](https://github.com/openresty/lua-nginx-module/compare/master...rainingmaster:enter_body_filter?expand=1#diff-c91b2ec425e9be9d56fee2df662b67d2R404), whether or not configured `body_filter_by_lua_*`, to control whether or not to default to enter `body filter` phase, and alson we have a [command](https://github.com/rainingmaster/lua-resty-core/blob/skip_body_filter/lib/ngx/bodyfilter.lua#L21) to control whether or not to enter body filter in each request by lua. So we've built this PR, so help me and see if there's any problem? thanks~



