### PR TITLE
Try to use meta_lua_ngx_module in shared dict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ install:
   - git clone https://github.com/openresty/srcache-nginx-module.git ../srcache-nginx-module
   - git clone https://github.com/openresty/redis2-nginx-module.git ../redis2-nginx-module
   - git clone https://github.com/openresty/lua-resty-core.git ../lua-resty-core
+  - git clone https://github.com/rainingmaster/meta-lua-nginx-module ../meta-lua-nginx-module
   - git clone -b v2.1-agentzh https://github.com/openresty/luajit2.git
 
 before_script:

--- a/src/ngx_http_lua_api.c
+++ b/src/ngx_http_lua_api.c
@@ -10,6 +10,10 @@
 #include "ddebug.h"
 
 
+#ifdef NGX_HAVE_META_LUA
+#   include "ngx_meta_lua_api.h"
+#endif
+
 #include "ngx_http_lua_common.h"
 #include "api/ngx_http_lua_api.h"
 #include "ngx_http_lua_shdict.h"
@@ -87,6 +91,10 @@ ngx_shm_zone_t *
 ngx_http_lua_shared_memory_add(ngx_conf_t *cf, ngx_str_t *name, size_t size,
     void *tag)
 {
+#ifdef NGX_HAVE_META_LUA
+    return ngx_meta_lua_shared_memory_add(cf, name, size, tag);
+#endif
+
     ngx_http_lua_main_conf_t     *lmcf;
     ngx_shm_zone_t              **zp;
     ngx_shm_zone_t               *zone;

--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -11,6 +11,10 @@
 #include "ddebug.h"
 
 
+#ifdef NGX_HAVE_META_LUA
+#   include "ngx_meta_lua_api.h"
+#endif
+
 #include "ngx_http_lua_common.h"
 #include "ngx_http_lua_directive.h"
 #include "ngx_http_lua_util.h"
@@ -1131,6 +1135,11 @@ ngx_http_lua_init_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
     }
 
     lmcf->init_handler = (ngx_http_lua_main_conf_handler_pt) cmd->post;
+
+#ifdef NGX_HAVE_META_LUA
+    ngx_meta_lua_add_init_hooker(ngx_http_lua_init_callback, cf->cycle,
+                                 (void *)lmcf);
+#endif
 
     if (cmd->post == ngx_http_lua_init_by_file) {
         name = ngx_http_lua_rebase_path(cf->pool, value[1].data,

--- a/src/ngx_http_lua_initby.c
+++ b/src/ngx_http_lua_initby.c
@@ -39,4 +39,34 @@ ngx_http_lua_init_by_file(ngx_log_t *log, ngx_http_lua_main_conf_t *lmcf,
     return ngx_http_lua_report(log, L, status, "init_by_lua_file");
 }
 
+
+ngx_int_t
+ngx_http_lua_init_callback(ngx_cycle_t *cycle, void *data)
+{
+    ngx_http_lua_main_conf_t    *lmcf;
+    volatile ngx_cycle_t        *saved_cycle;
+    ngx_int_t                    rc;
+
+    lmcf = (ngx_http_lua_main_conf_t *) data;
+
+    if (!lmcf) {
+        return NGX_ERROR;
+    }
+
+    if (lmcf->init_handler) {
+        saved_cycle = ngx_cycle;
+        ngx_cycle = cycle;
+
+        rc = lmcf->init_handler(cycle->log, lmcf, lmcf->lua);
+
+        ngx_cycle = saved_cycle;
+
+        if (rc != NGX_OK) {
+            return NGX_ERROR;
+        }
+    }
+
+    return NGX_OK;
+}
+
 /* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/src/ngx_http_lua_initby.h
+++ b/src/ngx_http_lua_initby.h
@@ -17,6 +17,8 @@ ngx_int_t ngx_http_lua_init_by_inline(ngx_log_t *log,
 ngx_int_t ngx_http_lua_init_by_file(ngx_log_t *log,
     ngx_http_lua_main_conf_t *lmcf, lua_State *L);
 
+ngx_int_t ngx_http_lua_init_callback(ngx_cycle_t *cycle, void *data);
+
 
 #endif /* _NGX_HTTP_LUA_INITBY_H_INCLUDED_ */
 

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -11,6 +11,10 @@
 #include "ddebug.h"
 
 
+#ifdef NGX_HAVE_META_LUA
+#   include "ngx_meta_lua_api.h"
+#endif
+
 #include "ngx_http_lua_directive.h"
 #include "ngx_http_lua_capturefilter.h"
 #include "ngx_http_lua_contentby.h"
@@ -749,7 +753,13 @@ ngx_http_lua_init(ngx_conf_t *cf)
             return NGX_ERROR;
         }
 
-        if (!lmcf->requires_shm && lmcf->init_handler) {
+        if (lmcf->init_handler
+#ifdef NGX_HAVE_META_LUA
+            && ngx_meta_lua_shared_memory_count(cf) == 0)
+#else
+            && !lmcf->requires_shm)
+#endif
+        {
             saved_cycle = ngx_cycle;
             ngx_cycle = cf->cycle;
 

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -10,6 +10,10 @@
 #include "ddebug.h"
 
 
+#ifdef NGX_HAVE_META_LUA
+#   include "ngx_meta_lua_api.h"
+#endif
+
 #include "ngx_http_lua_shdict.h"
 #include "ngx_http_lua_util.h"
 #include "ngx_http_lua_api.h"
@@ -2170,6 +2174,10 @@ ngx_http_lua_shdict_llen(lua_State *L)
 ngx_shm_zone_t *
 ngx_http_lua_find_zone(u_char *name_data, size_t name_len)
 {
+#ifdef NGX_HAVE_META_LUA
+    return ngx_meta_lua_find_zone(name_data, name_len);
+#endif
+
     ngx_str_t                       *name;
     ngx_uint_t                       i;
     ngx_shm_zone_t                  *zone;

--- a/util/build.sh
+++ b/util/build.sh
@@ -53,6 +53,7 @@ time ngx-build $force $version \
                 --add-module=$root/t/data/fake-module \
                 --add-module=$root/t/data/fake-shm-module \
                 --add-module=$root/t/data/fake-delayed-load-module \
+                --add-module=$root/../meta-lua-nginx-module \
                 --with-http_gunzip_module \
                 --with-http_dav_module \
           --with-select_module \


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

This is an attempt to use [meta_lua's](https://github.com/rainingmaster/meta-lua-nginx-module) PR. Because, according to the [previous discussion](https://github.com/openresty/lua-nginx-module/pull/1050) of shdict between stream and http_lua, I implemented it here. Can you help me to see if this is all right?

In order to make the meta_lua callback function array format unified, [here](https://github.com/openresty/lua-nginx-module/compare/master...rainingmaster:for-meta?expand=1#diff-25af0ef4818fa2e14f35e9bb7ea18420R44) I added a `ngx_http_lua_init_callback`, passing in some more general parameters. but this parameter format may be a bit of a problem, some more better suggestions?