### PR TITLE
feature: implemented the ngx.errlog.get_sys_filter_level()  API function to get system default log level

### DIFF
--- a/src/ngx_http_lua_log.c
+++ b/src/ngx_http_lua_log.c
@@ -405,6 +405,28 @@ ngx_http_lua_ffi_errlog_get_msg(char **log, int *loglevel, u_char *err,
 #endif
 }
 
+
+int
+ngx_http_lua_ffi_errlog_get_sys_filter_level(ngx_http_request_t *r)
+{
+    ngx_log_t                   *log;
+    int                          log_level;
+
+    if (r && r->connection && r->connection->log) {
+        log = r->connection->log;
+
+    } else {
+        log = ngx_cycle->log;
+    }
+
+    log_level = log->log_level;
+    if (log_level == NGX_LOG_DEBUG_ALL) {
+        log_level = NGX_LOG_DEBUG;
+    }
+
+    return log_level;
+}
+
 #endif
 
 /* vi:set ft=c ts=4 sw=4 et fdm=marker: */


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

This pr is subsequent to https://github.com/openresty/lua-resty-core/issues/116.
It add a new FFI function to support getting the error log level in Lua land.
Looking forward to any further feedback.

BTW, the failed build seems to be related with known issue  #1072.
I will rerun the test once the problem is solved.