### PR TITLE
Add append_lua_package_path & append_lua_package_cpath directives

### DIFF
--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -165,6 +165,8 @@ struct ngx_http_lua_main_conf_s {
 
     ngx_str_t            lua_path;
     ngx_str_t            lua_cpath;
+    ngx_array_t         *append_lua_path;
+    ngx_array_t         *append_lua_cpath;
 
     ngx_cycle_t         *cycle;
     ngx_pool_t          *pool;
@@ -231,6 +233,8 @@ struct ngx_http_lua_main_conf_s {
     unsigned             requires_log:1;
     unsigned             requires_shm:1;
     unsigned             requires_capture_log:1;
+    unsigned             requires_append_lua_path:1;
+    unsigned             requires_append_lua_cpath:1;
 };
 
 

--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -241,8 +241,8 @@ ngx_http_append_lua_package_cpath(ngx_conf_t *cf, ngx_command_t *cmd,
         }
 
         if (ngx_array_init(lmcf->append_lua_cpath, cf->pool, 10,
-                    sizeof(ngx_str_t))
-                != NGX_OK)
+                           sizeof(ngx_str_t))
+            != NGX_OK)
         {
             return NGX_CONF_ERROR;
         }
@@ -283,8 +283,8 @@ ngx_http_append_lua_package_path(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
 
         if (ngx_array_init(lmcf->append_lua_path, cf->pool, 10,
-                    sizeof(ngx_str_t))
-                != NGX_OK)
+                           sizeof(ngx_str_t))
+            != NGX_OK)
         {
             return NGX_CONF_ERROR;
         }

--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -221,6 +221,91 @@ ngx_http_lua_package_path(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 }
 
 
+char *
+ngx_http_append_lua_package_cpath(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf)
+{
+
+    ngx_http_lua_main_conf_t *lmcf = conf;
+    ngx_str_t                *value;
+    ngx_str_t                *cpath;
+
+    dd("enter");
+
+    value = cf->args->elts;
+
+    if (lmcf->append_lua_cpath == NULL) {
+        lmcf->append_lua_cpath = ngx_palloc(cf->pool, sizeof(ngx_array_t));
+        if (lmcf->append_lua_cpath == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        if (ngx_array_init(lmcf->append_lua_cpath, cf->pool, 10,
+                    sizeof(ngx_str_t))
+                != NGX_OK)
+        {
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    cpath = ngx_array_push(lmcf->append_lua_cpath);
+    if (cpath == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    cpath->len = value[1].len;
+    cpath->data = value[1].data;
+
+    if (!lmcf->requires_append_lua_cpath) {
+        lmcf->requires_append_lua_cpath = 1;
+    }
+
+    return NGX_CONF_OK;
+}
+
+
+char *
+ngx_http_append_lua_package_path(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+
+    ngx_http_lua_main_conf_t *lmcf = conf;
+    ngx_str_t                *value;
+    ngx_str_t                *path;
+
+    dd("enter");
+
+    value = cf->args->elts;
+
+    if (lmcf->append_lua_path == NULL) {
+        lmcf->append_lua_path = ngx_palloc(cf->pool, sizeof(ngx_array_t));
+        if (lmcf->append_lua_path == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        if (ngx_array_init(lmcf->append_lua_path, cf->pool, 10,
+                    sizeof(ngx_str_t))
+                != NGX_OK)
+        {
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    path = ngx_array_push(lmcf->append_lua_path);
+    if (path == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    path->len = value[1].len;
+    path->data = value[1].data;
+
+    if (!lmcf->requires_append_lua_path) {
+        lmcf->requires_append_lua_path = 1;
+    }
+
+    return NGX_CONF_OK;
+}
+
+
 #if defined(NDK) && NDK
 char *
 ngx_http_lua_set_by_lua_block(ngx_conf_t *cf, ngx_command_t *cmd,

--- a/src/ngx_http_lua_directive.h
+++ b/src/ngx_http_lua_directive.h
@@ -17,6 +17,10 @@ char *ngx_http_lua_package_cpath(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 char *ngx_http_lua_package_path(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
+char *ngx_http_append_lua_package_cpath(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+char *ngx_http_append_lua_package_path(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
 char *ngx_http_lua_content_by_lua_block(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 char *ngx_http_lua_content_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -643,7 +643,8 @@ ngx_http_lua_init(ngx_conf_t *cf)
     ngx_int_t                   rc;
     ngx_uint_t                  i;
     size_t                      len;
-    char                       *path;
+    u_char                     *path;
+    u_char                     *tmp;
     ngx_str_t                  *p;
     ngx_array_t                *arr;
     ngx_http_handler_pt        *h;
@@ -681,30 +682,29 @@ ngx_http_lua_init(ngx_conf_t *cf)
 
     len = lmcf->lua_cpath.len;
 
-    if (lmcf->requires_append_lua_path) {
+    if (lmcf->requires_append_lua_cpath) {
         for (i = 0; i < lmcf->append_lua_cpath->nelts; i++) {
             p = (ngx_str_t *) lmcf->append_lua_cpath->elts;
             len += p[i].len;
         }
 
-        path = (char *) ngx_palloc(cf->pool, len);
+        path = (u_char *) ngx_pcalloc(cf->pool, len);
         if (path == NULL) {
             return NGX_ERROR;
         }
 
-        ngx_memzero(path, len);
+        tmp = path;
 
         for (i = 0; i < lmcf->append_lua_cpath->nelts; i++) {
             p = (ngx_str_t *) lmcf->append_lua_cpath->elts;
-            path = strncat(path, (char *) p[i].data, p[i].len);
+            path = ngx_copy(path, p[i].data, p[i].len);
         }
 
         if (lmcf->lua_cpath.len) {
-            path = strncat(path, (char *) lmcf->lua_cpath.data,
-                           lmcf->lua_cpath.len);
+            path = ngx_copy(path, lmcf->lua_cpath.data, lmcf->lua_cpath.len);
         }
 
-        lmcf->lua_cpath.data = (u_char *) path;
+        lmcf->lua_cpath.data = tmp;
         lmcf->lua_cpath.len = len;
     }
 
@@ -716,24 +716,23 @@ ngx_http_lua_init(ngx_conf_t *cf)
             len += p[i].len;
         }
 
-        path = (char *) ngx_palloc(cf->pool, len);
+        path = (u_char *) ngx_pcalloc(cf->pool, len);
         if (path == NULL) {
             return NGX_ERROR;
         }
 
-        ngx_memzero(path, len);
+        tmp = path;
 
         for (i = 0; i < lmcf->append_lua_path->nelts; i++) {
             p = (ngx_str_t *) lmcf->append_lua_path->elts;
-            path = strncat(path, (char *) p[i].data, p[i].len);
+            path = ngx_copy(path, p[i].data, p[i].len);
         }
 
         if (lmcf->lua_path.len) {
-            path = strncat(path, (char *) lmcf->lua_path.data,
-                           lmcf->lua_path.len);
+            path = ngx_copy(path, lmcf->lua_path.data, lmcf->lua_path.len);
         }
 
-        lmcf->lua_path.data = (u_char *) path;
+        lmcf->lua_path.data = tmp;
         lmcf->lua_path.len = len;
     }
 

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -134,14 +134,14 @@ static ngx_command_t ngx_http_lua_cmds[] = {
     { ngx_string("append_lua_package_cpath"),
       NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
       ngx_http_append_lua_package_cpath,
-      0,
+      NGX_HTTP_MAIN_CONF_OFFSET,
       0,
       NULL },
 
     { ngx_string("append_lua_package_path"),
       NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
       ngx_http_append_lua_package_path,
-      0,
+      NGX_HTTP_MAIN_CONF_OFFSET,
       0,
       NULL },
 

--- a/t/004-require.t
+++ b/t/004-require.t
@@ -208,3 +208,125 @@ GET /ndk
 GET /ndk
 --- response_body
 %20
+
+
+
+=== TEST 11: append package path
+--- http_config
+    append_lua_package_path "/opt/program/?.lua;";
+--- config
+    location /main {
+        content_by_lua '
+            local m = ngx.re.match(package.path, [[/opt/program/\?\.lua]])
+            if m then
+                ngx.say([[the "program" package path found]])
+            end
+        ';
+    }
+--- request
+GET /main
+--- response_body
+the "program" package path found
+
+
+
+=== TEST 12: append package path (multi)
+--- http_config
+    append_lua_package_path "/opt/program/?.lua;";
+    append_lua_package_path "/opt/program2/?.lua;";
+--- config
+    location /main {
+        content_by_lua '
+            local m = ngx.re.match(package.path, [[/opt/program/\?\.lua]])
+            if m then
+                ngx.say([[the "program" package path found]])
+            end
+
+            local m = ngx.re.match(package.path, [[/opt/program2/\?\.lua]])
+            if m then
+                ngx.say([[the "program2" package path found]])
+            end
+        ';
+    }
+--- request
+GET /main
+--- response_body
+the "program" package path found
+the "program2" package path found
+
+
+
+=== TEST 13: append package cpath
+--- http_config
+    append_lua_package_cpath "/opt/program/?.so;";
+--- config
+    location /main {
+        content_by_lua '
+            local m = ngx.re.match(package.cpath, [[/opt/program/\?\.so]])
+            if m then
+                ngx.say([[the "program" package cpath found]])
+            end
+        ';
+    }
+--- request
+GET /main
+--- response_body
+the "program" package cpath found
+
+
+
+=== TEST 14: append package cpath (multi)
+--- http_config
+    append_lua_package_cpath "/opt/program/?.so;";
+    append_lua_package_cpath "/opt/program2/?.so;";
+--- config
+    location /main {
+        content_by_lua '
+            local m = ngx.re.match(package.cpath, [[/opt/program/\?\.so]])
+            if m then
+                ngx.say([[the "program" package cpath found]])
+            end
+
+            local m = ngx.re.match(package.cpath, [[/opt/program2/\?\.so]])
+            if m then
+                ngx.say([[the "program2" package cpath found]])
+            end
+        ';
+    }
+--- request
+GET /main
+--- response_body
+the "program" package cpath found
+the "program2" package cpath found
+
+
+
+=== TEST 15: append package path (with lua_package_path)
+--- http_config eval
+    "lua_package_path '$::HtmlDir/?.lua;;';
+    append_lua_package_path '/opt/program/?.lua;';"
+--- config
+    location /main {
+        content_by_lua '
+            ngx.print(package.path)
+        ';
+    }
+--- request
+GET /main
+--- response_body_like: /opt/program/\?.lua;[^;]+/servroot/html/\?.lua;.+lua;$
+
+
+
+=== TEST 16: append package cpath (with lua_package_cpath)
+--- http_config eval
+    "lua_package_cpath '$::HtmlDir/?.so;;';
+    append_lua_package_cpath '/opt/program/?.so;';"
+--- config
+    location /main {
+        content_by_lua '
+            ngx.print(package.cpath)
+        ';
+    }
+--- request
+GET /main
+--- response_body_like: /opt/program/\?.so;[^;]+/servroot/html/\?.so;.+so;$


### PR DESCRIPTION
Sometimes we need to add a new program (`server`), but we don't want to change the content of `lua_package_path` and `lua_package_cpath`. Because those may be maintained by other programs, so we need more independent directives to configure `lua_path` and `lua_cpath`.
This can be used by this way:
```nginx
http {
    append_lua_package_path "/opt/program1/?.lua;";
    append_lua_package_cpath "/opt/program1/?.so;";
    server {
        #...
    }
    append_lua_package_path "/opt/program2/?.lua;";
    append_lua_package_cpath "/opt/program2/?.so;";
    server {
        #...
    }
}
```

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
