### PR TITLE
balancer: support arbitrary HTTP codes when calling ngx.exit inside b…

### DIFF
--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -314,7 +314,8 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
 
     if (ctx->exited && ctx->exit_code != NGX_OK) {
         rc = ctx->exit_code;
-        if (rc == NGX_ERROR || rc == NGX_BUSY || rc == NGX_DECLINED) {
+        if (rc == NGX_ERROR || rc == NGX_BUSY || rc == NGX_DECLINED
+            || rc >= NGX_HTTP_SPECIAL_RESPONSE) {
             return rc;
         }
 

--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -314,8 +314,13 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
 
     if (ctx->exited && ctx->exit_code != NGX_OK) {
         rc = ctx->exit_code;
-        if (rc == NGX_ERROR || rc == NGX_BUSY || rc == NGX_DECLINED
-            || rc >= NGX_HTTP_SPECIAL_RESPONSE) {
+        if (rc == NGX_ERROR
+            || rc == NGX_BUSY
+            || rc == NGX_DECLINED
+#ifdef HAVE_BALANCER_STATUS_CODE_PATCH
+            || rc >= NGX_HTTP_SPECIAL_RESPONSE
+#endif
+        ) {
             return rc;
         }
 

--- a/t/138-balancer.t
+++ b/t/138-balancer.t
@@ -58,8 +58,8 @@ qr{\[crit\] .*? connect\(\) to 0\.0\.0\.1:80 failed .*?, upstream: "http://0\.0\
     }
 --- request
     GET /t
---- response_body_like: 500 Internal Server Error
---- error_code: 500
+--- response_body_like: 403 Forbidden
+--- error_code: 403
 --- error_log
 [lua] balancer_by_lua:2: hello from balancer by lua! while connecting to upstream,
 --- no_error_log eval


### PR DESCRIPTION
…alancer_by_lua.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

This PR depends on https://github.com/openresty/openresty/pull/270
