### PR TITLE
feature: added a pure C API function +ngx_http_lua_ffi_raw_log

### DIFF
--- a/src/ngx_http_lua_log.c
+++ b/src/ngx_http_lua_log.c
@@ -428,6 +428,30 @@ ngx_http_lua_ffi_errlog_get_sys_filter_level(ngx_http_request_t *r)
     return log_level;
 }
 
+
+int
+ngx_http_lua_ffi_raw_log(ngx_http_request_t *r, unsigned int level, u_char *s,
+    size_t s_len, u_char *err, size_t *errlen)
+{
+    ngx_log_t           *log;
+
+    if (level > NGX_LOG_DEBUG || level < NGX_LOG_STDERR) {
+        *errlen = ngx_snprintf(err, *errlen, "bad log level: %d", level) - err;
+        return NGX_ERROR;
+    }
+
+    if (r && r->connection && r->connection->log) {
+        log = r->connection->log;
+
+    } else {
+        log = ngx_cycle->log;
+    }
+
+    ngx_log_error(level, log, 0, "%*s", s_len, s);
+
+    return NGX_OK;
+}
+
 #endif
 
 /* vi:set ft=c ts=4 sw=4 et fdm=marker: */


### PR DESCRIPTION
Sister PR for openresty/lua-resty-core#128

To be used by ngx.errlog module's `rawlog()` function in the lua-resty-core library.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
