### PR TITLE
doc: fixed typo of `ngx.re.match`.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5909,7 +5909,7 @@ The optional fourth argument, `ctx`, can be a Lua table holding an optional `pos
 
  local ctx = { pos = 2 }
  local m, err = ngx.re.match("1234, hello", "[0-9]+", "", ctx)
-      -- m[0] = "34"
+      -- m[0] = "234"
       -- ctx.pos == 5
 ```
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -4932,7 +4932,7 @@ The optional fourth argument, <code>ctx</code>, can be a Lua table holding an op
 <geshi lang="lua">
     local ctx = { pos = 2 }
     local m, err = ngx.re.match("1234, hello", "[0-9]+", "", ctx)
-         -- m[0] = "34"
+         -- m[0] = "234"
          -- ctx.pos == 5
 </geshi>
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
