### PR TITLE
bugfix: ngx.flush will throw error after calling output API functions

### DIFF
--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -551,6 +551,9 @@ typedef struct ngx_http_lua_ctx_s {
     unsigned         acquired_raw_req_socket:1;  /* whether a raw req socket
                                                     is acquired */
     unsigned         seen_body_data:1;
+
+    unsigned         filter_finalize:1; /* whether hits the filter
+                                           finalization */
 } ngx_http_lua_ctx_t;
 
 

--- a/src/ngx_http_lua_output.c
+++ b/src/ngx_http_lua_output.c
@@ -49,6 +49,7 @@ ngx_http_lua_ngx_echo(lua_State *L, unsigned newline)
     int                          i;
     int                          nargs;
     int                          type;
+    int                          uri_changes;
     const char                  *msg;
 
     r = ngx_http_lua_get_req(L);
@@ -146,8 +147,23 @@ ngx_http_lua_ngx_echo(lua_State *L, unsigned newline)
         size += sizeof("\n") - 1;
     }
 
+    uri_changes = r->uri_changes;
+
     if (size == 0) {
         rc = ngx_http_lua_send_header_if_needed(r, ctx);
+
+        if (ctx != ngx_http_get_module_ctx(r, ngx_http_lua_module)
+            && r->filter_finalize)
+        {
+            if (uri_changes > r->uri_changes) {
+                ctx->filter_finalize = 1;
+                return lua_yield(L, 0);
+
+            } else {
+                ngx_http_set_ctx(r, ctx, ngx_http_lua_module);
+            }
+        }
+
         if (rc == NGX_ERROR || rc > NGX_OK) {
             lua_pushnil(L);
             lua_pushliteral(L, "nginx output filter error");
@@ -231,6 +247,18 @@ ngx_http_lua_ngx_echo(lua_State *L, unsigned newline)
                    newline ? "lua say response" : "lua print response");
 
     rc = ngx_http_lua_send_chain_link(r, ctx, cl);
+
+    if (ctx != ngx_http_get_module_ctx(r, ngx_http_lua_module)
+        && r->filter_finalize)
+    {
+        if (uri_changes > r->uri_changes) {
+            ctx->filter_finalize = 1;
+            return lua_yield(L, 0);
+
+        } else {
+            ngx_http_set_ctx(r, ctx, ngx_http_lua_module);
+        }
+    }
 
     if (rc == NGX_ERROR || rc >= NGX_HTTP_SPECIAL_RESPONSE) {
         lua_pushnil(L);
@@ -683,6 +711,7 @@ ngx_http_lua_inject_output_api(lua_State *L)
 static int
 ngx_http_lua_ngx_send_headers(lua_State *L)
 {
+    int                      uri_changes;
     ngx_int_t                rc;
     ngx_http_request_t      *r;
     ngx_http_lua_ctx_t      *ctx;
@@ -705,7 +734,22 @@ ngx_http_lua_ngx_send_headers(lua_State *L)
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                        "lua send headers");
 
+        uri_changes = r->uri_changes;
+
         rc = ngx_http_lua_send_header_if_needed(r, ctx);
+
+        if (ctx != ngx_http_get_module_ctx(r, ngx_http_lua_module)
+            && r->filter_finalize)
+        {
+            if (uri_changes > r->uri_changes) {
+                ctx->filter_finalize = 1;
+                return lua_yield(L, 0);
+
+            } else {
+                ngx_http_set_ctx(r, ctx, ngx_http_lua_module);
+            }
+        }
+
         if (rc == NGX_ERROR || rc > NGX_OK) {
             lua_pushnil(L);
             lua_pushliteral(L, "nginx output filter error");

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -95,6 +95,8 @@ static ngx_int_t ngx_http_lua_handle_exit(lua_State *L, ngx_http_request_t *r,
     ngx_http_lua_ctx_t *ctx);
 static ngx_int_t ngx_http_lua_handle_rewrite_jump(lua_State *L,
     ngx_http_request_t *r, ngx_http_lua_ctx_t *ctx);
+static ngx_int_t ngx_http_lua_handle_filter_finalize(lua_State *L,
+    ngx_http_request_t *r, ngx_http_lua_ctx_t * ctx);
 static int ngx_http_lua_thread_traceback(lua_State *L, lua_State *co,
     ngx_http_lua_co_ctx_t *coctx);
 static void ngx_http_lua_inject_ngx_api(lua_State *L,
@@ -1049,6 +1051,10 @@ ngx_http_lua_run_thread(lua_State *L, ngx_http_request_t *r,
 
                 if (ctx->exec_uri.len) {
                     return ngx_http_lua_handle_exec(L, r, ctx);
+                }
+
+                if (ctx->filter_finalize) {
+                    return ngx_http_lua_handle_filter_finalize(L, r, ctx);
                 }
 
                 /*
@@ -2603,6 +2609,25 @@ ngx_http_lua_handle_rewrite_jump(lua_State *L, ngx_http_request_t *r,
     ngx_http_lua_init_ctx(r, ctx);
 
     return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_lua_handle_filter_finalize(lua_State *L, ngx_http_request_t *r,
+    ngx_http_lua_ctx_t *ctx)
+{
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "lua thread aborting request with filter finalization");
+
+    ngx_http_lua_cleanup_pending_operation(ctx->cur_co_ctx);
+
+    ngx_http_lua_probe_coroutine_done(r, ctx->cur_co_ctx->co, 1);
+
+    ctx->cur_co_ctx->co_status = NGX_HTTP_LUA_CO_DEAD;
+
+    ngx_http_lua_request_cleanup(ctx, 1 /* forcible */);
+
+    return NGX_ERROR;
 }
 
 

--- a/t/014-bugs.t
+++ b/t/014-bugs.t
@@ -8,7 +8,7 @@ log_level('debug');
 
 repeat_each(3);
 
-plan tests => repeat_each() * (blocks() * 2 + 30);
+plan tests => repeat_each() * (blocks() * 2 + 33);
 
 our $HtmlDir = html_dir;
 #warn $html_dir;
@@ -1018,3 +1018,69 @@ write timer set: 1
 --- no_error_log
 [error]
 [alert]
+
+
+
+=== TEST 42: the module ctx of ngx_lua was cleared when the filter_finalize was triggered
+(with internal redirect).  (github issue #1131)
+
+--- config
+    location = /t1 {
+        error_page 412 /t2;
+        content_by_lua_block {
+            ngx.say("Hello world")
+            ngx.flush()
+            ngx.log(ngx.ERR, "impossible to reach here")
+        }
+    }
+
+    location = /t2 {
+        content_by_lua_block {
+            ngx.status = 200
+            ngx.req.clear_header("If-Unmodified-Since")
+            ngx.say("new location")
+        }
+    }
+
+--- request
+GET /t1
+
+--- more_headers
+If-Unmodified-Since: Mon, 17 Apr 2006 03:10:35 GMT
+
+--- error_code: 200
+
+--- response_body
+new location
+
+--- no_error_log
+[error]
+
+
+=== TEST 43: the module ctx of ngx_lua was cleared when the filter_finalize was triggered
+(without internal redirect).  (github issue #1131)
+
+--- config
+    location = /t1 {
+        content_by_lua_block {
+            ngx.say("Hello World")
+            ngx.flush()
+            ngx.log(ngx.WARN, "print this normally")
+        }
+    }
+
+--- request
+GET /t1
+
+--- more_headers
+If-Unmodified-Since: Mon, 17 Apr 2006 03:10:35 GMT
+
+--- error_code: 412
+
+--- response_body_like: 412 Precondition Failed
+
+--- error_log
+print this normally
+
+--- no_error_log
+[error]


### PR DESCRIPTION
When calling output API functions like ngx.print with
If-Unmodified-Since(or If-Match) in the request headers,
the ngx_http_not_modified_filter_module will "test the If-Unmodified-Since",
if failed, ngx_http_filter_finalize_request will be called and the contexts of
all http modules will be cleared, after that, error "no request found" will
be throwed if we calling ngx.flush.

Please see the github issue
https://github.com/openresty/lua-nginx-module/issues/1131
for the details.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
