### PR TITLE
bugfix: fix a coredump when use ngx.socket.tcp:connect multi time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,8 @@ before_script:
   - mysql -uroot -e 'create database ngx_test; grant all on ngx_test.* to "ngx_test"@"%" identified by "ngx_test"; flush privileges;'
 
 script:
+  - sudo iptables -I OUTPUT 1 -p udp --dport 10086 -j REJECT || exit 0
+  - sudo iptables -L || exit 0
   - cd luajit2/
   - make -j$JOBS CCDEBUG=-g Q= PREFIX=$LUAJIT_PREFIX CC=$CC XCFLAGS='-DLUA_USE_APICHECK -DLUA_USE_ASSERT -msse4.2' > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make install PREFIX=$LUAJIT_PREFIX > build.log 2>&1 || (cat build.log && exit 1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,8 +90,8 @@ before_script:
   - mysql -uroot -e 'create database ngx_test; grant all on ngx_test.* to "ngx_test"@"%" identified by "ngx_test"; flush privileges;'
 
 script:
-  - sudo iptables -I OUTPUT 1 -p udp --dport 10086 -j REJECT || exit 0
-  - sudo iptables -L || exit 0
+  - sudo iptables -I OUTPUT 1 -p udp --dport 10086 -j REJECT
+  - sudo iptables -L
   - cd luajit2/
   - make -j$JOBS CCDEBUG=-g Q= PREFIX=$LUAJIT_PREFIX CC=$CC XCFLAGS='-DLUA_USE_APICHECK -DLUA_USE_ASSERT -msse4.2' > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make install PREFIX=$LUAJIT_PREFIX > build.log 2>&1 || (cat build.log && exit 1)

--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -743,6 +743,9 @@ ngx_http_lua_socket_tcp_connect(lua_State *L)
 
         u->ft_type |= NGX_HTTP_LUA_SOCKET_FT_RESOLVER;
 
+        coctx->cleanup = NULL;
+        coctx->data = NULL;
+
         u->resolved->ctx = NULL;
         lua_pushnil(L);
         lua_pushfstring(L, "%s could not be resolved", host.data);

--- a/t/058-tcp-socket.t
+++ b/t/058-tcp-socket.t
@@ -4,7 +4,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * 190 + 6;
+plan tests => repeat_each() * 193;
 
 our $HtmlDir = html_dir;
 
@@ -3693,10 +3693,16 @@ close: 1 nil
 
 
 
-=== TEST 61: resolver send query failed
+=== TEST 61: resolver send query failing immediately in connect()
+this case did not clear coctx->cleanup properly and would lead to memory invalid accesses.
+
+this test case requires the following iptables rule to work properly:
+
+sudo iptables -I OUTPUT 1 -p udp --dport 10086 -j REJECT
 --- config
     location /t {
-    	resolver 127.0.0.1:10086 ipv6=off;
+        resolver 127.0.0.1:10086 ipv6=off;
+        resolver_timeout 10ms;
 
         content_by_lua_block {
             local sock = ngx.socket.tcp()
@@ -3718,5 +3724,5 @@ failed to connect: www.google.com could not be resolved
 failed to connect: www.google.com could not be resolved
 failed to connect: www.google.com could not be resolved
 hello!
---- error_log
-failed (1: Operation not permitted) while resolving
+--- error_log eval
+qr{\[alert\] .*? send\(\) failed \(\d+: Operation not permitted\) while resolving}

--- a/t/058-tcp-socket.t
+++ b/t/058-tcp-socket.t
@@ -4,7 +4,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * 190;
+plan tests => repeat_each() * 190 + 6;
 
 our $HtmlDir = html_dir;
 
@@ -3690,3 +3690,33 @@ received: OK
 close: 1 nil
 --- no_error_log
 [error]
+
+
+
+=== TEST 61: resolver send query failed
+--- config
+    location /t {
+    	resolver 127.0.0.1:10086 ipv6=off;
+
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+
+            for i = 1, 3 do -- retry
+                local ok, err = sock:connect("www.google.com", 80)
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                end
+            end
+
+            ngx.say("hello!")
+        }
+    }
+--- request
+GET /t
+--- response_body
+failed to connect: www.google.com could not be resolved
+failed to connect: www.google.com could not be resolved
+failed to connect: www.google.com could not be resolved
+hello!
+--- error_log
+failed (1: Operation not permitted) while resolving


### PR DESCRIPTION
When using ngx.socket.tcp, and we want to reconnect in Lua, we maybe code like this:
```
local sock = ngx.socket.tcp()

for i = 1, 3 do -- retry
    local ok, err = sock:connect("www.google.com", 80)
    if not ok then
        ngx.log(ngx.ERR, "failed to connect: ", err)
    end
end
```

But if in a bad network environment, if **resolver send query failed**(In the test case, I use iptables to implement it like [this](https://github.com/rainingmaster/lua-nginx-module/commit/eca0936293d387b2962c7e082650392d2499c211#diff-354f30a63fb0907d4ad57269548329e3R93), it takes some problem: if we use `connect` multiple times and call `ngx_http_lua_socket_tcp_connect` many times, In first times, the `coctx->cleanup` will set as [`ngx_http_lua_tcp_resolve_cleanup`](https://github.com/rainingmaster/lua-nginx-module/blob/resolver-reject/src/ngx_http_lua_socket_tcp.c#L735). In the second times,we will destroy `rctx` in [here](https://github.com/rainingmaster/lua-nginx-module/blob/resolver-reject/src/ngx_http_lua_socket_tcp.c#L734) by `ngx_resolve_name_done`. Therefore, I think cleanup should be set as `NULL` [at the first exit](https://github.com/rainingmaster/lua-nginx-module/blob/resolver-reject/src/ngx_http_lua_socket_tcp.c#L746)

Here is the old and core test cases: https://www.travis-ci.org/rainingmaster/lua-nginx-module/builds/266258969


I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
