### PR TITLE
bugfix: return error when timeout argument may overflow.

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -2708,6 +2708,11 @@ ngx_http_lua_socket_tcp_settimeout(lua_State *L)
     }
 
     timeout = (ngx_int_t) lua_tonumber(L, 2);
+    if (timeout > NGX_MAX_INT32_VALUE) {
+        return luaL_error(L, "lua tcp socket timeout %f will overflow",
+                          (lua_Number) timeout);
+    }
+
     lua_pushinteger(L, timeout);
     lua_pushinteger(L, timeout);
 
@@ -2751,8 +2756,22 @@ ngx_http_lua_socket_tcp_settimeouts(lua_State *L)
     }
 
     connect_timeout = (ngx_int_t) lua_tonumber(L, 2);
+    if (connect_timeout > NGX_MAX_INT32_VALUE) {
+        return luaL_error(L, "lua tcp socket connect timeout %f will overflow",
+                          (lua_Number) connect_timeout);
+    }
+
     send_timeout = (ngx_int_t) lua_tonumber(L, 3);
+    if (send_timeout > NGX_MAX_INT32_VALUE) {
+        return luaL_error(L, "lua tcp socket send timeout %f will overflow",
+                          (lua_Number) send_timeout);
+    }
+
     read_timeout = (ngx_int_t) lua_tonumber(L, 4);
+    if (read_timeout > NGX_MAX_INT32_VALUE) {
+        return luaL_error(L, "lua tcp socket read timeout %f will overflow",
+                          (lua_Number) read_timeout);
+    }
 
     lua_rawseti(L, 1, SOCKET_READ_TIMEOUT_INDEX);
     lua_rawseti(L, 1, SOCKET_SEND_TIMEOUT_INDEX);

--- a/t/065-tcp-socket-timeout.t
+++ b/t/065-tcp-socket-timeout.t
@@ -28,7 +28,7 @@ our $StapScript = $t::StapThread::StapScript;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 4 + 12);
+plan tests => repeat_each() * (blocks() * 4 + 11);
 
 our $HtmlDir = html_dir;
 
@@ -992,5 +992,34 @@ receive: nil timeout
 send failed: timeout
 close: 1 nil
 
+--- no_error_log
+[error]
+
+
+=== TEST 23: timeout overflow detection
+--- config
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            local ok, err = pcall(sock.settimeout, sock, (2 ^ 31) - 1)
+            if not ok then
+                ngx.say("failed to set timeout: ", err)
+            else
+                ngx.say("settimeout: ok")
+            end
+
+            ok, err = pcall(sock.settimeout, sock, 2 ^ 31)
+            if not ok then
+                ngx.say("failed to set timeout: ", err)
+            else
+                ngx.say("settimeout: ok")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+settimeout: ok
+failed to set timeout: lua tcp socket timeout 2147483648(?:\.\d+)? will overflow
 --- no_error_log
 [error]

--- a/t/147-tcp-socket-timeouts.t
+++ b/t/147-tcp-socket-timeouts.t
@@ -532,3 +532,93 @@ received: ok
 failed to receive a line: closed []
 --- no_error_log
 [error]
+
+
+=== TEST 8: connection timeout overflow detection
+--- config
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            local ok, err = pcall(sock.settimeouts, sock,
+                                  (2 ^ 31) - 1, 500, 500)
+            if not ok then
+                ngx.say("failed to set timeouts: ", err)
+            else
+                ngx.say("settimeouts: ok")
+            end
+
+            ok, err = pcall(sock.settimeouts, sock, 2 ^ 31, 500, 500)
+            if not ok then
+                ngx.say("failed to set timeouts: ", err)
+            else
+                ngx.say("settimeouts: ok")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+settimeouts: ok
+failed to set timeouts: lua tcp socket connect timeout 2147483648(?:\.\d+)? will overflow
+--- no_error_log
+[error]
+
+
+=== TEST 9: send timeout overflow detection
+--- config
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            local ok, err = pcall(sock.settimeouts, sock,
+                                  500, (2 ^ 31) - 1, 500)
+            if not ok then
+                ngx.say("failed to set timeouts: ", err)
+            else
+                ngx.say("settimeouts: ok")
+            end
+
+            ok, err = pcall(sock.settimeouts, sock, 500, 2 ^ 31, 500)
+            if not ok then
+                ngx.say("failed to set timeouts: ", err)
+            else
+                ngx.say("settimeouts: ok")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+settimeouts: ok
+failed to set timeouts: lua tcp socket send timeout 2147483648(?:\.\d+)? will overflow
+--- no_error_log
+[error]
+
+
+=== TEST 10: read timeout overflow detection
+--- config
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            local ok, err = pcall(sock.settimeouts, sock,
+                                  500, 500, (2 ^ 31) - 1)
+            if not ok then
+                ngx.say("failed to set timeouts: ", err)
+            else
+                ngx.say("settimeouts: ok")
+            end
+
+            ok, err = pcall(sock.settimeouts, sock, 500, 500, 2 ^ 31)
+            if not ok then
+                ngx.say("failed to set timeouts: ", err)
+            else
+                ngx.say("settimeouts: ok")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+settimeouts: ok
+failed to set timeouts: lua tcp socket read timeout 2147483648(?:\.\d+)? will overflow
+--- no_error_log
+[error]


### PR DESCRIPTION
From now on, settimeout/settimeouts will return result to indicate if
the operation succeeded or not.
We also emit error log since people might not check the return of
settimeout/settimeouts.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

Will update documentation if this pr could be accepted.
