### PR TITLE
Add receiveatmost.

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -23,7 +23,10 @@ static int ngx_http_lua_socket_tcp_connect(lua_State *L);
 #if (NGX_HTTP_SSL)
 static int ngx_http_lua_socket_tcp_sslhandshake(lua_State *L);
 #endif
+static int ngx_http_lua_socket_tcp_receive_common(lua_State *L,
+                                                  unsigned fulfill_partial);
 static int ngx_http_lua_socket_tcp_receive(lua_State *L);
+static int ngx_http_lua_socket_tcp_receiveatmost(lua_State *L);
 static int ngx_http_lua_socket_tcp_send(lua_State *L);
 static int ngx_http_lua_socket_tcp_close(lua_State *L);
 static int ngx_http_lua_socket_tcp_setoption(lua_State *L);
@@ -226,10 +229,13 @@ ngx_http_lua_inject_socket_tcp_api(ngx_log_t *log, lua_State *L)
 
     /* {{{req socket object metatable */
     lua_pushlightuserdata(L, &ngx_http_lua_req_socket_metatable_key);
-    lua_createtable(L, 0 /* narr */, 5 /* nrec */);
+    lua_createtable(L, 0 /* narr */, 6 /* nrec */);
 
     lua_pushcfunction(L, ngx_http_lua_socket_tcp_receive);
     lua_setfield(L, -2, "receive");
+
+    lua_pushcfunction(L, ngx_http_lua_socket_tcp_receiveatmost);
+    lua_setfield(L, -2, "receiveatmost");
 
     lua_pushcfunction(L, ngx_http_lua_socket_tcp_receiveuntil);
     lua_setfield(L, -2, "receiveuntil");
@@ -248,10 +254,13 @@ ngx_http_lua_inject_socket_tcp_api(ngx_log_t *log, lua_State *L)
 
     /* {{{raw req socket object metatable */
     lua_pushlightuserdata(L, &ngx_http_lua_raw_req_socket_metatable_key);
-    lua_createtable(L, 0 /* narr */, 6 /* nrec */);
+    lua_createtable(L, 0 /* narr */, 7 /* nrec */);
 
     lua_pushcfunction(L, ngx_http_lua_socket_tcp_receive);
     lua_setfield(L, -2, "receive");
+
+    lua_pushcfunction(L, ngx_http_lua_socket_tcp_receiveatmost);
+    lua_setfield(L, -2, "receiveatmost");
 
     lua_pushcfunction(L, ngx_http_lua_socket_tcp_receiveuntil);
     lua_setfield(L, -2, "receiveuntil");
@@ -273,7 +282,7 @@ ngx_http_lua_inject_socket_tcp_api(ngx_log_t *log, lua_State *L)
 
     /* {{{tcp object metatable */
     lua_pushlightuserdata(L, &ngx_http_lua_tcp_socket_metatable_key);
-    lua_createtable(L, 0 /* narr */, 12 /* nrec */);
+    lua_createtable(L, 0 /* narr */, 13 /* nrec */);
 
     lua_pushcfunction(L, ngx_http_lua_socket_tcp_connect);
     lua_setfield(L, -2, "connect");
@@ -287,6 +296,9 @@ ngx_http_lua_inject_socket_tcp_api(ngx_log_t *log, lua_State *L)
 
     lua_pushcfunction(L, ngx_http_lua_socket_tcp_receive);
     lua_setfield(L, -2, "receive");
+
+    lua_pushcfunction(L, ngx_http_lua_socket_tcp_receiveatmost);
+    lua_setfield(L, -2, "receiveatmost");
 
     lua_pushcfunction(L, ngx_http_lua_socket_tcp_receiveuntil);
     lua_setfield(L, -2, "receiveuntil");
@@ -1709,7 +1721,21 @@ ngx_http_lua_socket_tcp_conn_retval_handler(ngx_http_request_t *r,
 
 
 static int
+ngx_http_lua_socket_tcp_receiveatmost(lua_State *L)
+{
+    return ngx_http_lua_socket_tcp_receive_common(L, 1);
+}
+
+
+static int
 ngx_http_lua_socket_tcp_receive(lua_State *L)
+{
+    return ngx_http_lua_socket_tcp_receive_common(L, 0);
+}
+
+
+static int
+ngx_http_lua_socket_tcp_receive_common(lua_State *L, unsigned fulfill_partial)
 {
     ngx_http_request_t                  *r;
     ngx_http_lua_socket_tcp_upstream_t  *u;
@@ -1779,6 +1805,12 @@ ngx_http_lua_socket_tcp_receive(lua_State *L)
 
         switch (typ) {
         case LUA_TSTRING:
+            if (fulfill_partial) {
+                p = (char *) lua_pushfstring(L,
+                        "bad pattern argument: receiveatmost accepts a number");
+                return luaL_argerror(L, 2, p);
+            }
+
             pat.data = (u_char *) luaL_checklstring(L, 2, &pat.len);
             if (pat.len != 2 || pat.data[0] != '*') {
                 p = (char *) lua_pushfstring(L, "bad pattern argument: %s",
@@ -1862,6 +1894,7 @@ ngx_http_lua_socket_tcp_receive(lua_State *L)
 
     u->read_waiting = 0;
     u->read_co_ctx = NULL;
+    u->fulfill_partial = fulfill_partial;
 
     rc = ngx_http_lua_socket_tcp_read(r, u);
 
@@ -2323,6 +2356,14 @@ success:
         return NGX_ERROR;
     }
 #endif
+
+    // Whether to fulfill a partial read.
+    dd("fulfill_partial=%d rest=%d length=%d", u->fulfill_partial, (int)u->rest,
+       (int)u->length);
+    if (u->fulfill_partial && u->rest < u->length) {
+        ngx_http_lua_socket_handle_read_success(r, u);
+        return NGX_OK;
+    }
 
     if (rev->active) {
         ngx_add_timer(rev, u->read_timeout);
@@ -3819,6 +3860,7 @@ ngx_http_lua_socket_receiveuntil_iterator(lua_State *L)
 
     u->read_waiting = 0;
     u->read_co_ctx = NULL;
+    u->fulfill_partial = 0;
 
     rc = ngx_http_lua_socket_tcp_read(r, u);
 

--- a/src/ngx_http_lua_socket_tcp.h
+++ b/src/ngx_http_lua_socket_tcp.h
@@ -108,6 +108,7 @@ struct ngx_http_lua_socket_tcp_upstream_s {
     unsigned                         ssl_verify:1;
     unsigned                         ssl_session_reuse:1;
 #endif
+    unsigned                         fulfill_partial:1;
 };
 
 


### PR DESCRIPTION
receiveatmost is just like receive, but does not wait until the receive
buffer is fully filled, or the timeout passes. It receive at least 1
byte and at most N bytes, specified by the argument.

This is useful as there's currently no nonblocking reads. Users can
process input as soon as data arrives.

Note: I'm not very familiar with nginx development. Inputs are appreciated.