### PR TITLE
Add FFI methods for taking stats to ngx.shared.DICT

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6674,7 +6674,7 @@ This feature was first introduced in the `v0.7.3` release.
 [Back to TOC](#nginx-api-for-lua)
 
 ngx.shared.DICT.capacity
----------------------
+------------------------
 **syntax:** *capacity_bytes = ngx.shared.DICT:capacity()*
 
 **context:** *init_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;*
@@ -6683,7 +6683,6 @@ ngx.shared.DICT.capacity
 
 Retrieving the capacity in bytes for the shm-based dictionary [ngx.shared.DICT](#ngxshareddict) declared with
 the [lua_shared_dict](#lua_shared_dict) directive.
-
 
 Example:
 
@@ -6698,6 +6697,8 @@ Example:
 This feature was first introduced in the `v0.10.11` release.
 
 **Note:** This method requires the `resty.core.shdict` or `resty.core` modules from the [lua-resty-core](https://github.com/openresty/lua-resty-core) library.
+
+This feature requires at least nginx core version `0.7.3`.
 
 See also [ngx.shared.DICT](#ngxshareddict).
 

--- a/README.markdown
+++ b/README.markdown
@@ -3196,7 +3196,8 @@ Nginx API for Lua
 * [ngx.shared.DICT.flush_all](#ngxshareddictflush_all)
 * [ngx.shared.DICT.flush_expired](#ngxshareddictflush_expired)
 * [ngx.shared.DICT.get_keys](#ngxshareddictget_keys)
-* [ngx.shared.DICT.stats](#ngxshareddictstats)
+* [ngx.shared.DICT.capacity](#ngxshareddictcapacity)
+* [ngx.shared.DICT.free_space](#ngxshareddictfree_space)
 * [ngx.socket.udp](#ngxsocketudp)
 * [udpsock:setpeername](#udpsocksetpeername)
 * [udpsock:send](#udpsocksend)
@@ -6206,7 +6207,8 @@ The resulting object `dict` has the following methods:
 * [flush_all](#ngxshareddictflush_all)
 * [flush_expired](#ngxshareddictflush_expired)
 * [get_keys](#ngxshareddictget_keys)
-* [stats](#ngxshareddictstats)
+* [capacity](#ngxshareddictcapacity)
+* [free_space](#ngxshareddictfree_space)
 
 All these methods are *atomic* operations, that is, safe from concurrent accesses from multiple nginx worker processes for the same `lua_shared_dict` zone.
 
@@ -6671,21 +6673,51 @@ This feature was first introduced in the `v0.7.3` release.
 
 [Back to TOC](#nginx-api-for-lua)
 
-ngx.shared.DICT.stats
+ngx.shared.DICT.capacity
 ---------------------
-**syntax:** *free_page_bytes = ngx.shared.DICT:stats()*
+**syntax:** *capacity_bytes = ngx.shared.DICT:capacity()*
 
 **context:** *init_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;*
 
 **requires:** `resty.core.shdict` or `resty.core`
 
-Retrieving the free pages size in bytes for the shm-based dictionary [ngx.shared.DICT](#ngxshareddict).
+Retrieving the capacity in bytes for the shm-based dictionary [ngx.shared.DICT](#ngxshareddict) declared with
+the [lua_shared_dict](#lua_shared_dict) directive.
+
+
+Example:
+
+```lua
+
+ require "resty.core"
+
+ local cats = ngx.shared.cats
+ local capacity_bytes = cats:capacity()
+```
+
+This feature was first introduced in the `v0.10.11` release.
+
+**Note:** This method requires the `resty.core.shdict` or `resty.core` modules from the [lua-resty-core](https://github.com/openresty/lua-resty-core) library.
+
+See also [ngx.shared.DICT](#ngxshareddict).
+
+[Back to TOC](#nginx-api-for-lua)
+
+ngx.shared.DICT.free_space
+--------------------------
+**syntax:** *free_page_bytes = ngx.shared.DICT:free_space()*
+
+**context:** *init_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;*
+
+**requires:** `resty.core.shdict` or `resty.core`
+
+Retrieving the free page size in bytes for the shm-based dictionary [ngx.shared.DICT](#ngxshareddict).
 
 **Note:** The memory for ngx.shared.DICT is allocated via the nginx slab allocator which has each slot for
 data size ranges like ~8, 9~16, 17~32, ..., 1025~2048, 2048~ bytes. And pages are assigned to a slot if there
 is no room in already assigned pages for the slot.
 
-So even if the return value of the `stats` method is zero, there may be room in already assigned pages, so
+So even if the return value of the `free_space` method is zero, there may be room in already assigned pages, so
 you may successfully set a new key value pair to the shared dict without getting `true` for `forcieble` or
 non nil `err` from the `ngx.shared.DICT.set`.
 
@@ -6699,8 +6731,8 @@ Example:
 
  require "resty.core"
 
- local dogs = ngx.shared.cats
- local free_page_bytes = dogs:stats()
+ local cats = ngx.shared.cats
+ local free_page_bytes = cats:free_space()
 ```
 
 This feature was first introduced in the `v0.10.11` release.

--- a/README.markdown
+++ b/README.markdown
@@ -3196,6 +3196,7 @@ Nginx API for Lua
 * [ngx.shared.DICT.flush_all](#ngxshareddictflush_all)
 * [ngx.shared.DICT.flush_expired](#ngxshareddictflush_expired)
 * [ngx.shared.DICT.get_keys](#ngxshareddictget_keys)
+* [ngx.shared.DICT.stats](#ngxshareddictstats)
 * [ngx.socket.udp](#ngxsocketudp)
 * [udpsock:setpeername](#udpsocksetpeername)
 * [udpsock:send](#udpsocksend)
@@ -6205,6 +6206,7 @@ The resulting object `dict` has the following methods:
 * [flush_all](#ngxshareddictflush_all)
 * [flush_expired](#ngxshareddictflush_expired)
 * [get_keys](#ngxshareddictget_keys)
+* [stats](#ngxshareddictstats)
 
 All these methods are *atomic* operations, that is, safe from concurrent accesses from multiple nginx worker processes for the same `lua_shared_dict` zone.
 
@@ -6666,6 +6668,34 @@ By default, only the first 1024 keys (if any) are returned. When the `<max_count
 **CAUTION** Avoid calling this method on dictionaries with a very large number of keys as it may lock the dictionary for significant amount of time and block Nginx worker processes trying to access the dictionary.
 
 This feature was first introduced in the `v0.7.3` release.
+
+[Back to TOC](#nginx-api-for-lua)
+
+ngx.shared.DICT.stats
+---------------------
+**syntax:** *used, total = ngx.shared.DICT:stats()*
+
+**context:** *init_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;*
+
+**requires:** `resty.core.shdict` or `resty.core`
+
+Retrieving the total used counts and total size in bytes for the shm-based dictionary [ngx.shared.DICT](#ngxshareddict).
+
+Example:
+
+```lua
+
+ require "resty.core"
+
+ local cats = ngx.shared.cats
+ local used, total = cats:stats()
+```
+
+This feature was first introduced in the `v0.10.11` release.
+
+**Note:** This method requires the `resty.core.shdict` or `resty.core` modules from the [lua-resty-core](https://github.com/openresty/lua-resty-core) library.
+
+See also [ngx.shared.DICT](#ngxshareddict).
 
 [Back to TOC](#nginx-api-for-lua)
 

--- a/README.markdown
+++ b/README.markdown
@@ -6719,7 +6719,7 @@ data size ranges like ~8, 9~16, 17~32, ..., 1025~2048, 2048~ bytes. And pages ar
 is no room in already assigned pages for the slot.
 
 So even if the return value of the `free_space` method is zero, there may be room in already assigned pages, so
-you may successfully set a new key value pair to the shared dict without getting `true` for `forcieble` or
+you may successfully set a new key value pair to the shared dict without getting `true` for `forcible` or
 non nil `err` from the `ngx.shared.DICT.set`.
 
 On the other hand, if already assigned pages for a slot are full and a new key value pair is added to the

--- a/README.markdown
+++ b/README.markdown
@@ -6681,7 +6681,7 @@ ngx.shared.DICT.capacity
 
 **requires:** `resty.core.shdict` or `resty.core`
 
-Retrieving the capacity in bytes for the shm-based dictionary [ngx.shared.DICT](#ngxshareddict) declared with
+Retrieves the capacity in bytes for the shm-based dictionary [ngx.shared.DICT](#ngxshareddict) declared with
 the [lua_shared_dict](#lua_shared_dict) directive.
 
 Example:
@@ -6712,7 +6712,7 @@ ngx.shared.DICT.free_space
 
 **requires:** `resty.core.shdict` or `resty.core`
 
-Retrieving the free page size in bytes for the shm-based dictionary [ngx.shared.DICT](#ngxshareddict).
+Retrieves the free page size in bytes for the shm-based dictionary [ngx.shared.DICT](#ngxshareddict).
 
 **Note:** The memory for ngx.shared.DICT is allocated via the nginx slab allocator which has each slot for
 data size ranges like ~8, 9~16, 17~32, ..., 1025~2048, 2048~ bytes. And pages are assigned to a slot if there

--- a/README.markdown
+++ b/README.markdown
@@ -6707,6 +6707,8 @@ This feature was first introduced in the `v0.10.11` release.
 
 **Note:** This method requires the `resty.core.shdict` or `resty.core` modules from the [lua-resty-core](https://github.com/openresty/lua-resty-core) library.
 
+This feature requires at least nginx core version `1.11.7`.
+
 See also [ngx.shared.DICT](#ngxshareddict).
 
 [Back to TOC](#nginx-api-for-lua)

--- a/README.markdown
+++ b/README.markdown
@@ -6673,13 +6673,25 @@ This feature was first introduced in the `v0.7.3` release.
 
 ngx.shared.DICT.stats
 ---------------------
-**syntax:** *used, total = ngx.shared.DICT:stats()*
+**syntax:** *free_page_bytes = ngx.shared.DICT:stats()*
 
 **context:** *init_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;*
 
 **requires:** `resty.core.shdict` or `resty.core`
 
-Retrieving the total used counts and total size in bytes for the shm-based dictionary [ngx.shared.DICT](#ngxshareddict).
+Retrieving the free pages size in bytes for the shm-based dictionary [ngx.shared.DICT](#ngxshareddict).
+
+**Note:** The memory for ngx.shared.DICT is allocated via the nginx slab allocator which has each slot for
+data size ranges like ~8, 9~16, 17~32, ..., 1025~2048, 2048~ bytes. And pages are assigned to a slot if there
+is no room in already assigned pages for the slot.
+
+So even if the return value of the `stats` method is zero, there may be room in already assigned pages, so
+you may successfully set a new key value pair to the shared dict without getting `true` for `forcieble` or
+non nil `err` from the `ngx.shared.DICT.set`.
+
+On the other hand, if already assigned pages for a slot are full and a new key value pair is added to the
+slot and there is no free page, you may get `true` for `forcible` or non nil `err` from the
+`ngx.shared.DICT.set` method.
 
 Example:
 
@@ -6687,8 +6699,8 @@ Example:
 
  require "resty.core"
 
- local cats = ngx.shared.cats
- local used, total = cats:stats()
+ local dogs = ngx.shared.cats
+ local free_page_bytes = dogs:stats()
 ```
 
 This feature was first introduced in the `v0.10.11` release.

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -5201,6 +5201,8 @@ The resulting object <code>dict</code> has the following methods:
 * [[#ngx.shared.DICT.flush_all|flush_all]]
 * [[#ngx.shared.DICT.flush_expired|flush_expired]]
 * [[#ngx.shared.DICT.get_keys|get_keys]]
+* [[#ngx.shared.DICT.capacity|capacity]]
+* [[#ngx.shared.DICT.free_space|free_space]]
 
 All these methods are ''atomic'' operations, that is, safe from concurrent accesses from multiple nginx worker processes for the same <code>lua_shared_dict</code> zone.
 
@@ -5597,6 +5599,71 @@ By default, only the first 1024 keys (if any) are returned. When the <code><max_
 '''CAUTION''' Avoid calling this method on dictionaries with a very large number of keys as it may lock the dictionary for significant amount of time and block Nginx worker processes trying to access the dictionary.
 
 This feature was first introduced in the <code>v0.7.3</code> release.
+
+== ngx.shared.DICT.capacity ==
+'''syntax:''' ''capacity_bytes = ngx.shared.DICT:capacity()''
+
+'''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
+
+'''requires:''' <code>resty.core.shdict</code> or <code>resty.core</code>
+
+Retrieving the capacity in bytes for the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]] declared with
+the [[#lua_shared_dict|lua_shared_dict]] directive.
+
+Example:
+
+<geshi lang="lua">
+    require "resty.core"
+
+    local cats = ngx.shared.cats
+    local capacity_bytes = cats:capacity()
+</geshi>
+
+This feature was first introduced in the <code>v0.10.11</code> release.
+
+'''Note:''' This method requires the <code>resty.core.shdict</code> or <code>resty.core</code> modules from the [https://github.com/openresty/lua-resty-core lua-resty-core] library.
+
+This feature requires at least nginx core version <code>0.7.3</code>.
+
+See also [[#ngx.shared.DICT|ngx.shared.DICT]].
+
+== ngx.shared.DICT.free_space ==
+'''syntax:''' ''free_page_bytes = ngx.shared.DICT:free_space()''
+
+'''context:''' ''init_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
+
+'''requires:''' <code>resty.core.shdict</code> or <code>resty.core</code>
+
+Retrieving the free page size in bytes for the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]].
+
+'''Note:''' The memory for ngx.shared.DICT is allocated via the nginx slab allocator which has each slot for
+data size ranges like ~8, 9~16, 17~32, ..., 1025~2048, 2048~ bytes. And pages are assigned to a slot if there
+is no room in already assigned pages for the slot.
+
+So even if the return value of the <code>free_space</code> method is zero, there may be room in already assigned pages, so
+you may successfully set a new key value pair to the shared dict without getting <code>true</code> for <code>forcieble</code> or
+non nil <code>err</code> from the <code>ngx.shared.DICT.set</code>.
+
+On the other hand, if already assigned pages for a slot are full and a new key value pair is added to the
+slot and there is no free page, you may get <code>true</code> for <code>forcible</code> or non nil <code>err</code> from the
+<code>ngx.shared.DICT.set</code> method.
+
+Example:
+
+<geshi lang="lua">
+    require "resty.core"
+
+    local cats = ngx.shared.cats
+    local free_page_bytes = cats:free_space()
+</geshi>
+
+This feature was first introduced in the <code>v0.10.11</code> release.
+
+'''Note:''' This method requires the <code>resty.core.shdict</code> or <code>resty.core</code> modules from the [https://github.com/openresty/lua-resty-core lua-resty-core] library.
+
+This feature requires at least nginx core version <code>1.11.7</code>.
+
+See also [[#ngx.shared.DICT|ngx.shared.DICT]].
 
 == ngx.socket.udp ==
 '''syntax:''' ''udpsock = ngx.socket.udp()''

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -5607,7 +5607,7 @@ This feature was first introduced in the <code>v0.7.3</code> release.
 
 '''requires:''' <code>resty.core.shdict</code> or <code>resty.core</code>
 
-Retrieving the capacity in bytes for the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]] declared with
+Retrieves the capacity in bytes for the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]] declared with
 the [[#lua_shared_dict|lua_shared_dict]] directive.
 
 Example:
@@ -5634,7 +5634,7 @@ See also [[#ngx.shared.DICT|ngx.shared.DICT]].
 
 '''requires:''' <code>resty.core.shdict</code> or <code>resty.core</code>
 
-Retrieving the free page size in bytes for the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]].
+Retrieves the free page size in bytes for the shm-based dictionary [[#ngx.shared.DICT|ngx.shared.DICT]].
 
 '''Note:''' The memory for ngx.shared.DICT is allocated via the nginx slab allocator which has each slot for
 data size ranges like ~8, 9~16, 17~32, ..., 1025~2048, 2048~ bytes. And pages are assigned to a slot if there

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -5641,7 +5641,7 @@ data size ranges like ~8, 9~16, 17~32, ..., 1025~2048, 2048~ bytes. And pages ar
 is no room in already assigned pages for the slot.
 
 So even if the return value of the <code>free_space</code> method is zero, there may be room in already assigned pages, so
-you may successfully set a new key value pair to the shared dict without getting <code>true</code> for <code>forcieble</code> or
+you may successfully set a new key value pair to the shared dict without getting <code>true</code> for <code>forcible</code> or
 non nil <code>err</code> from the <code>ngx.shared.DICT.set</code>.
 
 On the other hand, if already assigned pages for a slot are full and a new key value pair is added to the

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -2988,36 +2988,17 @@ ngx_http_lua_ffi_shdict_set_expire(ngx_shm_zone_t *zone, u_char *key,
 #if nginx_version >= 1011007
 void
 ngx_http_lua_ffi_shdict_get_stats(ngx_shm_zone_t *zone,
-    size_t *total_used, size_t *total_size)
+    size_t *free_page_bytes)
 {
     ngx_http_lua_shdict_ctx_t   *ctx;
-    ngx_slab_stat_t             *stat;
-    size_t                       slot_count;
-    size_t                       slot_size;
-    size_t                       i;
-    size_t                       sum_used = 0;
-    size_t                       sum_size = 0;
 
     ctx = zone->data;
 
     ngx_shmtx_lock(&ctx->shpool->mutex);
 
-    slot_count = ngx_pagesize_shift - ctx->shpool->min_shift;
-    stat = ctx->shpool->stats;
-    slot_size = ctx->shpool->min_size;
-
-    for (i = 0; i < slot_count; i++) {
-        sum_used += stat->used;
-        sum_size += stat->used * slot_size;
-
-        stat++;
-        slot_size <<= 1;
-    }
+    *free_page_bytes = ctx->shpool->pfree * ngx_pagesize;
 
     ngx_shmtx_unlock(&ctx->shpool->mutex);
-
-    *total_used = sum_used;
-    *total_size = sum_size;
 }
 #endif /* nginx_version >= 1011007 */
 #endif /* NGX_LUA_NO_FFI_API */

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -2985,7 +2985,7 @@ ngx_http_lua_ffi_shdict_set_expire(ngx_shm_zone_t *zone, u_char *key,
 }
 
 
-#if nginx_version >= 1011007
+#    if nginx_version >= 1011007
 void
 ngx_http_lua_ffi_shdict_get_stats(ngx_shm_zone_t *zone,
     size_t *free_page_bytes)
@@ -3000,7 +3000,9 @@ ngx_http_lua_ffi_shdict_get_stats(ngx_shm_zone_t *zone,
 
     ngx_shmtx_unlock(&ctx->shpool->mutex);
 }
-#endif /* nginx_version >= 1011007 */
+#    endif /* nginx_version >= 1011007 */
+
+
 #endif /* NGX_LUA_NO_FFI_API */
 
 

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -2983,6 +2983,39 @@ ngx_http_lua_ffi_shdict_set_expire(ngx_shm_zone_t *zone, u_char *key,
 
     return NGX_OK;
 }
+
+void
+ngx_http_lua_ffi_shdict_get_stats(ngx_shm_zone_t *zone,
+    size_t *total_used, size_t *total_size)
+{
+    ngx_http_lua_shdict_ctx_t   *ctx;
+    ngx_slab_stat_t             *stat;
+    size_t                       slot_count;
+    size_t                       slot_size;
+    size_t                       i;
+    size_t                       sum_used = 0;
+    size_t                       sum_size = 0;
+
+    ctx = zone->data;
+
+    ngx_shmtx_lock(&ctx->shpool->mutex);
+    slot_count = ngx_pagesize_shift - ctx->shpool->min_shift;
+    stat = ctx->shpool->stats;
+    slot_size = ctx->shpool->min_size;
+
+    for (i = 0; i < slot_count; i++) {
+        sum_used += stat->used;
+        sum_size += stat->used * slot_size;
+
+        stat++;
+        slot_size <<= 1;
+    }
+
+    ngx_shmtx_unlock(&ctx->shpool->mutex);
+
+    *total_used = sum_used;
+    *total_size = sum_size;
+}
 #endif /* NGX_LUA_NO_FFI_API */
 
 

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -2984,6 +2984,7 @@ ngx_http_lua_ffi_shdict_set_expire(ngx_shm_zone_t *zone, u_char *key,
     return NGX_OK;
 }
 
+
 #if nginx_version >= 1011007
 void
 ngx_http_lua_ffi_shdict_get_stats(ngx_shm_zone_t *zone,
@@ -3000,6 +3001,7 @@ ngx_http_lua_ffi_shdict_get_stats(ngx_shm_zone_t *zone,
     ctx = zone->data;
 
     ngx_shmtx_lock(&ctx->shpool->mutex);
+
     slot_count = ngx_pagesize_shift - ctx->shpool->min_shift;
     stat = ctx->shpool->stats;
     slot_size = ctx->shpool->min_size;

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -2985,28 +2985,31 @@ ngx_http_lua_ffi_shdict_set_expire(ngx_shm_zone_t *zone, u_char *key,
 }
 
 
-void
-ngx_http_lua_ffi_shdict_capacity(ngx_shm_zone_t *zone,
-    size_t *capacity_bytes)
+#    if nginx_version >= 1011007
+size_t
+ngx_http_lua_ffi_shdict_capacity(ngx_shm_zone_t *zone)
 {
-    *capacity_bytes = zone->shm.size;
+    return zone->shm.size;
 }
+#    endif /* nginx_version >= 1011007 */
 
 
 #    if nginx_version >= 1011007
-void
-ngx_http_lua_ffi_shdict_free_space(ngx_shm_zone_t *zone,
-    size_t *free_page_bytes)
+size_t
+ngx_http_lua_ffi_shdict_free_space(ngx_shm_zone_t *zone)
 {
     ngx_http_lua_shdict_ctx_t   *ctx;
+    size_t                       free_page_bytes;
 
     ctx = zone->data;
 
     ngx_shmtx_lock(&ctx->shpool->mutex);
 
-    *free_page_bytes = ctx->shpool->pfree * ngx_pagesize;
+    free_page_bytes = ctx->shpool->pfree * ngx_pagesize;
 
     ngx_shmtx_unlock(&ctx->shpool->mutex);
+
+    return free_page_bytes;
 }
 #    endif /* nginx_version >= 1011007 */
 

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -2984,6 +2984,7 @@ ngx_http_lua_ffi_shdict_set_expire(ngx_shm_zone_t *zone, u_char *key,
     return NGX_OK;
 }
 
+#if nginx_version >= 1011007
 void
 ngx_http_lua_ffi_shdict_get_stats(ngx_shm_zone_t *zone,
     size_t *total_used, size_t *total_size)
@@ -3016,6 +3017,7 @@ ngx_http_lua_ffi_shdict_get_stats(ngx_shm_zone_t *zone,
     *total_used = sum_used;
     *total_size = sum_size;
 }
+#endif /* nginx_version >= 1011007 */
 #endif /* NGX_LUA_NO_FFI_API */
 
 

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -2985,13 +2985,11 @@ ngx_http_lua_ffi_shdict_set_expire(ngx_shm_zone_t *zone, u_char *key,
 }
 
 
-#    if nginx_version >= 1011007
 size_t
 ngx_http_lua_ffi_shdict_capacity(ngx_shm_zone_t *zone)
 {
     return zone->shm.size;
 }
-#    endif /* nginx_version >= 1011007 */
 
 
 #    if nginx_version >= 1011007

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -2985,9 +2985,17 @@ ngx_http_lua_ffi_shdict_set_expire(ngx_shm_zone_t *zone, u_char *key,
 }
 
 
+void
+ngx_http_lua_ffi_shdict_capacity(ngx_shm_zone_t *zone,
+    size_t *capacity_bytes)
+{
+    *capacity_bytes = zone->shm.size;
+}
+
+
 #    if nginx_version >= 1011007
 void
-ngx_http_lua_ffi_shdict_get_stats(ngx_shm_zone_t *zone,
+ngx_http_lua_ffi_shdict_free_space(ngx_shm_zone_t *zone,
     size_t *free_page_bytes)
 {
     ngx_http_lua_shdict_ctx_t   *ctx;


### PR DESCRIPTION
This is a pull request for adding `get_stats` method to `ngx.shared.DICT`.

I'd like to know memory usage of a `ngx.shared.DICT`.
I noticed there is the systemtap solution https://github.com/openresty/openresty-systemtap-toolkit/blob/master/ngx-shm
However, I'd like to know memory usage on other OSes (such as FreeBSD) than Linux,
so I need a Lua API.

`get_stats` returns the information of the `stats` field in `ngx_slab_pool_t`
https://github.com/nginx/nginx/blob/418124e21983aa53db4d99b7fd2eb0eee7ab4be0/src/core/ngx_slab.h#L25-L31
The return value is an array table of record tables which has the following keys:

* size
* total
* used
* reqs
* fails

The last four keys corresponds to the fields in `ngx_slab_stat_t`.
https://github.com/nginx/nginx/blob/418124e21983aa53db4d99b7fd2eb0eee7ab4be0/src/core/ngx_slab.h#L25-L31

The `size` key are a calculated page size for each slot.
The size of the first slot is `pool->min_size` and the size of following slot is twice of the previous slot.
https://github.com/nginx/nginx/blob/418124e21983aa53db4d99b7fd2eb0eee7ab4be0/src/core/ngx_slab.c#L208-L216

An example config:

```
...
http {
    lua_shared_dict dogs 10m;

    server {
        ...
        location /set {
            content_by_lua_block {
                local dogs = ngx.shared.dogs
                for i = 1, 2000 do
                    dogs:set(string.format("key%d", i), string.rep("v", i))
                end
                ngx.say("STORED")
            }
        }
        location /stats {
            content_by_lua_block {
                local dogs = ngx.shared.dogs
                local stats = dogs:get_stats()
                for slot, s in ipairs(stats) do
                    ngx.say(string.format("slot=%d, size=%d, total=%d, used=%d, reqs=%d, fails=
%d", slot, s.size, s.total, s.used, s.reqs, s.fails))
                end
            }
        }
    }
}
```

An example output:

```
# curl localhost/set
STORED
# curl localhost/stats
slot=1, size=8, total=0, used=0, reqs=0, fails=0
slot=2, size=16, total=0, used=0, reqs=0, fails=0
slot=3, size=32, total=127, used=1, reqs=1, fails=0
slot=4, size=64, total=0, used=0, reqs=0, fails=0
slot=5, size=128, total=64, used=56, reqs=56, fails=0
slot=6, size=256, total=128, used=127, reqs=127, fails=0
slot=7, size=512, total=256, used=256, reqs=256, fails=0
slot=8, size=1024, total=512, used=512, reqs=512, fails=0
slot=9, size=2048, total=1024, used=1023, reqs=1023, fails=0
```

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

