### PR TITLE
feature: added pure C functions for shdict:ttl() and shdict:expire() APIs

### DIFF
--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -2944,12 +2944,16 @@ ngx_http_lua_ffi_shdict_set_expire(ngx_shm_zone_t *zone, u_char *key,
 {
     uint32_t                     hash;
     ngx_int_t                    rc;
-    ngx_time_t                  *tp;
+    ngx_time_t                  *tp = NULL;
     ngx_http_lua_shdict_ctx_t   *ctx;
     ngx_http_lua_shdict_node_t  *sd;
 
     if (zone == NULL) {
         return NGX_ERROR;
+    }
+
+    if (exptime > 0) {
+        tp = ngx_timeofday();
     }
 
     ctx = zone->data;
@@ -2968,7 +2972,6 @@ ngx_http_lua_ffi_shdict_set_expire(ngx_shm_zone_t *zone, u_char *key,
     /* rc == NGX_OK */
 
     if (exptime > 0) {
-        tp = ngx_timeofday();
         sd->expires = (uint64_t) tp->sec * 1000 + tp->msec
                       + (uint64_t) exptime;
 

--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -2843,6 +2843,136 @@ ngx_http_lua_ffi_shdict_flush_all(ngx_shm_zone_t *zone)
 
     return NGX_OK;
 }
+
+
+static ngx_int_t
+ngx_http_lua_shdict_peek(ngx_shm_zone_t *shm_zone, ngx_uint_t hash,
+    u_char *kdata, size_t klen, ngx_http_lua_shdict_node_t **sdp)
+{
+    ngx_int_t                    rc;
+    ngx_rbtree_node_t           *node, *sentinel;
+    ngx_http_lua_shdict_ctx_t   *ctx;
+    ngx_http_lua_shdict_node_t  *sd;
+
+    ctx = shm_zone->data;
+
+    node = ctx->sh->rbtree.root;
+    sentinel = ctx->sh->rbtree.sentinel;
+
+    while (node != sentinel) {
+
+        if (hash < node->key) {
+            node = node->left;
+            continue;
+        }
+
+        if (hash > node->key) {
+            node = node->right;
+            continue;
+        }
+
+        /* hash == node->key */
+
+        sd = (ngx_http_lua_shdict_node_t *) &node->color;
+
+        rc = ngx_memn2cmp(kdata, sd->data, klen, (size_t) sd->key_len);
+
+        if (rc == 0) {
+            *sdp = sd;
+
+            return NGX_OK;
+        }
+
+        node = (rc < 0) ? node->left : node->right;
+    }
+
+    *sdp = NULL;
+
+    return NGX_DECLINED;
+}
+
+
+int
+ngx_http_lua_ffi_shdict_get_ttl(ngx_shm_zone_t *zone, u_char *key,
+    size_t key_len)
+{
+    uint32_t                     hash;
+    uint64_t                     now;
+    ngx_int_t                    rc;
+    ngx_time_t                  *tp;
+    ngx_http_lua_shdict_ctx_t   *ctx;
+    ngx_http_lua_shdict_node_t  *sd;
+
+    if (zone == NULL) {
+        return NGX_ERROR;
+    }
+
+    ctx = zone->data;
+    hash = ngx_crc32_short(key, key_len);
+
+    ngx_shmtx_lock(&ctx->shpool->mutex);
+
+    rc = ngx_http_lua_shdict_peek(zone, hash, key, key_len, &sd);
+
+    ngx_shmtx_unlock(&ctx->shpool->mutex);
+
+    if (rc == NGX_DECLINED) {
+        return NGX_DECLINED;
+    }
+
+    /* rc == NGX_OK */
+
+    if (sd->expires == 0) {
+        return 0;
+    }
+
+    tp = ngx_timeofday();
+    now = (uint64_t) tp->sec * 1000 + tp->msec;
+
+    return sd->expires - now;
+}
+
+
+int
+ngx_http_lua_ffi_shdict_set_expire(ngx_shm_zone_t *zone, u_char *key,
+    size_t key_len, int exptime)
+{
+    uint32_t                     hash;
+    ngx_int_t                    rc;
+    ngx_time_t                  *tp;
+    ngx_http_lua_shdict_ctx_t   *ctx;
+    ngx_http_lua_shdict_node_t  *sd;
+
+    if (zone == NULL) {
+        return NGX_ERROR;
+    }
+
+    ctx = zone->data;
+    hash = ngx_crc32_short(key, key_len);
+
+    ngx_shmtx_lock(&ctx->shpool->mutex);
+
+    rc = ngx_http_lua_shdict_peek(zone, hash, key, key_len, &sd);
+
+    ngx_shmtx_unlock(&ctx->shpool->mutex);
+
+    if (rc == NGX_DECLINED) {
+        return NGX_DECLINED;
+    }
+
+    /* rc == NGX_OK */
+
+    if (exptime > 0) {
+        tp = ngx_timeofday();
+        sd->expires = (uint64_t) tp->sec * 1000 + tp->msec
+                      + (uint64_t) exptime;
+
+    } else {
+        sd->expires = 0;
+    }
+
+    return NGX_OK;
+}
 #endif /* NGX_LUA_NO_FFI_API */
 
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

Sister PR for openresty/lua-resty-core#140