### PR TITLE
bugfix: set_by_lua_block breaks config dump (-T switch)

### DIFF
--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -1542,7 +1542,7 @@ ngx_http_lua_conf_read_lua_token(ngx_conf_t *cf,
 
 #if nginx_version >= 1009002
             if (dump) {
-                dump->last = ngx_cpymem(dump->last, b->pos, size);
+                dump->last = ngx_cpymem(dump->last, b->start + len, size);
             }
 #endif
         }


### PR DESCRIPTION
My colleague kindly provided this fix for issue #1066.
