### PR TITLE
bugfix: the connection might be closed when some handlers using fake …

### DIFF
--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -186,7 +186,6 @@ ngx_http_lua_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
 {
     lua_State                       *L;
     ngx_int_t                        rc;
-    ngx_uint_t                       reusable;
     ngx_connection_t                *c, *fc;
     ngx_http_request_t              *r = NULL;
     ngx_pool_cleanup_t              *cln;
@@ -198,7 +197,7 @@ ngx_http_lua_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
 
     c = ngx_ssl_get_connection(ssl_conn);
 
-    dd("c = %p", c);
+    dd("c = %p, reusable = %d", c, (int) c->reusable);
 
     cctx = ngx_http_lua_ssl_get_ctx(c->ssl->connection);
 
@@ -221,19 +220,11 @@ ngx_http_lua_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
 
     dd("first time");
 
-    hc = c->data;
-    reusable = c->reusable;
+    ngx_reusable_connection(c, 0);
 
-    if (reusable) {
-        ngx_reusable_connection(c, 0);
-    }
+    hc = c->data;
 
     fc = ngx_http_lua_create_fake_connection(NULL);
-
-    if (reusable) {
-        ngx_reusable_connection(c, 1);
-    }
-
     if (fc == NULL) {
         goto failed;
     }

--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -186,6 +186,7 @@ ngx_http_lua_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
 {
     lua_State                       *L;
     ngx_int_t                        rc;
+    ngx_uint_t                       reusable;
     ngx_connection_t                *c, *fc;
     ngx_http_request_t              *r = NULL;
     ngx_pool_cleanup_t              *cln;
@@ -221,8 +222,18 @@ ngx_http_lua_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
     dd("first time");
 
     hc = c->data;
+    reusable = c->reusable;
+
+    if (reusable) {
+        ngx_reusable_connection(c, 0);
+    }
 
     fc = ngx_http_lua_create_fake_connection(NULL);
+
+    if (reusable) {
+        ngx_reusable_connection(c, 1);
+    }
+
     if (fc == NULL) {
         goto failed;
     }

--- a/src/ngx_http_lua_ssl_session_fetchby.c
+++ b/src/ngx_http_lua_ssl_session_fetchby.c
@@ -176,6 +176,7 @@ ngx_http_lua_ssl_sess_fetch_handler(ngx_ssl_conn_t *ssl_conn, u_char *id,
 {
     lua_State                       *L;
     ngx_int_t                        rc;
+    ngx_uint_t                       reusable;
     ngx_connection_t                *c, *fc = NULL;
     ngx_http_request_t              *r = NULL;
     ngx_pool_cleanup_t              *cln;
@@ -225,8 +226,18 @@ ngx_http_lua_ssl_sess_fetch_handler(ngx_ssl_conn_t *ssl_conn, u_char *id,
     dd("first time");
 
     hc = c->data;
+    reusable = c->reusable;
+
+    if (reusable) {
+        ngx_reusable_connection(c, 0);
+    }
 
     fc = ngx_http_lua_create_fake_connection(NULL);
+
+    if (reusable) {
+        ngx_reusable_connection(c, 1);
+    }
+
     if (fc == NULL) {
         goto failed;
     }

--- a/src/ngx_http_lua_ssl_session_fetchby.c
+++ b/src/ngx_http_lua_ssl_session_fetchby.c
@@ -176,7 +176,6 @@ ngx_http_lua_ssl_sess_fetch_handler(ngx_ssl_conn_t *ssl_conn, u_char *id,
 {
     lua_State                       *L;
     ngx_int_t                        rc;
-    ngx_uint_t                       reusable;
     ngx_connection_t                *c, *fc = NULL;
     ngx_http_request_t              *r = NULL;
     ngx_pool_cleanup_t              *cln;
@@ -192,7 +191,7 @@ ngx_http_lua_ssl_sess_fetch_handler(ngx_ssl_conn_t *ssl_conn, u_char *id,
 
     c = ngx_ssl_get_connection(ssl_conn);
 
-    dd("c = %p", c);
+    dd("c = %p, reusable = %d", c, (int) c->reusable);
 
     cctx = ngx_http_lua_ssl_get_ctx(c->ssl->connection);
 
@@ -225,19 +224,11 @@ ngx_http_lua_ssl_sess_fetch_handler(ngx_ssl_conn_t *ssl_conn, u_char *id,
 
     dd("first time");
 
-    hc = c->data;
-    reusable = c->reusable;
+    ngx_reusable_connection(c, 0);
 
-    if (reusable) {
-        ngx_reusable_connection(c, 0);
-    }
+    hc = c->data;
 
     fc = ngx_http_lua_create_fake_connection(NULL);
-
-    if (reusable) {
-        ngx_reusable_connection(c, 1);
-    }
-
     if (fc == NULL) {
         goto failed;
     }

--- a/src/ngx_http_lua_ssl_session_storeby.c
+++ b/src/ngx_http_lua_ssl_session_storeby.c
@@ -174,6 +174,7 @@ ngx_http_lua_ssl_sess_store_handler(ngx_ssl_conn_t *ssl_conn,
 {
     lua_State                       *L;
     ngx_int_t                        rc;
+    ngx_uint_t                       reusable;
     ngx_connection_t                *c, *fc = NULL;
     ngx_http_request_t              *r = NULL;
     ngx_http_connection_t           *hc;
@@ -190,8 +191,18 @@ ngx_http_lua_ssl_sess_store_handler(ngx_ssl_conn_t *ssl_conn,
     dd("ssl sess_store handler, sess_store-ctx=%p", cctx);
 
     hc = c->data;
+    reusable = c->reusable;
+
+    if (reusable) {
+        ngx_reusable_connection(c, 0);
+    }
 
     fc = ngx_http_lua_create_fake_connection(NULL);
+
+    if (reusable) {
+        ngx_reusable_connection(c, 1);
+    }
+
     if (fc == NULL) {
         goto failed;
     }

--- a/src/ngx_http_lua_ssl_session_storeby.c
+++ b/src/ngx_http_lua_ssl_session_storeby.c
@@ -174,7 +174,6 @@ ngx_http_lua_ssl_sess_store_handler(ngx_ssl_conn_t *ssl_conn,
 {
     lua_State                       *L;
     ngx_int_t                        rc;
-    ngx_uint_t                       reusable;
     ngx_connection_t                *c, *fc = NULL;
     ngx_http_request_t              *r = NULL;
     ngx_http_connection_t           *hc;
@@ -184,25 +183,15 @@ ngx_http_lua_ssl_sess_store_handler(ngx_ssl_conn_t *ssl_conn,
 
     c = ngx_ssl_get_connection(ssl_conn);
 
-    dd("c = %p", c);
+    dd("c = %p, reusable = %d", c, (int) c->reusable);
 
     cctx = ngx_http_lua_ssl_get_ctx(c->ssl->connection);
 
     dd("ssl sess_store handler, sess_store-ctx=%p", cctx);
 
     hc = c->data;
-    reusable = c->reusable;
-
-    if (reusable) {
-        ngx_reusable_connection(c, 0);
-    }
 
     fc = ngx_http_lua_create_fake_connection(NULL);
-
-    if (reusable) {
-        ngx_reusable_connection(c, 1);
-    }
-
     if (fc == NULL) {
         goto failed;
     }


### PR DESCRIPTION
…connection are involved (like ssl_certficate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*).

fix the issue reported at [ngx_http_lua_ssl_cert_handler crash](https://groups.google.com/forum/#!topic/openresty/eLd8Q7qe_jk).

it's a little difficult to add a test case to cover this. any idea?

@agentzh 

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
