### PR TITLE
feature: log the tcp cosocket address when connect times out

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -1013,12 +1013,14 @@ ngx_http_lua_socket_init_peer_connection_addr_text(ngx_peer_connection_t *pc)
     c = pc->connection;
 
     switch (pc->sockaddr->sa_family) {
+
 #if (NGX_HAVE_INET6)
     case AF_INET6:
         addr_text_max_len = NGX_INET6_ADDRSTRLEN;
         break;
 #endif
 #if (NGX_HAVE_UNIX_DOMAIN)
+
     case AF_UNIX:
         addr_text_max_len = NGX_UNIX_ADDRSTRLEN;
         break;
@@ -1026,6 +1028,7 @@ ngx_http_lua_socket_init_peer_connection_addr_text(ngx_peer_connection_t *pc)
     case AF_INET:
         addr_text_max_len = NGX_INET_ADDRSTRLEN;
         break;
+
     default:
         addr_text_max_len = NGX_SOCKADDR_STRLEN;
         break;

--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -32,6 +32,8 @@ static int ngx_http_lua_socket_tcp_settimeouts(lua_State *L);
 static void ngx_http_lua_socket_tcp_handler(ngx_event_t *ev);
 static ngx_int_t ngx_http_lua_socket_tcp_get_peer(ngx_peer_connection_t *pc,
     void *data);
+static void ngx_http_lua_socket_init_peer_connection_addr_text(
+    ngx_peer_connection_t *pc);
 static void ngx_http_lua_socket_read_handler(ngx_http_request_t *r,
     ngx_http_lua_socket_tcp_upstream_t *u);
 static void ngx_http_lua_socket_send_handler(ngx_http_request_t *r,
@@ -999,6 +1001,46 @@ nomem:
         lua_pushnil(L);
         lua_pushliteral(L, "no memory");
     }
+}
+
+
+static void
+ngx_http_lua_socket_init_peer_connection_addr_text(ngx_peer_connection_t *pc)
+{
+    ngx_connection_t            *c;
+    size_t                       addr_text_max_len;
+
+    c = pc->connection;
+
+    switch (pc->sockaddr->sa_family) {
+#if (NGX_HAVE_INET6)
+    case AF_INET6:
+        addr_text_max_len = NGX_INET6_ADDRSTRLEN;
+        break;
+#endif
+#if (NGX_HAVE_UNIX_DOMAIN)
+    case AF_UNIX:
+        addr_text_max_len = NGX_UNIX_ADDRSTRLEN;
+        break;
+#endif
+    case AF_INET:
+        addr_text_max_len = NGX_INET_ADDRSTRLEN;
+        break;
+    default:
+        addr_text_max_len = NGX_SOCKADDR_STRLEN;
+        break;
+    }
+
+    c->addr_text.data = ngx_pnalloc(c->pool, addr_text_max_len);
+    if (c->addr_text.data == NULL) {
+        ngx_log_error(NGX_LOG_ERR, pc->log, 0,
+                      "init peer connection addr_text failed: no memory");
+        return;
+    }
+
+    c->addr_text.len = ngx_sock_ntop(pc->sockaddr, pc->socklen,
+                                     c->addr_text.data,
+                                     addr_text_max_len, 0);
 }
 
 
@@ -3268,8 +3310,11 @@ ngx_http_lua_socket_connected_handler(ngx_http_request_t *r,
         llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
 
         if (llcf->log_socket_errors) {
+            ngx_http_lua_socket_init_peer_connection_addr_text(&u->peer);
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                          "lua tcp socket connect timed out");
+                          "lua tcp socket connect timed out,"
+                          " when connecting to %V:%ud",
+                          &c->addr_text, ngx_inet_get_port(u->peer.sockaddr));
         }
 
         ngx_http_lua_socket_handle_conn_error(r, u,

--- a/t/023-rewrite/tcp-socket-timeout.t
+++ b/t/023-rewrite/tcp-socket-timeout.t
@@ -63,7 +63,7 @@ GET /t1
 failed to connect: timeout
 --- error_log
 lua tcp socket connect timeout: 100
-lua tcp socket connect timed out
+lua tcp socket connect timed out, when connecting to 106.184.1.99:12345
 --- timeout: 10
 
 

--- a/t/023-rewrite/tcp-socket.t
+++ b/t/023-rewrite/tcp-socket.t
@@ -329,7 +329,7 @@ send: nil closed
 receive: nil closed
 close: nil closed
 --- error_log
-lua tcp socket connect timed out
+lua tcp socket connect timed out, when connecting to 106.184.1.99:12345
 --- timeout: 10
 
 

--- a/t/058-tcp-socket.t
+++ b/t/058-tcp-socket.t
@@ -321,7 +321,7 @@ send: nil closed
 receive: nil closed
 close: nil closed
 --- error_log
-lua tcp socket connect timed out
+lua tcp socket connect timed out, when connecting to 106.184.1.99:12345
 --- timeout: 10
 
 

--- a/t/065-tcp-socket-timeout.t
+++ b/t/065-tcp-socket-timeout.t
@@ -66,7 +66,7 @@ GET /t
 failed to connect: timeout
 --- error_log
 lua tcp socket connect timeout: 100
-lua tcp socket connect timed out
+lua tcp socket connect timed out, when connecting to 106.184.1.99:12345
 --- timeout: 10
 
 
@@ -96,7 +96,7 @@ GET /t
 failed to connect: timeout
 --- error_log
 lua tcp socket connect timeout: 150
-lua tcp socket connect timed out
+lua tcp socket connect timed out, when connecting to 106.184.1.99:12345
 --- timeout: 10
 
 
@@ -125,7 +125,7 @@ GET /t
 failed to connect: timeout
 --- error_log
 lua tcp socket connect timeout: 102
-lua tcp socket connect timed out
+lua tcp socket connect timed out, when connecting to 106.184.1.99:12345
 
 
 
@@ -154,7 +154,7 @@ GET /t
 failed to connect: timeout
 --- error_log
 lua tcp socket connect timeout: 102
-lua tcp socket connect timed out
+lua tcp socket connect timed out, when connecting to 106.184.1.99:12345
 --- timeout: 10
 
 
@@ -707,7 +707,7 @@ GET /t
 2: connected: 1
 --- error_log
 lua tcp socket connect timeout: 100
-lua tcp socket connect timed out
+lua tcp socket connect timed out, when connecting to 106.184.1.99:12345
 --- timeout: 10
 
 

--- a/t/090-log-socket-errors.t
+++ b/t/090-log-socket-errors.t
@@ -59,7 +59,7 @@ GET /t
 --- response_body
 timeout
 --- error_log
-lua tcp socket connect timed out
+lua tcp socket connect timed out, when connecting to 106.184.1.99:12345
 
 
 

--- a/t/147-tcp-socket-timeouts.t
+++ b/t/147-tcp-socket-timeouts.t
@@ -346,7 +346,7 @@ send: nil closed
 receive: nil closed
 close: nil closed
 --- error_log
-lua tcp socket connect timed out
+lua tcp socket connect timed out, when connecting to 106.184.1.99:12345
 --- timeout: 10
 
 


### PR DESCRIPTION
This feature makes debug connect timeout errors easier, since domain
name may map to different ip address in different time.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
