### PR TITLE
optimize: destroyed the Lua VM and avoided running any init_worker_by_lua* inside cache processes.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1487,6 +1487,8 @@ This hook is often used to create per-worker reoccurring timers (via the [ngx.ti
 
 This directive was first introduced in the `v0.9.5` release.
 
+After `v0.10.12` release, the specified Lua code doesn't run in cache processes anymore.
+
 [Back to TOC](#directives)
 
 init_worker_by_lua_block

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -1196,6 +1196,8 @@ This hook is often used to create per-worker reoccurring timers (via the [[#ngx.
 
 This directive was first introduced in the <code>v0.9.5</code> release.
 
+After <code>v0.10.12</code> release, the specified Lua code doesn't run in cache processes anymore.
+
 == init_worker_by_lua_block ==
 
 '''syntax:''' ''init_worker_by_lua_block { lua-script }''

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -162,6 +162,7 @@ typedef struct {
 
 struct ngx_http_lua_main_conf_s {
     lua_State           *lua;
+    ngx_pool_cleanup_t  *vm_cleanup;
 
     ngx_str_t            lua_path;
     ngx_str_t            lua_cpath;

--- a/src/ngx_http_lua_initworkerby.c
+++ b/src/ngx_http_lua_initworkerby.c
@@ -40,11 +40,7 @@ ngx_http_lua_init_worker(ngx_cycle_t *cycle)
 
     lmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_lua_module);
 
-    if (lmcf == NULL) {
-        return NGX_OK;
-    }
-
-    if (lmcf->lua != NULL) {
+    if (lmcf != NULL && lmcf->lua != NULL) {
         /* disable init_worker_by_lua* and destroy lua VM in cache processes */
         if (ngx_process == NGX_PROCESS_HELPER) {
 #if defined(HAVE_PRIVILEGED_PROCESS_PATCH) && !NGX_WIN32
@@ -61,12 +57,12 @@ ngx_http_lua_init_worker(ngx_cycle_t *cycle)
             }
 #endif
         }
-
-    } else {
-        return NGX_OK;
     }
 
-    if (lmcf->init_worker_handler == NULL) {
+    if (lmcf == NULL
+        || lmcf->init_worker_handler == NULL
+        || lmcf->lua == NULL)
+    {
         return NGX_OK;
     }
 

--- a/src/ngx_http_lua_initworkerby.c
+++ b/src/ngx_http_lua_initworkerby.c
@@ -40,29 +40,30 @@ ngx_http_lua_init_worker(ngx_cycle_t *cycle)
 
     lmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_lua_module);
 
-    if (lmcf != NULL && lmcf->lua != NULL) {
-        /* disable init_worker_by_lua* and destroy lua VM in cache processes */
-        if (ngx_process == NGX_PROCESS_HELPER) {
-#if defined(HAVE_PRIVILEGED_PROCESS_PATCH) && !NGX_WIN32
-            if (!ngx_is_privileged_agent) {
-#endif
-
-                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
-                               "lua close the global Lua VM %p in "
-                               "cache process %P", lmcf->lua, ngx_pid);
-                lmcf->vm_cleanup->handler(lmcf->vm_cleanup->data);
-                lmcf->vm_cleanup->handler = NULL;
-                return NGX_OK;
-#if defined(HAVE_PRIVILEGED_PROCESS_PATCH) && !NGX_WIN32
-            }
-#endif
-        }
+    if (lmcf == NULL || lmcf->lua == NULL) {
+        return NGX_OK;
     }
 
-    if (lmcf == NULL
-        || lmcf->init_worker_handler == NULL
-        || lmcf->lua == NULL)
-    {
+    /* lmcf != NULL && lmcf->lua != NULL */
+
+    /* disable init_worker_by_lua* and destroy lua VM in cache processes */
+    if (ngx_process == NGX_PROCESS_HELPER) {
+#if defined(HAVE_PRIVILEGED_PROCESS_PATCH) && !NGX_WIN32
+        if (!ngx_is_privileged_agent) {
+#endif
+
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                           "lua close the global Lua VM %p in "
+                           "cache process %P", lmcf->lua, ngx_pid);
+            lmcf->vm_cleanup->handler(lmcf->vm_cleanup->data);
+            lmcf->vm_cleanup->handler = NULL;
+            return NGX_OK;
+#if defined(HAVE_PRIVILEGED_PROCESS_PATCH) && !NGX_WIN32
+        }
+#endif
+    }
+
+    if (lmcf->init_worker_handler == NULL) {
         return NGX_OK;
     }
 

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -3768,6 +3768,7 @@ ngx_http_lua_init_vm(lua_State *parent_vm, ngx_cycle_t *cycle,
 
     cln->data = state;
 
+    /* this VM cleanup should be only called in the main vm */
     if (lmcf->vm_cleanup == NULL) {
         lmcf->vm_cleanup = cln;
     }

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -3768,6 +3768,10 @@ ngx_http_lua_init_vm(lua_State *parent_vm, ngx_cycle_t *cycle,
 
     cln->data = state;
 
+    if (lmcf->vm_cleanup == NULL) {
+        lmcf->vm_cleanup = cln;
+    }
+
     if (pcln) {
         *pcln = cln;
     }

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -3768,7 +3768,7 @@ ngx_http_lua_init_vm(lua_State *parent_vm, ngx_cycle_t *cycle,
 
     cln->data = state;
 
-    /* this VM cleanup should be only called in the main vm */
+    /* this VM cleanup should only be called in the main vm */
     if (lmcf->vm_cleanup == NULL) {
         lmcf->vm_cleanup = cln;
     }

--- a/t/135-worker-id.t
+++ b/t/135-worker-id.t
@@ -9,7 +9,7 @@ workers(2);
 
 #repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 3 + 1);
+plan tests => repeat_each() * (blocks() * 3);
 
 #no_diff();
 #no_long_string();
@@ -31,63 +31,3 @@ GET /lua
 --- no_error_log
 [error]
 --- skip_nginx: 3: <=1.9.0
-
-
-
-=== TEST 2: worker id should be nil for non-worker processes
---- http_config
-    proxy_cache_path conf/cache levels=1:2 keys_zone=my-cache:8m max_size=10m inactive=60m;
-    proxy_temp_path conf/temp;
-
-    lua_shared_dict counters 1m;
-
-    init_by_lua_block {
-        ngx.shared.counters:set("c", 0)
-    }
-
-    init_worker_by_lua_block {
-        ngx.shared.counters:incr("c", 1)
-        ngx.log(ngx.INFO, ngx.worker.pid(), ": worker id ", ngx.worker.id());
-    }
---- config
-    location = /t {
-        content_by_lua_block {
-            local counters = ngx.shared.counters
-            local ok, c
-            for i = 1, 100 do
-                c = counters:get("c")
-                if c >= 4 then
-                    ok = true
-                    break
-                end
-                local delay = 0.001 * i
-                if delay > 0.1 then
-                    delay = 0.1
-                end
-                ngx.sleep(delay)
-            end
-            if ok then
-                ngx.say("ok")
-            else
-                ngx.say("not ok: c=", c)
-            end
-        }
-    }
-    location /cache {
-        proxy_pass http://127.0.0.1:$server_port;
-        proxy_cache my-cache;
-    }
---- request
-GET /t
---- response_body
-ok
---- grep_error_log eval: qr/worker id nil/
---- grep_error_log_out
-worker id nil
-worker id nil
---- no_error_log
-[error]
---- wait: 0.1
---- skip_nginx: 3: <=1.9.0
---- log_level: info
---- timeout: 6


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
