### PR TITLE
feature : $installation_prefix for NGX_PREFIX

### DIFF
--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -147,7 +147,16 @@ ngx_http_lua_set_path(ngx_cycle_t *cycle, lua_State *L, int tab_idx,
     prefix = lua_tostring(L, -1);
     tmp_path = luaL_gsub(L, tmp_path, "$prefix", prefix);
     tmp_path = luaL_gsub(L, tmp_path, "${prefix}", prefix);
-    lua_pop(L, 3);
+
+#ifdef NGX_PREFIX
+    tmp_path = luaL_gsub(L, tmp_path, "$installation_prefix", NGX_PREFIX);
+    tmp_path = luaL_gsub(L, tmp_path, "${installation_prefix}", NGX_PREFIX);
+#else
+    tmp_path = luaL_gsub(L, tmp_path, "$installation_prefix", prefix);
+    tmp_path = luaL_gsub(L, tmp_path, "${installation_prefix}", prefix);
+#endif
+
+    lua_pop(L, 5);
 
     dd("tmp_path path: %s", tmp_path);
 


### PR DESCRIPTION
I add a new notation '$installation_prefix' which can be used in lua_package_cpath or lua_package_path.

With this  notation, we do not need to write :
lua_package_path    "/usr/local/openresty/lualib/?.lua;"；

and we can write like below:
 lua_package_path    "$installation_prefix/../lualib/?.lua;"

It may be more flexiable than absolute path.
