### PR TITLE
bugfix: first part headers will be discard when using single LF as delimiter

### DIFF
--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -245,7 +245,7 @@ ngx_http_lua_ngx_req_raw_header(lua_State *L)
 
         if (b != mr->header_in) {
             /* skip truncated header entries (if any) */
-            while (last > data && last[-1] != LF) {
+            while (last > data && last[-1] != LF && last[-1] != '\0') {
                 last--;
             }
         }
@@ -315,7 +315,7 @@ ngx_http_lua_ngx_req_raw_header(lua_State *L)
 
 #if 1
             /* skip truncated header entries (if any) */
-            while (last > p && last[-1] != LF) {
+            while (last > p && last[-1] != LF && last[-1] != '\0') {
                 last--;
             }
 #endif
@@ -325,8 +325,7 @@ ngx_http_lua_ngx_req_raw_header(lua_State *L)
                 if (*p == '\0') {
                     j++;
                     if (p + 1 == last) {
-                        /* XXX this should not happen */
-                        dd("found string end!!");
+                        *p = LF;
 
                     } else if (*(p + 1) == LF) {
                         *p = CR;

--- a/t/104-req-raw-header.t
+++ b/t/104-req-raw-header.t
@@ -876,3 +876,115 @@ Foo: bar\r
 --- no_error_log
 [error]
 --- timeout: 5
+
+
+
+=== TEST 30: large headers(using single LF as line break)
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.print(ngx.req.raw_header())
+        }
+    }
+
+--- raw_request eval
+"GET /t HTTP/1.1
+Host: localhost
+Connection: close
+".
+(CORE::join "\n", map { "Header$_: value-$_" } 1..512) . "\n\n"
+
+--- response_body eval
+qq{GET /t HTTP/1.1
+Host: localhost
+Connection: close
+}
+.(CORE::join "\n", map { "Header$_: value-$_" } 1..512) . "\n\n"
+
+--- no_error_log
+[error]
+--- timeout: 5
+
+
+
+=== TEST 31: large headers without request line(using single LF as line break)
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.print(ngx.req.raw_header(true))
+        }
+    }
+
+--- raw_request eval
+"GET /t HTTP/1.1
+Host: localhost
+Connection: close
+".
+(CORE::join "\n", map { "Header$_: value-$_" } 1..512) . "\n\n"
+
+--- response_body eval
+qq{Host: localhost
+Connection: close
+}
+.(CORE::join "\n", map { "Header$_: value-$_" } 1..512) . "\n\n"
+
+--- no_error_log
+[error]
+--- timeout: 5
+
+
+
+=== TEST 32: large headers with leading CRLF(using single LF as line break)
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.print(ngx.req.raw_header())
+        }
+    }
+
+--- raw_request eval
+"\r
+GET /t HTTP/1.1
+Host: localhost
+Connection: close
+".
+(CORE::join "\n", map { "Header$_: value-$_" } 1..512) . "\n\n"
+
+--- response_body eval
+qq{GET /t HTTP/1.1
+Host: localhost
+Connection: close
+}
+.(CORE::join "\n", map { "Header$_: value-$_" } 1..512) . "\n\n"
+
+--- no_error_log
+[error]
+--- timeout: 5
+
+
+
+=== TEST 33: large headers without request line but contains leading CRLF(using single LF as line break)
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.print(ngx.req.raw_header(true))
+        }
+    }
+
+--- raw_request eval
+"\r
+GET /t HTTP/1.1
+Host: localhost
+Connection: close
+".
+(CORE::join "\n", map { "Header$_: value-$_" } 1..512) . "\n\n"
+
+--- response_body eval
+qq{Host: localhost
+Connection: close
+}
+.(CORE::join "\n", map { "Header$_: value-$_" } 1..512) . "\n\n"
+
+--- no_error_log
+[error]
+--- timeout: 5


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

When the delimiter is the single LF and the request has large headers, `ngx.req.raw_header` will discard the first part headers.