### PR TITLE
feature: supported OpenSSL 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ env:
     - OPENSSL_PREFIX=/opt/ssl
     - OPENSSL_LIB=$OPENSSL_PREFIX/lib
     - OPENSSL_INC=$OPENSSL_PREFIX/include
-    - OPENSSL_VER=1.0.2k
     - LIBDRIZZLE_PREFIX=/opt/drizzle
     - LIBDRIZZLE_INC=$LIBDRIZZLE_PREFIX/include/libdrizzle-1.0
     - LIBDRIZZLE_LIB=$LIBDRIZZLE_PREFIX/lib
@@ -49,7 +48,8 @@ env:
     - DRIZZLE_VER=2011.07.21
     - TEST_NGINX_SLEEP=0.006
   matrix:
-    - NGINX_VERSION=1.13.6
+    - NGINX_VERSION=1.13.6 OPENSSL_VER=1.0.2j
+    - NGINX_VERSION=1.13.6 OPENSSL_VER=1.1.0c
 
 services:
  - memcache
@@ -66,7 +66,7 @@ install:
   - if [ ! -f download-cache/pcre-$PCRE_VER.tar.gz ]; then wget -P download-cache http://ftp.cs.stanford.edu/pub/exim/pcre/pcre-$PCRE_VER.tar.gz; fi
   - if [ ! -f download-cache/openssl-$OPENSSL_VER.tar.gz ]; then wget -P download-cache https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz; fi
   - git clone https://github.com/openresty/test-nginx.git
-  - git clone https://github.com/openresty/openresty.git ../openresty
+  - git clone -b openssl https://github.com/doujiang24/openresty.git ../openresty
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone https://github.com/openresty/openresty-devel-utils.git
   - git clone https://github.com/openresty/mockeagain.git
@@ -112,8 +112,7 @@ script:
   - cd ..
   - tar zxf download-cache/openssl-$OPENSSL_VER.tar.gz
   - cd openssl-$OPENSSL_VER/
-  - if [ ! -f ../download-cache/openssl-1.0.2h-sess_set_get_cb_yield.patch ]; then wget -P ../download-cache https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-1.0.2h-sess_set_get_cb_yield.patch; fi
-  - patch -p1 < ../download-cache/openssl-1.0.2h-sess_set_get_cb_yield.patch
+  - patch -p1 < ../../openresty/patches/openssl-$OPENSSL_VER-sess_set_get_cb_yield.patch
   - ./config shared --prefix=$OPENSSL_PREFIX -DPURIFY > build.log 2>&1 || (cat build.log && exit 1)
   - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make PATH=$PATH install_sw > build.log 2>&1 || (cat build.log && exit 1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,8 @@ env:
     - DRIZZLE_VER=2011.07.21
     - TEST_NGINX_SLEEP=0.006
   matrix:
-    - NGINX_VERSION=1.13.6 OPENSSL_VER=1.0.2j
-    - NGINX_VERSION=1.13.6 OPENSSL_VER=1.1.0c
+    - NGINX_VERSION=1.13.6 OPENSSL_VER=1.0.2k OPENSSL_PATCH_VER=1.0.2h
+    - NGINX_VERSION=1.13.6 OPENSSL_VER=1.1.0c OPENSSL_PATCH_VER=1.1.0c
 
 services:
  - memcache
@@ -66,7 +66,7 @@ install:
   - if [ ! -f download-cache/pcre-$PCRE_VER.tar.gz ]; then wget -P download-cache http://ftp.cs.stanford.edu/pub/exim/pcre/pcre-$PCRE_VER.tar.gz; fi
   - if [ ! -f download-cache/openssl-$OPENSSL_VER.tar.gz ]; then wget -P download-cache https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz; fi
   - git clone https://github.com/openresty/test-nginx.git
-  - git clone -b openssl https://github.com/doujiang24/openresty.git ../openresty
+  - git clone -b os11 https://github.com/spacewander/openresty.git ../openresty
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone https://github.com/openresty/openresty-devel-utils.git
   - git clone https://github.com/openresty/mockeagain.git
@@ -86,7 +86,7 @@ install:
   - git clone https://github.com/openresty/lua-resty-core.git ../lua-resty-core
   - git clone https://github.com/openresty/lua-resty-lrucache.git ../lua-resty-lrucache
   - git clone https://github.com/openresty/lua-resty-mysql.git ../lua-resty-mysql
-  - git clone https://github.com/openresty/stream-lua-nginx-module.git ../stream-lua-nginx-module
+  - git clone -b os11 https://github.com/spacewander/stream-lua-nginx-module.git ../stream-lua-nginx-module
   - git clone -b v2.1-agentzh https://github.com/openresty/luajit2.git
 
 before_script:
@@ -112,7 +112,8 @@ script:
   - cd ..
   - tar zxf download-cache/openssl-$OPENSSL_VER.tar.gz
   - cd openssl-$OPENSSL_VER/
-  - patch -p1 < ../../openresty/patches/openssl-$OPENSSL_VER-sess_set_get_cb_yield.patch
+  - if [ ! -f ../download-cache/openssl-$OPENSSL_PATCH_VER-sess_set_get_cb_yield.patch ]; then wget -P ../download-cache https://raw.githubusercontent.com/spacewander/openresty/os11/patches/openssl-$OPENSSL_PATCH_VER-sess_set_get_cb_yield.patch; fi
+  - patch -p1 < ../../openresty/patches/openssl-$OPENSSL_PATCH_VER-sess_set_get_cb_yield.patch
   - ./config shared --prefix=$OPENSSL_PREFIX -DPURIFY > build.log 2>&1 || (cat build.log && exit 1)
   - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make PATH=$PATH install_sw > build.log 2>&1 || (cat build.log && exit 1)

--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -1368,9 +1368,8 @@ ngx_http_lua_socket_tcp_sslhandshake(lua_State *L)
                     return 2;
                 }
 
-                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
-                               "lua ssl set session: %p:%d",
-                               *psession, (*psession)->references);
+                ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                               "lua ssl set session: %p", *psession);
             }
         }
 
@@ -1635,9 +1634,8 @@ ngx_http_lua_ssl_handshake_retval_handler(ngx_http_request_t *r,
     } else {
         *ud = ssl_session;
 
-       ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
-                      "lua ssl save session: %p:%d", ssl_session,
-                      ssl_session->references);
+       ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                      "lua ssl save session: %p", ssl_session);
 
         /* set up the __gc metamethod */
         lua_pushlightuserdata(L, &ngx_http_lua_ssl_session_metatable_key);
@@ -5444,9 +5442,8 @@ ngx_http_lua_ssl_free_session(lua_State *L)
 
     psession = lua_touserdata(L, 1);
     if (psession && *psession != NULL) {
-        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
-                       "lua ssl free session: %p:%d", *psession,
-                       (*psession)->references);
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                       "lua ssl free session: %p", *psession);
 
         ngx_ssl_free_session(*psession);
     }

--- a/src/ngx_http_lua_ssl_ocsp.c
+++ b/src/ngx_http_lua_ssl_ocsp.c
@@ -468,7 +468,11 @@ ngx_http_lua_ffi_ssl_set_ocsp_status_resp(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
+#ifdef SSL_CTRL_GET_TLSEXT_STATUS_REQ_TYPE
+    if (SSL_get_tlsext_status_type(ssl_conn) == -1) {
+#else
     if (ssl_conn->tlsext_status_type == -1) {
+#endif
         dd("no ocsp status req from client");
         return NGX_DECLINED;
     }

--- a/src/ngx_http_lua_ssl_session_fetchby.c
+++ b/src/ngx_http_lua_ssl_session_fetchby.c
@@ -171,8 +171,11 @@ ngx_http_lua_ssl_sess_fetch_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
 
 /* cached session fetching callback to be set with SSL_CTX_sess_set_get_cb */
 ngx_ssl_session_t *
-ngx_http_lua_ssl_sess_fetch_handler(ngx_ssl_conn_t *ssl_conn, u_char *id,
-    int len, int *copy)
+ngx_http_lua_ssl_sess_fetch_handler(ngx_ssl_conn_t *ssl_conn,
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+    const
+#endif
+    u_char *id, int len, int *copy)
 {
     lua_State                       *L;
     ngx_int_t                        rc;
@@ -287,7 +290,7 @@ ngx_http_lua_ssl_sess_fetch_handler(ngx_ssl_conn_t *ssl_conn, u_char *id,
     cctx->exit_code = 1;  /* successful by default */
     cctx->connection = c;
     cctx->request = r;
-    cctx->session_id.data = id;
+    cctx->session_id.data = (u_char *) id;
     cctx->session_id.len = len;
     cctx->entered_sess_fetch_handler = 1;
     cctx->done = 0;

--- a/src/ngx_http_lua_ssl_session_fetchby.h
+++ b/src/ngx_http_lua_ssl_session_fetchby.h
@@ -25,7 +25,11 @@ char *ngx_http_lua_ssl_sess_fetch_by_lua_block(ngx_conf_t *cf,
     ngx_command_t *cmd, void *conf);
 
 ngx_ssl_session_t *ngx_http_lua_ssl_sess_fetch_handler(
-    ngx_ssl_conn_t *ssl_conn, u_char *id, int len, int *copy);
+    ngx_ssl_conn_t *ssl_conn,
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+    const
+#endif
+    u_char *id, int len, int *copy);
 #endif
 
 

--- a/src/ngx_http_lua_ssl_session_storeby.c
+++ b/src/ngx_http_lua_ssl_session_storeby.c
@@ -172,6 +172,8 @@ int
 ngx_http_lua_ssl_sess_store_handler(ngx_ssl_conn_t *ssl_conn,
     ngx_ssl_session_t *sess)
 {
+    const u_char                    *sess_id;
+    unsigned int                     sess_id_len;
     lua_State                       *L;
     ngx_int_t                        rc;
     ngx_connection_t                *c, *fc = NULL;
@@ -247,11 +249,13 @@ ngx_http_lua_ssl_sess_store_handler(ngx_ssl_conn_t *ssl_conn,
         }
     }
 
+    sess_id = SSL_SESSION_get_id(sess, &sess_id_len);
+
     cctx->connection = c;
     cctx->request = r;
     cctx->session = sess;
-    cctx->session_id.data = sess->session_id;
-    cctx->session_id.len = sess->session_id_length;
+    cctx->session_id.data = (u_char *) sess_id;
+    cctx->session_id.len = sess_id_len;
     cctx->done = 0;
 
     dd("setting cctx");

--- a/t/129-ssl-socket.t
+++ b/t/129-ssl-socket.t
@@ -108,10 +108,10 @@ sent http request: 59 bytes.
 received: HTTP/1.1 (?:200 OK|302 Found)
 close: 1 nil
 \z
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl free session: ([0-9A-F]+):1
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
 $/
 --- no_error_log
 lua ssl server name:
@@ -182,8 +182,11 @@ connected: 1
 failed to do SSL handshake: handshake failed
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
---- grep_error_log_out
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
+--- grep_error_log_out eval
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
+$/
 --- no_error_log
 lua ssl server name:
 SSL reused session
@@ -255,10 +258,10 @@ received: HTTP/1.1 302 Moved Temporarily
 close: 1 nil
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl free session: ([0-9A-F]+):1
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
 $/
 --- error_log
 lua ssl server name: "openresty.org"
@@ -343,13 +346,13 @@ sent http request: 56 bytes.
 received: HTTP/1.1 200 OK
 close: 1 nil
 
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl set session: \1:2
-lua ssl save session: \1:3
-lua ssl free session: \1:2
-lua ssl free session: \1:1
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl set session: \1
+lua ssl save session: \1
+lua ssl free session: \1
+lua ssl free session: \1
 $/
 
 --- error_log
@@ -432,7 +435,7 @@ failed to send http request: closed
 \z
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out
 --- error_log
 lua ssl server name: "blah.openresty.org"
@@ -512,7 +515,7 @@ failed to send http request: closed
 \z
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out
 --- error_log
 lua ssl server name: "blah.openresty.org"
@@ -587,10 +590,10 @@ received: HTTP/1.1 404 Not Found
 close: 1 nil
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl free session: ([0-9A-F]+):1
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
 $/
 
 --- error_log
@@ -672,10 +675,10 @@ received: HTTP/1.1 302 Moved Temporarily
 close: 1 nil
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]++/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl free session: ([0-9A-F]+):1
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
 $/
 
 --- error_log
@@ -754,7 +757,7 @@ failed to do SSL handshake: 20: unable to get local issuer certificate
 failed to send http request: closed
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out
 --- error_log
 lua ssl server name: "openresty.org"
@@ -833,7 +836,7 @@ failed to do SSL handshake: 20: unable to get local issuer certificate
 failed to send http request: closed
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out
 --- error_log
 lua ssl server name: "openresty.org"
@@ -923,10 +926,10 @@ sent http request: 59 bytes.
 received: HTTP/1.1 (?:200 OK|302 Found)
 close: 1 nil
 \z
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl free session: ([0-9A-F]+):1
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
 $/
 --- error_log
 lua ssl server name: "www.google.com"
@@ -1013,7 +1016,7 @@ GET /t
 connected: 1
 failed to do SSL handshake: 20: unable to get local issuer certificate
 
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out
 --- error_log
 lua ssl server name: "www.google.com"
@@ -1095,10 +1098,10 @@ received: HTTP/1.1 302 Moved Temporarily
 close: 1 nil
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl free session: ([0-9A-F]+):1
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
 $/
 
 --- error_log
@@ -1174,10 +1177,10 @@ received: HTTP/1.1 302 Moved Temporarily
 close: 1 nil
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl free session: ([0-9A-F]+):1
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
 $/
 --- error_log
 lua ssl server name: "openresty.org"
@@ -1254,10 +1257,10 @@ received: HTTP/1.1 302 Moved Temporarily
 close: 1 nil
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl free session: ([0-9A-F]+):1
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
 $/
 --- error_log
 lua ssl server name: "openresty.org"
@@ -1334,10 +1337,10 @@ received: HTTP/1.1 302 Moved Temporarily
 close: 1 nil
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl free session: ([0-9A-F]+):1
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
 $/
 --- error_log
 lua ssl server name: "openresty.org"
@@ -1412,7 +1415,7 @@ failed to do SSL handshake: handshake failed
 failed to send http request: closed
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out
 --- error_log eval
 [
@@ -1488,10 +1491,10 @@ ssl handshake: userdata
 set keepalive: 1 nil
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl free session: \1:2
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: \1
 $/
 
 --- error_log
@@ -1564,14 +1567,14 @@ ssl handshake: userdata
 set keepalive: 1 nil
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl save session: \1:3
-lua ssl save session: \1:4
-lua ssl free session: \1:4
-lua ssl free session: \1:3
-lua ssl free session: \1:2
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl save session: \1
+lua ssl save session: \1
+lua ssl free session: \1
+lua ssl free session: \1
+lua ssl free session: \1
 $/
 
 --- error_log
@@ -1615,7 +1618,7 @@ hello world
 --- response_body_like: 500 Internal Server Error
 --- error_code: 500
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out
 --- error_log
 attempt to call method 'sslhandshake' (a nil value)
@@ -1714,10 +1717,10 @@ $::TestCertificateKey
 >>> test.crt
 $::TestCertificate"
 
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl free session: ([0-9A-F]+):1
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
 $/
 --- no_error_log
 lua ssl server name:
@@ -1819,10 +1822,10 @@ $::TestCertificateKey
 >>> test.crt
 $::TestCertificate"
 
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl free session: ([0-9A-F]+):1
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
 $/
 --- error_log
 lua ssl server name: "test.com"
@@ -1912,7 +1915,7 @@ failed to do SSL handshake: handshake failed
 ">>> test.crt
 $::TestCertificate"
 
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out
 --- error_log eval
 qr/SSL_do_handshake\(\) failed .*?unknown protocol/
@@ -2011,7 +2014,7 @@ $::TestCertificate
 >>> test.crl
 $::TestCRL"
 
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out
 --- error_log
 lua ssl server name: "test.com"
@@ -2090,12 +2093,12 @@ received: HTTP/1.1 302 Moved Temporarily
 close: 1 nil
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl save session: ([0-9A-F]+):3
-lua ssl free session: ([0-9A-F]+):2
-lua ssl free session: ([0-9A-F]+):1
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
 $/
 --- error_log
 lua ssl server name: "openresty.org"
@@ -2149,7 +2152,7 @@ connected: 1
 failed to do SSL handshake: timeout
 
 --- log_level: debug
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out
 --- error_log
 lua ssl server name: "openresty.org"
@@ -2221,7 +2224,7 @@ $::TestCertificateKey
 >>> test.crt
 $::TestCertificate"
 
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out
 --- no_error_log
 lua ssl server name:
@@ -2292,10 +2295,10 @@ $::TestCertificateKey
 >>> test.crt
 $::TestCertificate"
 
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl free session: ([0-9A-F]+):1
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
 $/
 --- no_error_log
 lua ssl server name:
@@ -2372,7 +2375,7 @@ $::TestCertificateKey
 >>> test.crt
 $::TestCertificate"
 
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out
 --- no_error_log
 lua ssl server name:
@@ -2474,10 +2477,10 @@ $::TestCertificateKey
 >>> test.crt
 $::TestCertificate"
 
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+):2
-lua ssl free session: ([0-9A-F]+):1
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
 $/
 --- error_log
 --- no_error_log
@@ -2570,7 +2573,7 @@ $::TestCertificateKey
 >>> test.crt
 $::TestCertificate"
 
---- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+:\d+/
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out
 --- error_log
 lua ssl certificate verify error: (18: self signed certificate)

--- a/t/129-ssl-socket.t
+++ b/t/129-ssl-socket.t
@@ -1918,7 +1918,7 @@ $::TestCertificate"
 --- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out
 --- error_log eval
-qr/SSL_do_handshake\(\) failed .*?unknown protocol/
+qr/SSL_do_handshake\(\) failed .*?(unknown protocol|wrong version number)/
 --- no_error_log
 lua ssl server name:
 SSL reused session

--- a/t/129-ssl-socket.t
+++ b/t/129-ssl-socket.t
@@ -183,10 +183,7 @@ failed to do SSL handshake: handshake failed
 
 --- log_level: debug
 --- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
---- grep_error_log_out eval
-qr/^lua ssl save session: ([0-9A-F]+)
-lua ssl free session: ([0-9A-F]+)
-$/
+--- grep_error_log_out
 --- no_error_log
 lua ssl server name:
 SSL reused session
@@ -696,7 +693,7 @@ SSL reused session
     server_tokens off;
     resolver $TEST_NGINX_RESOLVER ipv6=off;
     lua_ssl_trusted_certificate ../html/trusted.crt;
-    lua_ssl_verify_depth 1;
+    lua_ssl_verify_depth 0;
     location /t {
         #set $port 5000;
         set $port $TEST_NGINX_MEMCACHED_PORT;
@@ -751,17 +748,18 @@ $::DSTRootCertificate"
 
 --- request
 GET /t
---- response_body
-connected: 1
-failed to do SSL handshake: 20: unable to get local issuer certificate
+--- response_body eval
+qr{connected: 1
+failed to do SSL handshake: (22: certificate chain too long|20: unable to get local issuer certificate)
 failed to send http request: closed
+}
 
 --- log_level: debug
 --- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
 --- grep_error_log_out
---- error_log
-lua ssl server name: "openresty.org"
-lua ssl certificate verify error: (20: unable to get local issuer certificate)
+--- error_log eval
+['lua ssl server name: "openresty.org"',
+qr/lua ssl certificate verify error: \((22: certificate chain too long|20: unable to get local issuer certificate)\)/]
 --- no_error_log
 SSL reused session
 [alert]
@@ -774,7 +772,7 @@ SSL reused session
     server_tokens off;
     resolver $TEST_NGINX_RESOLVER ipv6=off;
     lua_ssl_trusted_certificate ../html/trusted.crt;
-    lua_ssl_verify_depth 1;
+    lua_ssl_verify_depth 0;
     lua_socket_log_errors off;
     location /t {
         #set $port 5000;
@@ -830,10 +828,11 @@ $::DSTRootCertificate"
 
 --- request
 GET /t
---- response_body
-connected: 1
-failed to do SSL handshake: 20: unable to get local issuer certificate
+--- response_body eval
+qr/connected: 1
+failed to do SSL handshake: (22: certificate chain too long|20: unable to get local issuer certificate)
 failed to send http request: closed
+/
 
 --- log_level: debug
 --- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
@@ -1262,9 +1261,9 @@ close: 1 nil
 qr/^lua ssl save session: ([0-9A-F]+)
 lua ssl free session: ([0-9A-F]+)
 $/
---- error_log
-lua ssl server name: "openresty.org"
-SSL: TLSv1.2, cipher: "ECDHE-RSA-AES256-SHA SSLv3
+--- error_log eval
+['lua ssl server name: "openresty.org"',
+qr/SSL: TLSv1.2, cipher: "ECDHE-RSA-AES256-SHA (SSLv3|TLSv1)/]
 --- no_error_log
 SSL reused session
 [error]
@@ -1342,9 +1341,9 @@ close: 1 nil
 qr/^lua ssl save session: ([0-9A-F]+)
 lua ssl free session: ([0-9A-F]+)
 $/
---- error_log
-lua ssl server name: "openresty.org"
-SSL: TLSv1, cipher: "ECDHE-RSA-AES128-SHA SSLv3
+--- error_log eval
+['lua ssl server name: "openresty.org"',
+qr/SSL: TLSv1, cipher: "ECDHE-RSA-AES128-SHA (SSLv3|TLSv1)/]
 --- no_error_log
 SSL reused session
 [error]
@@ -1419,7 +1418,7 @@ failed to send http request: closed
 --- grep_error_log_out
 --- error_log eval
 [
-qr/\[crit\] .*?SSL_do_handshake\(\) failed .*?unsupported protocol/,
+qr/\[crit\] .*?SSL_do_handshake\(\) failed .*?(unsupported protocol|no protocols available)/,
 'lua ssl server name: "openresty.org"',
 ]
 --- no_error_log

--- a/t/142-ssl-session-store.t
+++ b/t/142-ssl-session-store.t
@@ -32,7 +32,7 @@ __DATA__
         server_name   test.com;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
-        ssl_protocols SSLv3;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -107,7 +107,7 @@ ssl_session_store_by_lua_block:1: ssl session store by lua is running!,
         server_name   test.com;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
-        ssl_protocols SSLv3;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -182,7 +182,7 @@ API disabled in the context of ssl_session_store_by_lua*
         server_name   test.com;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
-        ssl_protocols SSLv3;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -272,9 +272,9 @@ my timer run!
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         server_name   test.com;
 
-        ssl_protocols SSLv3;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -340,9 +340,9 @@ API disabled in the context of ssl_session_store_by_lua*
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         server_name test.com;
-        ssl_protocols SSLv3;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -412,9 +412,9 @@ ngx.exit does not yield and the error code is eaten.
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         server_name test.com;
-        ssl_protocols SSLv3;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -485,9 +485,9 @@ ssl_session_store_by_lua*: handler return value: 0, sess new cb exit code: 0
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         server_name test.com;
-        ssl_protocols SSLv3;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -553,9 +553,9 @@ should never reached here
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         server_name test.com;
-        ssl_protocols SSLv3;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -626,7 +626,7 @@ get_phase: ssl_session_store
         }
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
-        ssl_protocols SSLv3;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -695,7 +695,7 @@ qr/elapsed in ssl cert by lua: 0.(?:09|1[01])\d+,/,
         server_name   test.com;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
-        ssl_protocols SSLv3;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -765,7 +765,6 @@ a.lua:1: ssl store session by lua is running!
         ssl_session_store_by_lua_block {
             print("handler in test.com")
         }
-        ssl_protocols SSLv3;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
 
@@ -775,7 +774,6 @@ a.lua:1: ssl store session by lua is running!
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         server_name test.com;
-        ssl_protocols SSLv3;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
 
@@ -841,7 +839,7 @@ qr/\[emerg\] .*? "ssl_session_store_by_lua_block" directive is not allowed here 
         server_name   test.com;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
-        ssl_protocols SSLv3;
+        ssl_session_tickets off;
 
         server_tokens off;
     }

--- a/t/143-ssl-session-fetch.t
+++ b/t/143-ssl-session-fetch.t
@@ -33,7 +33,7 @@ __DATA__
         server_name   test.com;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
-        ssl_protocols SSLv3;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -119,7 +119,7 @@ ssl_session_fetch_by_lua_block:1: ssl fetch sess by lua is running!,
         server_name   test.com;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
-        ssl_protocols SSLv3;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -203,7 +203,7 @@ qr/elapsed in ssl fetch session by lua: 0.(?:09|1[01])\d+,/,
         server_name   test.com;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
-        ssl_protocols SSLv3;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -302,9 +302,9 @@ qr/my timer run!/s
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         server_name   test.com;
-        ssl_protocols SSLv3;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -382,9 +382,9 @@ qr/received memc reply: OK/s
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         server_name test.com;
-        ssl_protocols SSLv3;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -463,9 +463,9 @@ should never reached here
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         server_name test.com;
-        ssl_protocols SSLv3;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -545,9 +545,9 @@ should never reached here
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         server_name test.com;
-        ssl_protocols SSLv3;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -626,9 +626,9 @@ should never reached here
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         server_name test.com;
-        ssl_protocols SSLv3;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -709,9 +709,9 @@ should never reached here
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         server_name test.com;
-        ssl_protocols SSLv3;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -792,7 +792,7 @@ should never reached here
         server_name   test.com;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
-        ssl_protocols SSLv3;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -877,7 +877,7 @@ qr/get_phase: ssl_session_fetch/s
         }
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
-        ssl_protocols SSLv3;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -961,7 +961,7 @@ ssl store session by lua is running!
         server_name   test.com;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
-        ssl_protocols SSLv3;
+        ssl_session_tickets off;
 
         server_tokens off;
     }
@@ -1041,7 +1041,7 @@ qr/\S+:\d+: ssl fetch sess by lua is running!/s
         server_name   test.com;
         ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
         ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
-        ssl_protocols SSLv3;
+        ssl_session_tickets off;
 
         server_tokens off;
     }


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

For #903 and #1172.

Changes contains:
1. Take changes from #761 and #922.
2. Update the error message.
3. Compared to 1.0.2, OpenSSL 1.1.0 SSL_CTX_set_verify_depth verifies
one more level. Since Nginx doesn't change the default value for
ssl_verfiy_depth, I just update the test cases instead of updating the
C code.
4. Add OpenSSL 1.1.0c to the travis build.