### PR TITLE
bugfix: ssl by lua handlers might be NULL

### DIFF
--- a/src/ngx_http_lua_ssl_session_fetchby.c
+++ b/src/ngx_http_lua_ssl_session_fetchby.c
@@ -307,8 +307,12 @@ ngx_http_lua_ssl_sess_fetch_handler(ngx_ssl_conn_t *ssl_conn, u_char *id,
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
     c->log->action = "fetching SSL session by lua";
-
-    rc = lscf->srv.ssl_sess_fetch_handler(r, lscf, L);
+    
+    if(lscf->srv.ssl_sess_fetch_handler) {
+        rc = lscf->srv.ssl_sess_fetch_handler(r, lscf, L);
+    } else {
+        rc = 0;
+    }
 
     if (rc >= NGX_OK || rc == NGX_ERROR) {
         cctx->done = 1;

--- a/src/ngx_http_lua_ssl_session_storeby.c
+++ b/src/ngx_http_lua_ssl_session_storeby.c
@@ -269,8 +269,11 @@ ngx_http_lua_ssl_sess_store_handler(ngx_ssl_conn_t *ssl_conn,
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
     c->log->action = "storing SSL session by lua";
-
-    rc = lscf->srv.ssl_sess_store_handler(r, lscf, L);
+    if(lscf->srv.ssl_sess_store_handler) {
+        rc = lscf->srv.ssl_sess_store_handler(r, lscf, L);
+    } else {
+        rc = 0;
+    }
 
     if (rc >= NGX_OK || rc == NGX_ERROR) {
         cctx->done = 1;


### PR DESCRIPTION
ssl by lua handlers might be NULL. This happens when 2 or more nginx server block listen on a same port with different server_name; one is configured with 'xxx_by_lua' and another is not.

this is because the 2 server block in fact use the same ssl ctx, and openssl will call back once any of the server block set 'xxx_by_lua'. For those without such config, the code may end with calling a null function ptr, segment fault for ip=0x0.

-----
add some error screenshots
note that the nginx is not in the newest version, but same problem still exists
![1](https://user-images.githubusercontent.com/15938850/34340364-b9544526-e9bd-11e7-8b19-6864cb3f70f8.png)
![2](https://user-images.githubusercontent.com/15938850/34340365-b9888de0-e9bd-11e7-94ba-6df9751cc760.png)
![3](https://user-images.githubusercontent.com/15938850/34340366-b9bbfb12-e9bd-11e7-81ec-893269dc551b.png)

