### PR TITLE
feature: ngx_http_lua_ffi_master_pid

### DIFF
--- a/src/ngx_http_lua_worker.c
+++ b/src/ngx_http_lua_worker.c
@@ -105,7 +105,7 @@ ngx_http_lua_ffi_master_pid(void)
 #if (nginx_version >= 1013008)
     return (int) ngx_parent;
 #else
-    return (int) ((ngx_process == NGX_PROCESS_SINGLE) ? ngx_pid : getppid());
+    return -1;
 #endif
 }
 

--- a/src/ngx_http_lua_worker.c
+++ b/src/ngx_http_lua_worker.c
@@ -100,6 +100,17 @@ ngx_http_lua_ffi_worker_pid(void)
 
 
 int
+ngx_http_lua_ffi_master_pid(void)
+{
+#if (nginx_version >= 1013008)
+    return (int) ngx_parent;
+#else
+    return (int) ((ngx_process == NGX_PROCESS_SINGLE) ? ngx_pid : getppid());
+#endif
+}
+
+
+int
 ngx_http_lua_ffi_worker_id(void)
 {
 #if (nginx_version >= 1009001)


### PR DESCRIPTION
Nginx 1.13.8 adds a new feature : ngx_parent, which is the pid of master process.

I think it is an useful feature, with this we can identify multi nginx instance, so I add a ffi C function : ngx_http_lua_ffi_master_pid, which could works in `lua-resty-core`.
