### PR TITLE
doc: typo fix: fix "\d+" to [[\d+]].

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -840,7 +840,7 @@ As noted earlier, PCRE sequences presented within `*_by_lua_block {}` directives
  # nginx.conf
  location /test {
      content_by_lua_block {
-         local regex = "\d+"
+         local regex = [[\d+]]
          local m = ngx.re.match("hello, 1234", regex)
          if m then ngx.say(m[0]) else ngx.say("not matched!") end
      }

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -684,7 +684,7 @@ As noted earlier, PCRE sequences presented within <code>*_by_lua_block {}</code>
     # nginx.conf
     location /test {
         content_by_lua_block {
-            local regex = "\d+"
+            local regex = [[\d+]]
             local m = ngx.re.match("hello, 1234", regex)
             if m then ngx.say(m[0]) else ngx.say("not matched!") end
         }


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
