### PR TITLE
optimize: switched exptime argument type to 'long' in the shdict FFI API to avoid potential overflows.

### DIFF
--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -2212,7 +2212,7 @@ ngx_http_lua_find_zone(u_char *name_data, size_t name_len)
 int
 ngx_http_lua_ffi_shdict_store(ngx_shm_zone_t *zone, int op, u_char *key,
     size_t key_len, int value_type, u_char *str_value_buf,
-    size_t str_value_len, double num_value, int exptime, int user_flags,
+    size_t str_value_len, double num_value, long exptime, int user_flags,
     char **errmsg, int *forcible)
 {
     int                          i, n;
@@ -2229,7 +2229,7 @@ ngx_http_lua_ffi_shdict_store(ngx_shm_zone_t *zone, int op, u_char *key,
         return NGX_ERROR;
     }
 
-    dd("exptime: %d", exptime);
+    dd("exptime: %ld", exptime);
 
     ctx = zone->data;
 
@@ -2903,7 +2903,7 @@ ngx_http_lua_shdict_peek(ngx_shm_zone_t *shm_zone, ngx_uint_t hash,
 }
 
 
-int
+long
 ngx_http_lua_ffi_shdict_get_ttl(ngx_shm_zone_t *zone, u_char *key,
     size_t key_len)
 {
@@ -2951,7 +2951,7 @@ ngx_http_lua_ffi_shdict_get_ttl(ngx_shm_zone_t *zone, u_char *key,
 
 int
 ngx_http_lua_ffi_shdict_set_expire(ngx_shm_zone_t *zone, u_char *key,
-    size_t key_len, int exptime)
+    size_t key_len, long exptime)
 {
     uint32_t                     hash;
     ngx_int_t                    rc;


### PR DESCRIPTION
> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

As discussed [here](https://github.com/openresty/lua-nginx-module/pull/1226#discussion_r160292541).

Sister PR of https://github.com/openresty/lua-resty-core/pull/170