### PR TITLE
bugfix: corrected the table size of req socket

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -4390,7 +4390,7 @@ ngx_http_lua_req_socket(lua_State *L)
         r->request_body = rb;
     }
 
-    lua_createtable(L, 3 /* narr */, 1 /* nrec */); /* the object */
+    lua_createtable(L, 2 /* narr */, 3 /* nrec */); /* the object */
 
     if (raw) {
         lua_pushlightuserdata(L, &ngx_http_lua_raw_req_socket_metatable_key);


### PR DESCRIPTION
The req socket uses two slots in array and three slots in hash at most.

At first it uses one array slot and one hash slot:
array part: upstream udata
hash part: __index

After calling settimeouts, it uses two array slot and three hash slot:
array part:
    [1] upstream udata
    [2] connect timeout
hash part:
    __index
    [4] send timeout
    [5] read timeout

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
