### PR TITLE
bugfix: coroutine.wrap: propagate errors to the parent coroutine.

### DIFF
--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -482,6 +482,13 @@ struct ngx_http_lua_co_ctx_s {
                                                         the ngx.thread.spawn()
                                                         call */
     unsigned                 sem_resume_status:1;
+
+    unsigned                 is_wrap:1; /* set when creating coroutines via
+                                           coroutine.wrap */
+
+    unsigned                 propagate_error:1; /* set when propagating an error
+                                                   from a coroutine to its
+                                                   parent */
 };
 
 

--- a/src/ngx_http_lua_coroutine.c
+++ b/src/ngx_http_lua_coroutine.c
@@ -25,6 +25,7 @@
 
 
 static int ngx_http_lua_coroutine_create(lua_State *L);
+static int ngx_http_lua_coroutine_wrap(lua_State *L);
 static int ngx_http_lua_coroutine_resume(lua_State *L);
 static int ngx_http_lua_coroutine_yield(lua_State *L);
 static int ngx_http_lua_coroutine_status(lua_State *L);
@@ -59,6 +60,45 @@ ngx_http_lua_coroutine_create(lua_State *L)
     }
 
     return ngx_http_lua_coroutine_create_helper(L, r, ctx, NULL);
+}
+
+
+static int
+ngx_http_lua_coroutine_wrap_runner(lua_State *L)
+{
+    /* retrieve closure and insert it at the bottom of
+     * the stack for coroutine.resume() */
+    lua_pushvalue(L, lua_upvalueindex(1));
+    lua_insert(L, 1);
+
+    return ngx_http_lua_coroutine_resume(L);
+}
+
+
+static int
+ngx_http_lua_coroutine_wrap(lua_State *L)
+{
+    ngx_http_request_t          *r;
+    ngx_http_lua_ctx_t          *ctx;
+    ngx_http_lua_co_ctx_t       *coctx = NULL;
+
+    r = ngx_http_lua_get_req(L);
+    if (r == NULL) {
+        return luaL_error(L, "no request found");
+    }
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+    if (ctx == NULL) {
+        return luaL_error(L, "no request ctx found");
+    }
+
+    ngx_http_lua_coroutine_create_helper(L, r, ctx, &coctx);
+
+    coctx->is_wrap = 1;
+
+    lua_pushcclosure(L, ngx_http_lua_coroutine_wrap_runner, 1);
+
+    return 1;
 }
 
 
@@ -250,7 +290,7 @@ ngx_http_lua_inject_coroutine_api(ngx_log_t *log, lua_State *L)
     int         rc;
 
     /* new coroutine table */
-    lua_createtable(L, 0 /* narr */, 14 /* nrec */);
+    lua_createtable(L, 0 /* narr */, 16 /* nrec */);
 
     /* get old coroutine table */
     lua_getglobal(L, "coroutine");
@@ -261,6 +301,9 @@ ngx_http_lua_inject_coroutine_api(ngx_log_t *log, lua_State *L)
 
     lua_getfield(L, -1, "create");
     lua_setfield(L, -3, "_create");
+
+    lua_getfield(L, -1, "wrap");
+    lua_setfield(L, -3, "_wrap");
 
     lua_getfield(L, -1, "resume");
     lua_setfield(L, -3, "_resume");
@@ -277,6 +320,9 @@ ngx_http_lua_inject_coroutine_api(ngx_log_t *log, lua_State *L)
     lua_pushcfunction(L, ngx_http_lua_coroutine_create);
     lua_setfield(L, -2, "__create");
 
+    lua_pushcfunction(L, ngx_http_lua_coroutine_wrap);
+    lua_setfield(L, -2, "__wrap");
+
     lua_pushcfunction(L, ngx_http_lua_coroutine_resume);
     lua_setfield(L, -2, "__resume");
 
@@ -291,7 +337,7 @@ ngx_http_lua_inject_coroutine_api(ngx_log_t *log, lua_State *L)
     /* inject coroutine APIs */
     {
         const char buf[] =
-            "local keys = {'create', 'yield', 'resume', 'status'}\n"
+            "local keys = {'create', 'yield', 'resume', 'status', 'wrap'}\n"
 #ifdef OPENRESTY_LUAJIT
             "local get_req = require 'thread.exdata'\n"
 #else
@@ -321,24 +367,18 @@ ngx_http_lua_inject_coroutine_api(ngx_log_t *log, lua_State *L)
                     "return std(...)\n"
                 "end\n"
             "end\n"
-            "local create, resume = coroutine.create, coroutine.resume\n"
-            "coroutine.wrap = function(f)\n"
-               "local co = create(f)\n"
-               "return function(...) return select(2, resume(co, ...)) end\n"
-            "end\n"
-            "package.loaded.coroutine = coroutine";
-
+            "package.loaded.coroutine = coroutine"
 #if 0
             "debug.sethook(function () collectgarbage() end, 'rl', 1)"
 #endif
             ;
 
-        rc = luaL_loadbuffer(L, buf, sizeof(buf) - 1, "=coroutine.wrap");
+        rc = luaL_loadbuffer(L, buf, sizeof(buf) - 1, "=coroutine_api");
     }
 
     if (rc != 0) {
         ngx_log_error(NGX_LOG_ERR, log, 0,
-                      "failed to load Lua code for coroutine.wrap(): %i: %s",
+                      "failed to load Lua code for coroutine_api: %i: %s",
                       rc, lua_tostring(L, -1));
 
         lua_pop(L, 1);
@@ -348,7 +388,7 @@ ngx_http_lua_inject_coroutine_api(ngx_log_t *log, lua_State *L)
     rc = lua_pcall(L, 0, 0, 0);
     if (rc != 0) {
         ngx_log_error(NGX_LOG_ERR, log, 0,
-                      "failed to run the Lua code for coroutine.wrap(): %i: %s",
+                      "failed to run the Lua code for coroutine_api: %i: %s",
                       rc, lua_tostring(L, -1));
         lua_pop(L, 1);
     }

--- a/t/062-count.t
+++ b/t/062-count.t
@@ -391,7 +391,7 @@ probe process("$LIBLUA_PATH").function("rehashtab") {
 --- stap_out2
 3
 --- response_body
-coroutine: 14
+coroutine: 16
 --- no_error_log
 [error]
 

--- a/t/091-coroutine.t
+++ b/t/091-coroutine.t
@@ -4,7 +4,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 3 + 5);
+plan tests => repeat_each() * (blocks() * 3 + 14);
 
 $ENV{TEST_NGINX_RESOLVER} ||= '8.8.8.8';
 
@@ -1318,3 +1318,397 @@ co yield: 2
 
 --- no_error_log
 [error]
+
+
+
+=== TEST 32: coroutine.wrap propagates errors to parent coroutine
+--- config
+    location = /t {
+        content_by_lua_block {
+            local co = coroutine.wrap(function()
+                print("in wrapped coroutine")
+                error("something went wrong")
+            end)
+
+            co()
+
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- error_code: 500
+--- response_body_unlike
+ok
+--- error_log eval
+[
+    qr/\[notice\] .*? in wrapped coroutine/,
+    qr/\[error\] .*? lua entry thread aborted: runtime error: content_by_lua\(nginx\.conf:\d+\):\d+: something went wrong/,
+    "stack traceback:",
+    "coroutine 0:",
+    "coroutine 1:"
+]
+
+
+
+=== TEST 33: coroutine.wrap propagates nested errors to parent coroutine
+Note: in this case, both the error message and the traceback are constructed
+from co1's stack level.
+--- config
+    location = /t {
+        content_by_lua_block {
+            local co1 = coroutine.wrap(function()
+                error("something went wrong in co1")
+            end)
+
+            local co2 = coroutine.wrap(function()
+                co1()
+            end)
+
+            co2()
+        }
+    }
+--- request
+GET /t
+--- error_code: 500
+--- ignore_response
+--- error_log eval
+[
+    qr/\[error\] .*? lua entry thread aborted: runtime error: content_by_lua\(nginx\.conf:\d+\):\d+: something went wrong in co1/,
+    "stack traceback:",
+    "coroutine 0:",
+    "coroutine 1:",
+    "coroutine 2:"
+]
+
+
+
+=== TEST 34: coroutine.wrap propagates nested errors with stack level to parent coroutine
+Note: in this case, the error message is constructed at the entry thread stack
+level, and the traceback is constructed from co1's stack level.
+--- config
+    location = /t {
+        content_by_lua_block {
+            local co1 = coroutine.wrap(function()
+                error("something went wrong in co1", 2)
+            end)
+
+            local co2 = coroutine.wrap(function()
+                co1()
+            end)
+
+            co2()
+        }
+    }
+--- request
+GET /t
+--- error_code: 500
+--- error_log eval
+[
+    qr/\[error\] .*? lua entry thread aborted: runtime error: something went wrong in co1/,
+    "stack traceback:",
+    "coroutine 0:",
+    "coroutine 1:",
+    "coroutine 2:"
+]
+
+
+
+=== TEST 35: coroutine.wrap runtime errors do not log errors
+--- config
+    location = /t {
+        content_by_lua_block {
+            local co = coroutine.wrap(function()
+                print("in wrapped coroutine")
+                error("something went wrong")
+            end)
+
+            co()
+        }
+    }
+--- request
+GET /t
+--- error_code: 500
+--- ignore_response
+--- no_error_log eval
+[
+    qr/\[error\] .*? lua coroutine: runtime error:/,
+    "[crit]",
+    "[emerg]",
+    "[warn]",
+]
+
+
+
+=== TEST 36: coroutine.wrap does not return status boolean on yield
+--- config
+    location = /t {
+        content_by_lua_block {
+            local co = coroutine.wrap(function()
+                coroutine.yield("ok", "err")
+            end)
+
+            local ret1, ret2 = co()
+
+            ngx.say(ret1, ", ", ret2)
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok, err
+--- no_error_log
+[error]
+
+
+
+=== TEST 37: coroutine.wrap does not return status boolean on done
+--- config
+    location = /t {
+        content_by_lua_block {
+            local co = coroutine.wrap(function() end)
+
+            local ret1 = co()
+
+            ngx.say(ret1)
+        }
+    }
+--- request
+GET /t
+--- response_body
+nil
+--- no_error_log
+[error]g
+
+
+
+=== TEST 38: coroutine.wrap does not return status boolean on error
+--- SKIP: not supported
+--- config
+    location = /t {
+        content_by_lua_block {
+            local co = coroutine.wrap(function()
+                error("something went wrong")
+            end)
+
+            local ret1, ret2 = pcall(co)
+
+            ngx.say(ret1, ", ", ret2)
+        }
+    }
+--- request
+GET /t
+--- response_body
+false, something went wrong
+--- no_error_log
+[error]
+
+
+
+=== TEST 39: coroutine.wrap creates different function refs
+--- config
+    location = /t {
+        content_by_lua_block {
+            local f = function() end
+            local co = coroutine.wrap(f)
+            local co2 = coroutine.wrap(f)
+
+            ngx.say("co == co2: ", co == co2)
+        }
+    }
+--- request
+GET /t
+--- response_body
+co == co2: false
+--- no_error_log
+[error]
+
+
+
+=== TEST 40: coroutine.wrap supports yielding and resuming
+--- config
+    location = /t {
+        content_by_lua_block {
+            function f()
+                local cnt = 0
+                for i = 1, 20 do
+                    ngx.say("co yield: ", cnt)
+                    coroutine.yield()
+                    cnt = cnt + 1
+                end
+            end
+
+            local f = coroutine.wrap(f)
+            for i = 1, 3 do
+                ngx.say("co resume")
+                f()
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+co resume
+co yield: 0
+co resume
+co yield: 1
+co resume
+co yield: 2
+--- no_error_log
+[error]
+
+
+
+=== TEST 41: coroutine.wrap return values
+--- config
+    location = /t {
+        content_by_lua_block {
+            function f()
+                local cnt = 0
+                for i = 1, 20 do
+                    coroutine.yield(cnt, cnt + 1)
+                    cnt = cnt + 1
+                end
+            end
+
+            local f = coroutine.wrap(f)
+            for i = 1, 3 do
+                ngx.say("co resume")
+                local ret1, ret2 = f()
+                ngx.say("co yield: ", ret1, ", ", ret2)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+co resume
+co yield: 0, 1
+co resume
+co yield: 1, 2
+co resume
+co yield: 2, 3
+--- no_error_log
+[error]
+
+
+
+=== TEST 42: coroutine.wrap arguments
+--- config
+    location = /t {
+        content_by_lua_block {
+            function f(step)
+                local cnt = 0
+                for i = 1, 20 do
+                    ngx.say("co yield: ", cnt)
+                    coroutine.yield()
+                    cnt = cnt + step
+                end
+            end
+
+            local f = coroutine.wrap(f)
+            for i = 1, 3 do
+                ngx.say("co resume")
+                f(i)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+co resume
+co yield: 0
+co resume
+co yield: 1
+co resume
+co yield: 2
+--- no_error_log
+[error]
+
+
+
+=== TEST 43: coroutine.wrap in header_filter_by_lua (orig coroutine.wrap)
+--- config
+    location = /t {
+        return 200;
+
+        header_filter_by_lua_block {
+            function f()
+                local cnt = 0
+                for i = 1, 20 do
+                    print("co yield: ", cnt)
+                    coroutine.yield()
+                    cnt = cnt + 1
+                end
+            end
+
+            local f = coroutine.wrap(f)
+            for i = 1, 3 do
+                print("co resume.")
+                f()
+            end
+        }
+    }
+--- request
+GET /t
+--- ignore_response
+--- grep_error_log eval: qr/co (?:yield: \d+|resume\.)/
+--- grep_error_log_out
+co resume.
+co yield: 0
+co resume.
+co yield: 1
+co resume.
+co yield: 2
+--- no_error_log
+[error]
+
+
+
+=== TEST 44: coroutine.wrap in header_filter_by_lua propagates errors (orig coroutine.wrap)
+--- config
+    location = /t {
+        return 200;
+
+        header_filter_by_lua_block {
+            local co = coroutine.wrap(function()
+                print("in wrapped coroutine")
+                error("something went wrong")
+            end)
+
+            local err = co()
+
+            ngx.log(ngx.CRIT, "err: ", err)
+        }
+    }
+--- request
+GET /t
+--- ignore_response
+--- error_log eval
+[
+    qr/\[notice\] .*? in wrapped coroutine/,
+    qr/\[error\] .*? failed to run header_filter_by_lua\*: header_filter_by_lua:\d+: header_filter_by_lua:\d+: something went wrong/,
+    "stack traceback:",
+    "in function 'co'"
+]
+
+
+
+=== TEST 45: coroutine.wrap in init_by_lua propagates errors (orig coroutine.wrap)
+--- http_config
+    init_by_lua_block {
+        local co = coroutine.wrap(function()
+            print("in wrapped coroutine")
+            error("something went wrong")
+        end)
+
+        local err = co()
+
+        ngx.log(ngx.CRIT, "err: ", err)
+    }
+--- config
+
+--- must_die
+--- grep_error_log eval: qr/init_by_lua error: .*? something went wrong/
+--- grep_error_log_out
+init_by_lua error: init_by_lua:7: init_by_lua:4: something went wrong


### PR DESCRIPTION
> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

The manual states that [coroutine.wrap](https://github.com/openresty/lua-nginx-module#coroutinewrap) is "Similar to the standard Lua API". However, the Lua API's `coroutine.wrap` has some nuances compared to the one provided by ngx_lua:

> Returns the same values returned by resume, except the first boolean. In case of error, propagates the error.

[Source (Lua 5.1 manual)](https://www.lua.org/manual/5.1/manual.html#pdf-coroutine.wrap).

This caused me some issues in the daily job's latest release, where we expected errors encountered in `coroutine.wrap` to be propagated to the Lua main thread, and cause 500 errors. But those errors were swallowed by the thread "scheduler".

Example:
```lua
-- test.lua
local co = coroutine.wrap(function() return nnil.hello end)
print(co(1))
print("still running")
```

With LuaJIT 2.1:
```
$ luajit ./test.lua
luajit: /<path>/test.lua:2: /<path>/test.lua:1: attempt to index global 'nnil' (a nil value)
stack traceback:
	[C]: in function 'co'
	/<path>/test.lua:2: in main chunk
	[C]: at 0x0100000ef0
```

With our resty-cli utility:
```
$ resty ./test.lua
2018/01/23 14:50:25 [error] 20269#0: *2 lua coroutine: runtime error: /<path>/test.lua:1: attempt to index global 'nnil' (a nil value)
stack traceback:
coroutine 0:
	/<path>/test.lua: in function </<path>/test.lua:1>
coroutine 1:
	[C]: in function 'resume'
	coroutine.wrap:21: in function 'co'
	/<path>/test.lua:2: in function 'file_gen'
	init_worker_by_lua:43: in function <init_worker_by_lua:41>
	[C]: in function 'xpcall'
	init_worker_by_lua:50: in function <init_worker_by_lua:48>, context: ngx.timer
/<path>/test.lua:1: attempt to index global 'nnil' (a nil value)
still running
```

Notice the `still running` line at the bottom.

My initial fix for this was to edit the inline Lua code that creates `coroutine.wrap` so that it would propagate errors with `error(..., 2)`, but it is a less than ideal fix, since the error becomes logged twice (once in the coroutine context, and once in the parent context), like so:
```
2018/01/23 15:01:35 [error] 49378#0: *2 lua coroutine: runtime error: content_by_lua(nginx.conf:49):4: something went wrong
stack traceback:
coroutine 0:
	[C]: in function 'error'
	content_by_lua(nginx.conf:49):4: in function <content_by_lua(nginx.conf:49):2>
coroutine 1:
	[C]: in function 'resume'
	coroutine.wrap:21: in function 'co'
	content_by_lua(nginx.conf:49):7: in function <content_by_lua(nginx.conf:49):1>, client: 127.0.0.1, server: localhost, request: "GET /t HTTP/1.1", host: "localhost"
2018/01/23 15:01:35 [error] 49378#0: *2 lua entry thread aborted: runtime error: content_by_lua(nginx.conf:49):7: content_by_lua(nginx.conf:49):4: something went wrong
stack traceback:
coroutine 0:
	[C]: in function 'error'
	coroutine.wrap:21: in function 'co'
	content_by_lua(nginx.conf:49):7: in function <content_by_lua(nginx.conf:49):1>, client: 127.0.0.1, server: localhost, request: "GET /t HTTP/1.1", host: "localhost"
```

Additionally, dealing with it in the Lua land would have meant a lot of expensive operations with the variadic arguments/return values aspects of `coroutine.resume` (we would have had to deal with `pack`, `unpack`, et al.).

Instead, I propose to get rid of the "hack" that is used to implement `coroutine.wrap`, and implement a version of it that embraces the ngx_lua threading model.