### PR TITLE
Switch out TLS1_get_version for SSL_version

### DIFF
--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -553,13 +553,6 @@ ngx_http_lua_ssl_cert_by_chunk(lua_State *L, ngx_http_request_t *r)
 int
 ngx_http_lua_ffi_ssl_get_tls1_version(ngx_http_request_t *r, char **err)
 {
-#ifndef TLS1_get_version
-
-    *err = "no TLS1 support";
-    return NGX_ERROR;
-
-#else
-
     ngx_ssl_conn_t    *ssl_conn;
 
     if (r->connection == NULL || r->connection->ssl == NULL) {
@@ -573,11 +566,9 @@ ngx_http_lua_ffi_ssl_get_tls1_version(ngx_http_request_t *r, char **err)
         return NGX_ERROR;
     }
 
-    dd("tls1 ver: %d", (int) TLS1_get_version(ssl_conn));
+    dd("tls1 ver: %d", SSL_version(ssl_conn));
 
-    return (int) TLS1_get_version(ssl_conn);
-
-#endif
+    return SSL_version(ssl_conn);
 }
 
 


### PR DESCRIPTION
`TLS1_get_version` is a simple wrapper for `SSL_version` that returns 0 when used with DTLS. However, it was removed from BoringSSL in google/boringssl@593047fd8056e40b690f5b695ad35a4b09f9f9bb (2015), which breaks [`ngx.ssl.get_tls1_version`](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/ssl.md#get_tls1_version). This PR replaces it with `SSL_version` directly instead.

`ngx_http_lua_ffi_ssl_get_tls1_version` can never be reached with DTLS so the behaviour is the same.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
