### PR TITLE
bugfix: avoid memory leak when set_serialized_session called repeatly

### DIFF
--- a/src/ngx_http_lua_ssl_session_fetchby.c
+++ b/src/ngx_http_lua_ssl_session_fetchby.c
@@ -567,6 +567,7 @@ ngx_http_lua_ffi_ssl_set_serialized_session(ngx_http_request_t *r,
     ngx_ssl_conn_t                  *ssl_conn;
     ngx_connection_t                *c;
     ngx_ssl_session_t               *session = NULL;
+    ngx_ssl_session_t               *old_session;
     ngx_http_lua_ssl_ctx_t          *cctx;
 
     c = r->connection;
@@ -597,7 +598,12 @@ ngx_http_lua_ffi_ssl_set_serialized_session(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
+    old_session = cctx->session;
     cctx->session = session;
+
+    if (old_session) {
+        ngx_ssl_free_session(old_session);
+    }
 
     return NGX_OK;
 }


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

The way to reproduce the memory leak:
Run `TEST_NGINX_USE_VALGRIND=1 prove t/ssl-session-fetch.t` in the pull request https://github.com/openresty/lua-resty-core/pull/177
