### PR TITLE
feature: added queue to connection pool

### DIFF
--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -5979,6 +5979,43 @@ An optional Lua table can be specified as the last argument to this method to sp
 * <code>pool</code>
 : specify a custom name for the connection pool being used. If omitted, then the connection pool name will be generated from the string template <code>"<host>:<port>"</code> or <code>"<unix-socket-path>"</code>.
 
+* <code>pool_size</code>
+: specify the size of the connection pool. If omitted and no
+: <code>backlog</code> option was provided, no pool will be created. If omitted
+: but <code>backlog</code> was provided, the pool will be created with a default
+: size equal to the value of the [[#lua_socket_pool_size|lua_socket_pool_size]]
+: directive.
+: The connection pool holds up to <code>pool_size</code> alive connections
+: ready to be reused by subsequent calls to [[#tcpsock:connect|connect]], but
+: note that there is no upper limit to the total number of opened connections
+: outside of the pool. If you need to restrict the total number of opened
+: connections, specify the <code>backlog</code> option.
+: When the connection pool would exceed its size limit, the least recently used
+: (kept-alive) connection already in the pool will be closed to make room for
+: the current connection.
+: Note that the cosocket connection pool is per Nginx worker process rather
+: than per Nginx server instance, so the size limit specified here also applies
+: to every single Nginx worker process. Also note that the size of the connection
+: pool cannot be changed once it has been created.
+: This option was first introduced in the <code>v0.10.14</code> release.
+
+* <code>backlog</code>
+: if specified, this module will limit the total number of opened connections
+: for this pool. No more connections than <code>pool_size</code> can be opened
+: for this pool at any time. If the connection pool is full, subsequent
+: connect operations will be queued into a queue equal to this option's
+: value (the "backlog" queue).
+: If the number of queued connect operations is equal to <code>backlog</code>,
+: subsequent connect operations will fail and return <code>nil</code> plus the
+: error string <code>"too many waiting connect operations"</code>.
+: The queued connect operations will be resumed once the number of connections
+: in the pool is less than <code>pool_size</code>.
+: The queued connect operation will abort once they have been queued for more
+: than <code>connect_timeout</code>, controlled by
+: [[#tcpsock:settimeouts|settimeouts]], and will return <code>nil</code> plus
+: the error string <code>"timeout"</code>.
+: This option was first introduced in the <code>v0.10.14</code> release.
+
 The support for the options table argument was first introduced in the <code>v0.5.7</code> release.
 
 This method was first introduced in the <code>v0.5.0rc1</code> release.
@@ -6273,13 +6310,31 @@ Puts the current socket's connection immediately into the cosocket built-in conn
 
 The first optional argument, <code>timeout</code>, can be used to specify the maximal idle timeout (in milliseconds) for the current connection. If omitted, the default setting in the [[#lua_socket_keepalive_timeout|lua_socket_keepalive_timeout]] config directive will be used. If the <code>0</code> value is given, then the timeout interval is unlimited.
 
-The second optional argument, <code>size</code>, can be used to specify the maximal number of connections allowed in the connection pool for the current server (i.e., the current host-port pair or the unix domain socket file path). Note that the size of the connection pool cannot be changed once the pool is created. When this argument is omitted, the default setting in the [[#lua_socket_pool_size|lua_socket_pool_size]] config directive will be used.
-
-When the connection pool exceeds the available size limit, the least recently used (idle) connection already in the pool will be closed to make room for the current connection.
-
-Note that the cosocket connection pool is per Nginx worker process rather than per Nginx server instance, so the size limit specified here also applies to every single Nginx worker process.
-
-Idle connections in the pool will be monitored for any exceptional events like connection abortion or unexpected incoming data on the line, in which cases the connection in question will be closed and removed from the pool.
+The second optional argument <code>size</code> is considered deprecated since
+the <code>v0.10.14</code> release of this module, in favor of the
+<code>pool_size</code> option of the [[#tcpsock:connect|connect]] method.
+Since the <code>v0.10.14</code> release, this option will only take effect if
+the call to [[#tcpsock:connect|connect]] did not already create a connection
+pool.
+When this option takes effect (no connection pool was previously created by
+[[#tcpsock:connect|connect]]), it will specify the size of the connection pool,
+and create it.
+If omitted (and no pool was previously created), the default size is the value
+of the [[#lua_socket_pool_size|lua_socket_pool_size]] directive.
+The connection pool holds up to <code>size</code> alive connections ready to be
+reused by subsequent calls to [[#tcpsock:connect|connect]], but note that there
+is no upper limit to the total number of opened connections outside of the
+pool.
+When the connection pool would exceed its size limit, the least recently used
+(kept-alive) connection already in the pool will be closed to make room for
+the current connection.
+Note that the cosocket connection pool is per Nginx worker process rather
+than per Nginx server instance, so the size limit specified here also applies
+to every single Nginx worker process. Also note that the size of the connection
+pool cannot be changed once it has been created.
+If you need to restrict the total number of opened connections, specify both
+the <code>pool_size</code> and <code>backlog</code> option in the call to
+[[#tcpsock:connect|connect]].
 
 In case of success, this method returns <code>1</code>; otherwise, it returns <code>nil</code> and a string describing the error.
 

--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -100,12 +100,28 @@ static int ngx_http_lua_req_socket(lua_State *L);
 static void ngx_http_lua_req_socket_rev_handler(ngx_http_request_t *r);
 static int ngx_http_lua_socket_tcp_getreusedtimes(lua_State *L);
 static int ngx_http_lua_socket_tcp_setkeepalive(lua_State *L);
+static void ngx_http_lua_socket_tcp_create_socket_pool(lua_State *L,
+    ngx_http_request_t *r, ngx_str_t key, ngx_int_t pool_size,
+    ngx_int_t backlog, ngx_http_lua_socket_pool_t **spool);
 static ngx_int_t ngx_http_lua_get_keepalive_peer(ngx_http_request_t *r,
-    lua_State *L, int key_index,
     ngx_http_lua_socket_tcp_upstream_t *u);
 static void ngx_http_lua_socket_keepalive_dummy_handler(ngx_event_t *ev);
+static int ngx_http_lua_socket_tcp_connect_helper(lua_State *L,
+    ngx_http_lua_socket_tcp_upstream_t *u, ngx_http_request_t *r,
+    ngx_http_lua_ctx_t *ctx, u_char *host_ref, size_t host_len, in_port_t port,
+    unsigned resuming);
+static void ngx_http_lua_socket_tcp_conn_op_timeout_handler(
+    ngx_event_t *ev);
+static int ngx_http_lua_socket_tcp_conn_op_timeout_retval_handler(
+    ngx_http_request_t *r, ngx_http_lua_socket_tcp_upstream_t *u, lua_State *L);
+static void ngx_http_lua_socket_tcp_resume_conn_op(
+    ngx_http_lua_socket_pool_t *spool);
+static void ngx_http_lua_socket_tcp_conn_op_ctx_cleanup(void *data);
+static void ngx_http_lua_socket_tcp_conn_op_resume_handler(ngx_event_t *ev);
 static ngx_int_t ngx_http_lua_socket_keepalive_close_handler(ngx_event_t *ev);
 static void ngx_http_lua_socket_keepalive_rev_handler(ngx_event_t *ev);
+static int ngx_http_lua_socket_tcp_conn_op_resume_retval_handler(
+    ngx_http_request_t *r, ngx_http_lua_socket_tcp_upstream_t *u, lua_State *L);
 static int ngx_http_lua_socket_tcp_upstream_destroy(lua_State *L);
 static int ngx_http_lua_socket_downstream_destroy(lua_State *L);
 static ngx_int_t ngx_http_lua_socket_push_input_data(ngx_http_request_t *r,
@@ -118,6 +134,7 @@ static ngx_int_t ngx_http_lua_socket_add_input_buffer(ngx_http_request_t *r,
     ngx_http_lua_socket_tcp_upstream_t *u);
 static ngx_int_t ngx_http_lua_socket_insert_buffer(ngx_http_request_t *r,
     ngx_http_lua_socket_tcp_upstream_t *u, u_char *pat, size_t prefix);
+static ngx_int_t ngx_http_lua_socket_tcp_conn_op_resume(ngx_http_request_t *r);
 static ngx_int_t ngx_http_lua_socket_tcp_conn_resume(ngx_http_request_t *r);
 static ngx_int_t ngx_http_lua_socket_tcp_read_resume(ngx_http_request_t *r);
 static ngx_int_t ngx_http_lua_socket_tcp_write_resume(ngx_http_request_t *r);
@@ -155,7 +172,8 @@ enum {
 enum {
     SOCKET_OP_CONNECT,
     SOCKET_OP_READ,
-    SOCKET_OP_WRITE
+    SOCKET_OP_WRITE,
+    SOCKET_OP_RESUME_CONN
 };
 
 
@@ -431,30 +449,416 @@ ngx_http_lua_socket_tcp(lua_State *L)
 }
 
 
+static void
+ngx_http_lua_socket_tcp_create_socket_pool(lua_State *L, ngx_http_request_t *r,
+    ngx_str_t key, ngx_int_t pool_size, ngx_int_t backlog,
+    ngx_http_lua_socket_pool_t **spool)
+{
+    u_char                              *p;
+    size_t                               size, key_len;
+    ngx_int_t                            i;
+    ngx_http_lua_socket_pool_t          *sp;
+    ngx_http_lua_socket_pool_item_t     *items;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "lua tcp socket connection pool size: %i, backlog: %i",
+                   pool_size, backlog);
+
+    key_len = ngx_align(key.len + 1, sizeof(void *));
+
+    size = sizeof(ngx_http_lua_socket_pool_t) - 1 + key_len
+           + sizeof(ngx_http_lua_socket_pool_item_t) * pool_size;
+
+    /* before calling this function, the Lua stack is:
+     * -1 key
+     * -2 pools
+     */
+    sp = lua_newuserdata(L, size);
+    if (sp == NULL) {
+        luaL_error(L, "no memory");
+        return;
+    }
+
+    lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
+                          pool_udata_metatable_key));
+    lua_rawget(L, LUA_REGISTRYINDEX);
+    lua_setmetatable(L, -2);
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "lua tcp socket keepalive create connection pool for key"
+                   " \"%V\"", &key);
+
+    /* a new socket pool with metatable is push to the stack, so now we have:
+     * -1 sp
+     * -2 key
+     * -3 pools
+     *
+     * it is time to set pools[key] to sp.
+     */
+    lua_rawset(L, -3);
+
+    /* clean up the stack for consistency's sake */
+    lua_pop(L, 1);
+
+    sp->backlog = backlog;
+    sp->size = pool_size;
+    sp->connections = 0;
+    sp->lua_vm = ngx_http_lua_get_lua_vm(r, NULL);
+
+    ngx_queue_init(&sp->cache_connect_op);
+    ngx_queue_init(&sp->wait_connect_op);
+    ngx_queue_init(&sp->cache);
+    ngx_queue_init(&sp->free);
+
+    p = ngx_copy(sp->key, key.data, key.len);
+    *p++ = '\0';
+
+    items = (ngx_http_lua_socket_pool_item_t *) (sp->key + key_len);
+
+    dd("items: %p", items);
+
+    ngx_http_lua_assert((void *) items == ngx_align_ptr(items, sizeof(void *)));
+
+    for (i = 0; i < pool_size; i++) {
+        ngx_queue_insert_head(&sp->free, &items[i].queue);
+        items[i].socket_pool = sp;
+    }
+
+    *spool = sp;
+}
+
+
+static int
+ngx_http_lua_socket_tcp_connect_helper(lua_State *L,
+    ngx_http_lua_socket_tcp_upstream_t *u, ngx_http_request_t *r,
+    ngx_http_lua_ctx_t *ctx, u_char *host_ref, size_t host_len, in_port_t port,
+    unsigned resuming)
+{
+    int                                    n;
+    int                                    host_size;
+    int                                    saved_top;
+    ngx_int_t                              rc;
+    ngx_str_t                              host;
+    ngx_str_t                             *conn_op_host;
+    ngx_url_t                              url;
+    ngx_queue_t                           *q;
+    ngx_resolver_ctx_t                    *rctx, temp;
+    ngx_http_lua_co_ctx_t                 *coctx;
+    ngx_http_core_loc_conf_t              *clcf;
+    ngx_http_lua_socket_pool_t            *spool;
+    ngx_http_lua_socket_tcp_conn_op_ctx_t *conn_op_ctx;
+
+    spool = u->socket_pool;
+    if (spool != NULL) {
+        rc = ngx_http_lua_get_keepalive_peer(r, u);
+
+        if (rc == NGX_OK) {
+            lua_pushinteger(L, 1);
+            return 1;
+        }
+
+        /* rc == NGX_DECLINED */
+
+        spool->connections++;
+
+        /* check if backlog is enabled and
+         * don't queue resuming connection operation */
+        if (spool->backlog >= 0 && !resuming) {
+
+            dd("lua tcp socket %s connections %ld",
+               spool->key, spool->connections);
+
+            if (spool->connections > spool->size + spool->backlog) {
+                spool->connections--;
+                lua_pushnil(L);
+                lua_pushliteral(L, "too many waiting connect operations");
+                return 2;
+            }
+
+            if (spool->connections > spool->size) {
+                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, u->peer.log, 0,
+                               "lua tcp socket queue connect operation for "
+                               "connection pool \"%s\", connections: %i",
+                               spool->key, spool->connections);
+
+                host_size = sizeof(u_char) *
+                    (ngx_max(host_len, NGX_INET_ADDRSTRLEN) + 1);
+
+                if (!ngx_queue_empty(&spool->cache_connect_op)) {
+                    q = ngx_queue_last(&spool->cache_connect_op);
+                    ngx_queue_remove(q);
+                    conn_op_ctx = ngx_queue_data(
+                        q, ngx_http_lua_socket_tcp_conn_op_ctx_t, queue);
+
+                    conn_op_host = &conn_op_ctx->host;
+                    if (host_len > conn_op_host->len
+                        && host_len > NGX_INET_ADDRSTRLEN)
+                    {
+                        ngx_free(conn_op_host->data);
+                        conn_op_host->data = ngx_alloc(host_size,
+                                                       ngx_cycle->log);
+                        if (conn_op_host->data == NULL) {
+                            ngx_free(conn_op_ctx);
+                            goto no_memory_and_not_resuming;
+                        }
+                    }
+
+                } else {
+                    conn_op_ctx = ngx_alloc(
+                        sizeof(ngx_http_lua_socket_tcp_conn_op_ctx_t),
+                        ngx_cycle->log);
+                    if (conn_op_ctx == NULL) {
+                        goto no_memory_and_not_resuming;
+                    }
+
+                    conn_op_host = &conn_op_ctx->host;
+                    conn_op_host->data = ngx_alloc(host_size, ngx_cycle->log);
+                    if (conn_op_host->data == NULL) {
+                        ngx_free(conn_op_ctx);
+                        goto no_memory_and_not_resuming;
+                    }
+                }
+
+                conn_op_ctx->cleanup = NULL;
+
+                ngx_memcpy(conn_op_host->data, host_ref, host_len);
+                conn_op_host->data[host_len] = '\0';
+                conn_op_host->len = host_len;
+
+                conn_op_ctx->port = port;
+
+                u->write_co_ctx = ctx->cur_co_ctx;
+
+                conn_op_ctx->u = u;
+                ngx_memzero(&conn_op_ctx->event, sizeof(ngx_event_t));
+                conn_op_ctx->event.handler =
+                    ngx_http_lua_socket_tcp_conn_op_timeout_handler;
+                conn_op_ctx->event.data = conn_op_ctx;
+                conn_op_ctx->event.log = ngx_cycle->log;
+
+                ngx_add_timer(&conn_op_ctx->event, u->connect_timeout);
+
+                ngx_queue_insert_tail(&spool->wait_connect_op,
+                                      &conn_op_ctx->queue);
+
+                ngx_log_debug3(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                               "lua tcp socket queued connect operation for "
+                               "%d(ms), u: %p, ctx: %p",
+                               u->connect_timeout, conn_op_ctx->u, conn_op_ctx);
+
+                return lua_yield(L, 0);
+            }
+        }
+
+    } /* end spool != NULL */
+
+    host.data = ngx_palloc(r->pool, host_len + 1);
+    if (host.data == NULL) {
+        return luaL_error(L, "no memory");
+    }
+
+    host.len = host_len;
+
+    ngx_memcpy(host.data, host_ref, host_len);
+    host.data[host_len] = '\0';
+
+    ngx_memzero(&url, sizeof(ngx_url_t));
+    url.url = host;
+    url.default_port = port;
+    url.no_resolve = 1;
+
+    coctx = ctx->cur_co_ctx;
+
+    if (ngx_parse_url(r->pool, &url) != NGX_OK) {
+        lua_pushnil(L);
+
+        if (url.err) {
+            lua_pushfstring(L, "failed to parse host name \"%s\": %s",
+                            url.url.data, url.err);
+
+        } else {
+            lua_pushfstring(L, "failed to parse host name \"%s\"",
+                            url.url.data);
+        }
+
+        goto failed;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "lua tcp socket connect timeout: %M", u->connect_timeout);
+
+    u->resolved = ngx_pcalloc(r->pool, sizeof(ngx_http_upstream_resolved_t));
+    if (u->resolved == NULL) {
+        if (resuming) {
+            lua_pushnil(L);
+            lua_pushliteral(L, "no memory");
+            goto failed;
+        }
+
+        goto no_memory_and_not_resuming;
+    }
+
+    if (url.addrs && url.addrs[0].sockaddr) {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "lua tcp socket network address given directly");
+
+        u->resolved->sockaddr = url.addrs[0].sockaddr;
+        u->resolved->socklen = url.addrs[0].socklen;
+        u->resolved->naddrs = 1;
+        u->resolved->host = url.addrs[0].name;
+
+    } else {
+        u->resolved->host = host;
+        u->resolved->port = url.default_port;
+    }
+
+    if (u->resolved->sockaddr) {
+        rc = ngx_http_lua_socket_resolve_retval_handler(r, u, L);
+        if (rc == NGX_AGAIN && !resuming) {
+            return lua_yield(L, 0);
+        }
+
+        if (rc > 1) {
+            goto failed;
+        }
+
+        return rc;
+    }
+
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    temp.name = host;
+    rctx = ngx_resolve_start(clcf->resolver, &temp);
+    if (rctx == NULL) {
+        u->ft_type |= NGX_HTTP_LUA_SOCKET_FT_RESOLVER;
+        lua_pushnil(L);
+        lua_pushliteral(L, "failed to start the resolver");
+        goto failed;
+    }
+
+    if (rctx == NGX_NO_RESOLVER) {
+        u->ft_type |= NGX_HTTP_LUA_SOCKET_FT_RESOLVER;
+        lua_pushnil(L);
+        lua_pushfstring(L, "no resolver defined to resolve \"%s\"", host.data);
+        goto failed;
+    }
+
+    rctx->name = host;
+#if !defined(nginx_version) || nginx_version < 1005008
+    rctx->type = NGX_RESOLVE_A;
+#endif
+    rctx->handler = ngx_http_lua_socket_resolve_handler;
+    rctx->data = u;
+    rctx->timeout = clcf->resolver_timeout;
+
+    u->resolved->ctx = rctx;
+    u->write_co_ctx = ctx->cur_co_ctx;
+
+    ngx_http_lua_cleanup_pending_operation(coctx);
+    coctx->cleanup = ngx_http_lua_tcp_resolve_cleanup;
+    coctx->data = u;
+
+    saved_top = lua_gettop(L);
+
+    if (ngx_resolve_name(rctx) != NGX_OK) {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "lua tcp socket fail to run resolver immediately");
+
+        u->ft_type |= NGX_HTTP_LUA_SOCKET_FT_RESOLVER;
+
+        coctx->cleanup = NULL;
+        coctx->data = NULL;
+
+        u->resolved->ctx = NULL;
+        lua_pushnil(L);
+        lua_pushfstring(L, "%s could not be resolved", host.data);
+        goto failed;
+    }
+
+    if (u->conn_waiting) {
+        dd("resolved and already connecting");
+
+        if (resuming) {
+            return NGX_AGAIN;
+        }
+
+        return lua_yield(L, 0);
+    }
+
+    n = lua_gettop(L) - saved_top;
+    if (n) {
+        dd("errors occurred during resolving or connecting"
+           "or already connected");
+
+        if (n > 1) {
+            goto failed;
+        }
+
+        return n;
+    }
+
+    /* still resolving */
+
+    u->conn_waiting = 1;
+    u->write_prepare_retvals = ngx_http_lua_socket_resolve_retval_handler;
+
+    dd("setting data to %p", u);
+
+    if (ctx->entered_content_phase) {
+        r->write_event_handler = ngx_http_lua_content_wev_handler;
+
+    } else {
+        r->write_event_handler = ngx_http_core_run_phases;
+    }
+
+    if (resuming) {
+        return NGX_AGAIN;
+    }
+
+    return lua_yield(L, 0);
+
+failed:
+
+    if (spool != NULL) {
+        spool->connections--;
+        ngx_http_lua_socket_tcp_resume_conn_op(spool);
+    }
+
+    return 2;
+
+no_memory_and_not_resuming:
+
+    if (spool != NULL) {
+        spool->connections--;
+        ngx_http_lua_socket_tcp_resume_conn_op(spool);
+    }
+
+    return luaL_error(L, "no memory");
+}
+
+
 static int
 ngx_http_lua_socket_tcp_connect(lua_State *L)
 {
     ngx_http_request_t          *r;
     ngx_http_lua_ctx_t          *ctx;
-    ngx_str_t                    host;
     int                          port;
-    ngx_resolver_ctx_t          *rctx, temp;
-    ngx_http_core_loc_conf_t    *clcf;
-    int                          saved_top;
     int                          n;
     u_char                      *p;
     size_t                       len;
-    ngx_url_t                    url;
-    ngx_int_t                    rc;
     ngx_http_lua_loc_conf_t     *llcf;
     ngx_peer_connection_t       *pc;
     int                          connect_timeout, send_timeout, read_timeout;
     unsigned                     custom_pool;
     int                          key_index;
+    ngx_int_t                    backlog;
+    ngx_int_t                    pool_size;
+    ngx_str_t                    key;
     const char                  *msg;
-    ngx_http_lua_co_ctx_t       *coctx;
 
     ngx_http_lua_socket_tcp_upstream_t      *u;
+
+    ngx_http_lua_socket_pool_t              *spool;
 
     n = lua_gettop(L);
     if (n != 2 && n != 3 && n != 4) {
@@ -483,12 +887,53 @@ ngx_http_lua_socket_tcp_connect(lua_State *L)
 
     p = (u_char *) luaL_checklstring(L, 2, &len);
 
+    backlog = -1;
     key_index = 2;
+    pool_size = 0;
     custom_pool = 0;
+    llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
 
     if (lua_type(L, n) == LUA_TTABLE) {
 
         /* found the last optional option table */
+
+        lua_getfield(L, n, "pool_size");
+
+        if (lua_isnumber(L, -1)) {
+            pool_size = (ngx_int_t) lua_tointeger(L, -1);
+
+            if (pool_size <= 0) {
+                msg = lua_pushfstring(L, "bad \"pool_size\" option value: %i",
+                                      pool_size);
+                return luaL_argerror(L, n, msg);
+            }
+
+        } else if (!lua_isnil(L, -1)) {
+            msg = lua_pushfstring(L, "bad \"pool_size\" option type: %s",
+                                  lua_typename(L, lua_type(L, -1)));
+            return luaL_argerror(L, n, msg);
+        }
+
+        lua_pop(L, 1);
+
+        lua_getfield(L, n, "backlog");
+
+        if (lua_isnumber(L, -1)) {
+            backlog = (ngx_int_t) lua_tointeger(L, -1);
+
+            if (backlog < 0) {
+                msg = lua_pushfstring(L, "bad \"backlog\" option value: %i",
+                                      backlog);
+                return luaL_argerror(L, n, msg);
+            }
+
+            /* use default value for pool size if only backlog specified */
+            if (pool_size == 0) {
+                pool_size = llcf->pool_size;
+            }
+        }
+
+        lua_pop(L, 1);
 
         lua_getfield(L, n, "pool");
 
@@ -600,11 +1045,7 @@ ngx_http_lua_socket_tcp_connect(lua_State *L)
 
     ngx_memzero(u, sizeof(ngx_http_lua_socket_tcp_upstream_t));
 
-    coctx = ctx->cur_co_ctx;
-
     u->request = r; /* set the controlling request */
-
-    llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
 
     u->conf = llcf;
 
@@ -646,163 +1087,28 @@ ngx_http_lua_socket_tcp_connect(lua_State *L)
         u->read_timeout = u->conf->read_timeout;
     }
 
-    rc = ngx_http_lua_get_keepalive_peer(r, L, key_index, u);
+    lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(socket_pool_key));
+    lua_rawget(L, LUA_REGISTRYINDEX); /* table */
+    lua_pushvalue(L, key_index); /* key */
 
-    if (rc == NGX_OK) {
-        lua_pushinteger(L, 1);
-        return 1;
+    lua_rawget(L, -2);
+    spool = lua_touserdata(L, -1);
+    lua_pop(L, 1);
+
+    if (spool != NULL) {
+        u->socket_pool = spool;
+
+    } else if (pool_size > 0) {
+        lua_pushvalue(L, key_index);
+        key.data = (u_char *) lua_tolstring(L, -1, &key.len);
+
+        ngx_http_lua_socket_tcp_create_socket_pool(L, r, key, pool_size,
+                                                   backlog, &spool);
+        u->socket_pool = spool;
     }
 
-    if (rc == NGX_ERROR) {
-        lua_pushnil(L);
-        lua_pushliteral(L, "error in get keepalive peer");
-        return 2;
-    }
-
-    /* rc == NGX_DECLINED */
-
-    /* TODO: we should avoid this in-pool allocation */
-
-    host.data = ngx_palloc(r->pool, len + 1);
-    if (host.data == NULL) {
-        return luaL_error(L, "no memory");
-    }
-
-    host.len = len;
-
-    ngx_memcpy(host.data, p, len);
-    host.data[len] = '\0';
-
-    ngx_memzero(&url, sizeof(ngx_url_t));
-
-    url.url.len = host.len;
-    url.url.data = host.data;
-    url.default_port = (in_port_t) port;
-    url.no_resolve = 1;
-
-    if (ngx_parse_url(r->pool, &url) != NGX_OK) {
-        lua_pushnil(L);
-
-        if (url.err) {
-            lua_pushfstring(L, "failed to parse host name \"%s\": %s",
-                            host.data, url.err);
-
-        } else {
-            lua_pushfstring(L, "failed to parse host name \"%s\"", host.data);
-        }
-
-        return 2;
-    }
-
-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                   "lua tcp socket connect timeout: %M", u->connect_timeout);
-
-    u->resolved = ngx_pcalloc(r->pool, sizeof(ngx_http_upstream_resolved_t));
-    if (u->resolved == NULL) {
-        return luaL_error(L, "no memory");
-    }
-
-    if (url.addrs && url.addrs[0].sockaddr) {
-        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                       "lua tcp socket network address given directly");
-
-        u->resolved->sockaddr = url.addrs[0].sockaddr;
-        u->resolved->socklen = url.addrs[0].socklen;
-        u->resolved->naddrs = 1;
-        u->resolved->host = url.addrs[0].name;
-
-    } else {
-        u->resolved->host = host;
-        u->resolved->port = (in_port_t) port;
-    }
-
-    if (u->resolved->sockaddr) {
-        rc = ngx_http_lua_socket_resolve_retval_handler(r, u, L);
-        if (rc == NGX_AGAIN) {
-            return lua_yield(L, 0);
-        }
-
-        return rc;
-    }
-
-    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
-
-    temp.name = host;
-    rctx = ngx_resolve_start(clcf->resolver, &temp);
-    if (rctx == NULL) {
-        u->ft_type |= NGX_HTTP_LUA_SOCKET_FT_RESOLVER;
-        lua_pushnil(L);
-        lua_pushliteral(L, "failed to start the resolver");
-        return 2;
-    }
-
-    if (rctx == NGX_NO_RESOLVER) {
-        u->ft_type |= NGX_HTTP_LUA_SOCKET_FT_RESOLVER;
-        lua_pushnil(L);
-        lua_pushfstring(L, "no resolver defined to resolve \"%s\"", host.data);
-        return 2;
-    }
-
-    rctx->name = host;
-#if !defined(nginx_version) || nginx_version < 1005008
-    rctx->type = NGX_RESOLVE_A;
-#endif
-    rctx->handler = ngx_http_lua_socket_resolve_handler;
-    rctx->data = u;
-    rctx->timeout = clcf->resolver_timeout;
-
-    u->resolved->ctx = rctx;
-    u->write_co_ctx = ctx->cur_co_ctx;
-
-    ngx_http_lua_cleanup_pending_operation(coctx);
-    coctx->cleanup = ngx_http_lua_tcp_resolve_cleanup;
-    coctx->data = u;
-
-    saved_top = lua_gettop(L);
-
-    if (ngx_resolve_name(rctx) != NGX_OK) {
-        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                       "lua tcp socket fail to run resolver immediately");
-
-        u->ft_type |= NGX_HTTP_LUA_SOCKET_FT_RESOLVER;
-
-        coctx->cleanup = NULL;
-        coctx->data = NULL;
-
-        u->resolved->ctx = NULL;
-        lua_pushnil(L);
-        lua_pushfstring(L, "%s could not be resolved", host.data);
-
-        return 2;
-    }
-
-    if (u->conn_waiting) {
-        dd("resolved and already connecting");
-        return lua_yield(L, 0);
-    }
-
-    n = lua_gettop(L) - saved_top;
-    if (n) {
-        dd("errors occurred during resolving or connecting"
-           "or already connected");
-        return n;
-    }
-
-    /* still resolving */
-
-    u->conn_waiting = 1;
-    u->write_prepare_retvals = ngx_http_lua_socket_resolve_retval_handler;
-
-    dd("setting data to %p", u);
-
-    if (ctx->entered_content_phase) {
-        r->write_event_handler = ngx_http_lua_content_wev_handler;
-
-    } else {
-        r->write_event_handler = ngx_http_core_run_phases;
-    }
-
-    return lua_yield(L, 0);
+    return ngx_http_lua_socket_tcp_connect_helper(L, u, r, ctx, p,
+                                                  len, port, 0);
 }
 
 
@@ -3572,6 +3878,257 @@ ngx_http_lua_socket_tcp_finalize_write_part(ngx_http_request_t *r,
 
 
 static void
+ngx_http_lua_socket_tcp_conn_op_timeout_handler(ngx_event_t *ev)
+{
+    ngx_http_lua_socket_tcp_upstream_t      *u;
+    ngx_http_lua_ctx_t                      *ctx;
+    ngx_connection_t                        *c;
+    ngx_http_request_t                      *r;
+    ngx_http_lua_co_ctx_t                   *coctx;
+    ngx_http_lua_loc_conf_t                 *llcf;
+    ngx_http_lua_socket_tcp_conn_op_ctx_t   *conn_op_ctx;
+
+    conn_op_ctx = ev->data;
+    ngx_queue_remove(&conn_op_ctx->queue);
+
+    u = conn_op_ctx->u;
+    r = u->request;
+
+    coctx = u->write_co_ctx;
+    coctx->cleanup = NULL;
+    /* note that we store conn_op_ctx in coctx->data instead of u */
+    coctx->data = conn_op_ctx;
+    u->write_co_ctx = NULL;
+
+    llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
+
+    if (llcf->log_socket_errors) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "lua tcp socket queued connect timed out,"
+                      " when trying to connect to %V:%ud",
+                      &conn_op_ctx->host, conn_op_ctx->port);
+    }
+
+    ngx_queue_insert_head(&u->socket_pool->cache_connect_op,
+                          &conn_op_ctx->queue);
+    u->socket_pool->connections--;
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+    if (ctx == NULL) {
+        return;
+    }
+
+    ctx->cur_co_ctx = coctx;
+
+    ngx_http_lua_assert(coctx && (!ngx_http_lua_is_thread(ctx)
+                        || coctx->co_ref >= 0));
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "lua tcp socket waking up the current request");
+
+    u->write_prepare_retvals =
+        ngx_http_lua_socket_tcp_conn_op_timeout_retval_handler;
+
+    c = r->connection;
+
+    if (ctx->entered_content_phase) {
+        (void) ngx_http_lua_socket_tcp_conn_op_resume(r);
+
+    } else {
+        ctx->resume_handler = ngx_http_lua_socket_tcp_conn_op_resume;
+        ngx_http_core_run_phases(r);
+    }
+
+    ngx_http_run_posted_requests(c);
+}
+
+
+static int
+ngx_http_lua_socket_tcp_conn_op_timeout_retval_handler(ngx_http_request_t *r,
+    ngx_http_lua_socket_tcp_upstream_t *u, lua_State *L)
+{
+    lua_pushnil(L);
+    lua_pushliteral(L, "timeout");
+    return 2;
+}
+
+
+static void
+ngx_http_lua_socket_tcp_resume_conn_op(ngx_http_lua_socket_pool_t *spool)
+{
+    ngx_queue_t                             *q;
+    ngx_http_lua_socket_tcp_conn_op_ctx_t   *conn_op_ctx;
+
+#if (NGX_DEBUG)
+    ngx_http_lua_assert(spool->connections >= 0);
+
+#else
+    if (spool->connections < 0) {
+        ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
+                      "lua tcp socket connections count mismatched for "
+                      "connection pool \"%s\", connections: %i, size: %i",
+                      spool->key, spool->connections, spool->size);
+        spool->connections = 0;
+    }
+#endif
+
+    /* we manually destroy wait_connect_op before triggering connect
+     * operation resumption, so that there is no resumption happens when Nginx
+     * is exiting.
+     */
+    if (ngx_queue_empty(&spool->wait_connect_op)) {
+#if (NGX_DEBUG)
+        ngx_http_lua_assert(!(spool->backlog >= 0
+                              && spool->connections > spool->size));
+
+#else
+        if (spool->backlog >= 0 && spool->connections > spool->size) {
+            ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
+                          "lua tcp socket connections count mismatched for "
+                          "connection pool \"%s\", connections: %i, size: %i",
+                          spool->key, spool->connections, spool->size);
+            spool->connections = spool->size;
+        }
+#endif
+
+        return;
+    }
+
+    q = ngx_queue_head(&spool->wait_connect_op);
+    ngx_queue_remove(q);
+    conn_op_ctx = ngx_queue_data(q, ngx_http_lua_socket_tcp_conn_op_ctx_t,
+                                 queue);
+    ngx_log_debug4(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                   "lua tcp socket post connect operation resumption "
+                   "u: %p, ctx: %p for connection pool \"%s\", "
+                   "connections: %i",
+                   conn_op_ctx->u, conn_op_ctx, spool->key, spool->connections);
+
+    if (conn_op_ctx->event.timer_set) {
+        ngx_del_timer(&conn_op_ctx->event);
+    }
+
+    conn_op_ctx->event.handler =
+        ngx_http_lua_socket_tcp_conn_op_resume_handler;
+
+    ngx_post_event((&conn_op_ctx->event), &ngx_posted_events);
+}
+
+
+static void
+ngx_http_lua_socket_tcp_conn_op_ctx_cleanup(void *data)
+{
+    ngx_http_lua_socket_tcp_upstream_t     *u;
+    ngx_http_lua_socket_tcp_conn_op_ctx_t  *conn_op_ctx = data;
+
+    u = conn_op_ctx->u;
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, u->request->connection->log, 0,
+                   "cleanup lua tcp socket conn_op_ctx: \"%V\"",
+                   &u->request->uri);
+
+    ngx_queue_insert_head(&u->socket_pool->cache_connect_op,
+                          &conn_op_ctx->queue);
+}
+
+
+static void
+ngx_http_lua_socket_tcp_conn_op_resume_handler(ngx_event_t *ev)
+{
+    ngx_http_lua_socket_tcp_upstream_t      *u;
+    ngx_http_lua_ctx_t                      *ctx;
+    ngx_connection_t                        *c;
+    ngx_http_request_t                      *r;
+    ngx_http_cleanup_t                      *cln;
+    ngx_http_lua_co_ctx_t                   *coctx;
+    ngx_http_lua_socket_tcp_conn_op_ctx_t   *conn_op_ctx;
+
+    conn_op_ctx = ev->data;
+    u = conn_op_ctx->u;
+    r = u->request;
+
+    coctx = u->write_co_ctx;
+    coctx->cleanup = NULL;
+    /* note that we store conn_op_ctx in coctx->data instead of u */
+    coctx->data = conn_op_ctx;
+    u->write_co_ctx = NULL;
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+    if (ctx == NULL) {
+        ngx_queue_insert_head(&u->socket_pool->cache_connect_op,
+                              &conn_op_ctx->queue);
+        return;
+    }
+
+    ctx->cur_co_ctx = coctx;
+
+    ngx_http_lua_assert(coctx && (!ngx_http_lua_is_thread(ctx)
+                        || coctx->co_ref >= 0));
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "lua tcp socket waking up the current request");
+
+    u->write_prepare_retvals =
+        ngx_http_lua_socket_tcp_conn_op_resume_retval_handler;
+
+    c = r->connection;
+
+    if (ctx->entered_content_phase) {
+        (void) ngx_http_lua_socket_tcp_conn_op_resume(r);
+
+    } else {
+        cln = ngx_http_lua_cleanup_add(r, 0);
+        if (cln != NULL) {
+            cln->handler = ngx_http_lua_socket_tcp_conn_op_ctx_cleanup;
+            cln->data = conn_op_ctx;
+            conn_op_ctx->cleanup = &cln->handler;
+        }
+
+        ctx->resume_handler = ngx_http_lua_socket_tcp_conn_op_resume;
+        ngx_http_core_run_phases(r);
+    }
+
+    ngx_http_run_posted_requests(c);
+}
+
+
+static int
+ngx_http_lua_socket_tcp_conn_op_resume_retval_handler(ngx_http_request_t *r,
+    ngx_http_lua_socket_tcp_upstream_t *u, lua_State *L)
+{
+    int                                      nret;
+    ngx_http_lua_ctx_t                      *ctx;
+    ngx_http_lua_co_ctx_t                   *coctx;
+    ngx_http_lua_socket_tcp_conn_op_ctx_t   *conn_op_ctx;
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+    if (ctx == NULL) {
+        return NGX_ERROR;
+    }
+
+    coctx = ctx->cur_co_ctx;
+    dd("coctx: %p", coctx);
+    conn_op_ctx = coctx->data;
+    if (conn_op_ctx->cleanup != NULL) {
+        *conn_op_ctx->cleanup = NULL;
+        ngx_http_lua_cleanup_free(r, conn_op_ctx->cleanup);
+        conn_op_ctx->cleanup = NULL;
+    }
+
+    /* decrease pending connect operation counter */
+    u->socket_pool->connections--;
+
+    nret = ngx_http_lua_socket_tcp_connect_helper(L, u, r, ctx,
+                                                  conn_op_ctx->host.data,
+                                                  conn_op_ctx->host.len,
+                                                  conn_op_ctx->port, 1);
+    ngx_queue_insert_head(&u->socket_pool->cache_connect_op,
+                          &conn_op_ctx->queue);
+
+    return nret;
+}
+
+
+static void
 ngx_http_lua_socket_tcp_finalize(ngx_http_request_t *r,
     ngx_http_lua_socket_tcp_upstream_t *u)
 {
@@ -3621,21 +4178,21 @@ ngx_http_lua_socket_tcp_finalize(ngx_http_request_t *r,
 
         ngx_http_lua_socket_tcp_close_connection(c);
         u->peer.connection = NULL;
-
-        if (!u->reused) {
-            return;
-        }
+        u->conn_closed = 1;
 
         spool = u->socket_pool;
         if (spool == NULL) {
             return;
         }
 
-        spool->active_connections--;
+        spool->connections--;
 
-        if (spool->active_connections == 0) {
+        if (spool->connections == 0) {
             ngx_http_lua_socket_free_pool(r->connection->log, spool);
+            return;
         }
+
+        ngx_http_lua_socket_tcp_resume_conn_op(spool);
     }
 }
 
@@ -4608,20 +5165,18 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
     ngx_http_lua_socket_tcp_upstream_t  *u;
     ngx_connection_t                    *c;
     ngx_http_lua_socket_pool_t          *spool;
-    size_t                               size, key_len;
     ngx_str_t                            key;
-    ngx_uint_t                           i;
     ngx_queue_t                         *q;
     ngx_peer_connection_t               *pc;
-    u_char                              *p;
     ngx_http_request_t                  *r;
     ngx_msec_t                           timeout;
-    ngx_uint_t                           pool_size;
+    ngx_int_t                            pool_size;
     int                                  n;
     ngx_int_t                            rc;
     ngx_buf_t                           *b;
+    const char                          *msg;
 
-    ngx_http_lua_socket_pool_item_t     *items, *item;
+    ngx_http_lua_socket_pool_item_t     *item;
 
     n = lua_gettop(L);
 
@@ -4631,18 +5186,6 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
     }
 
     luaL_checktype(L, 1, LUA_TTABLE);
-
-    lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
-                          socket_pool_key));
-    lua_rawget(L, LUA_REGISTRYINDEX);
-
-    lua_rawgeti(L, 1, SOCKET_KEY_INDEX);
-    key.data = (u_char *) lua_tolstring(L, -1, &key.len);
-    if (key.data == NULL) {
-        lua_pushnil(L);
-        lua_pushliteral(L, "key not found");
-        return 2;
-    }
 
     lua_rawgeti(L, 1, SOCKET_CTX_INDEX);
     u = lua_touserdata(L, -1);
@@ -4654,7 +5197,7 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
         return 2;
     }
 
-    /* stack: obj cache key */
+    /* stack: obj timeout? size? */
 
     pc = &u->peer;
     c = pc->connection;
@@ -4711,11 +5254,26 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
                        "lua tcp socket set keepalive while process exiting, "
                        "closing connection %p", c);
 
-        goto finalize;
+        ngx_http_lua_socket_tcp_finalize(r, u);
+        lua_pushinteger(L, 1);
+        return 1;
     }
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                    "lua tcp socket set keepalive: saving connection %p", c);
+
+    lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(socket_pool_key));
+    lua_rawget(L, LUA_REGISTRYINDEX);
+
+    /* stack: obj timeout? size? pools */
+
+    lua_rawgeti(L, 1, SOCKET_KEY_INDEX);
+    key.data = (u_char *) lua_tolstring(L, -1, &key.len);
+    if (key.data == NULL) {
+        lua_pushnil(L);
+        lua_pushliteral(L, "key not found");
+        return 2;
+    }
 
     dd("saving connection to key %s", lua_tostring(L, -1));
 
@@ -4724,7 +5282,7 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
     spool = lua_touserdata(L, -1);
     lua_pop(L, 1);
 
-    /* stack: obj timeout? size? cache key */
+    /* stack: obj timeout? size? pools cache_key */
 
     llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
 
@@ -4738,68 +5296,31 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
             pool_size = llcf->pool_size;
         }
 
-        if (pool_size == 0) {
-            lua_pushnil(L);
-            lua_pushliteral(L, "zero pool size");
-            return 2;
+        if (pool_size <= 0) {
+            msg = lua_pushfstring(L, "bad \"pool_size\" option value: %i",
+                                  pool_size);
+            return luaL_argerror(L, n, msg);
         }
 
-        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                       "lua tcp socket connection pool size: %ui", pool_size);
-
-        key_len = ngx_align(key.len + 1, sizeof(void *));
-
-        size = sizeof(ngx_http_lua_socket_pool_t) + key_len - 1
-               + sizeof(ngx_http_lua_socket_pool_item_t)
-               * pool_size;
-
-        spool = lua_newuserdata(L, size);
-        if (spool == NULL) {
-            return luaL_error(L, "no memory");
-        }
-
-        lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
-                              pool_udata_metatable_key));
-        lua_rawget(L, LUA_REGISTRYINDEX);
-        lua_setmetatable(L, -2);
-
-        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                       "lua tcp socket keepalive create connection pool for key"
-                       " \"%s\"", lua_tostring(L, -2));
-
-        lua_rawset(L, -3);
-
-        spool->active_connections = 0;
-        spool->lua_vm = ngx_http_lua_get_lua_vm(r, NULL);
-
-        ngx_queue_init(&spool->cache);
-        ngx_queue_init(&spool->free);
-
-        p = ngx_copy(spool->key, key.data, key.len);
-        *p++ = '\0';
-
-        items = (ngx_http_lua_socket_pool_item_t *) (spool->key + key_len);
-
-        dd("items: %p", items);
-
-        ngx_http_lua_assert((void *) items == ngx_align_ptr(items,
-                                                            sizeof(void *)));
-
-        for (i = 0; i < pool_size; i++) {
-            ngx_queue_insert_head(&spool->free, &items[i].queue);
-            items[i].socket_pool = spool;
-        }
+        ngx_http_lua_socket_tcp_create_socket_pool(L, r, key, pool_size, -1,
+                                                   &spool);
+        /* we should always increase connections after getting connected,
+         * and decrease connections after getting closed.
+         * however, we don't create connection pool in previous connect method.
+         * so we increase connections here for backward compatibility.
+         */
+        spool->connections++;
     }
 
     if (ngx_queue_empty(&spool->free)) {
 
         q = ngx_queue_last(&spool->cache);
         ngx_queue_remove(q);
-        spool->active_connections--;
 
         item = ngx_queue_data(q, ngx_http_lua_socket_pool_item_t, queue);
 
         ngx_http_lua_socket_tcp_close_connection(item->connection);
+        spool->connections--;
 
     } else {
         q = ngx_queue_head(&spool->free);
@@ -4810,10 +5331,6 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
 
     item->connection = c;
     ngx_queue_insert_head(&spool->cache, q);
-
-    if (!u->reused) {
-        spool->active_connections++;
-    }
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                    "lua tcp socket clear current socket connection");
@@ -4879,11 +5396,15 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
         }
     }
 
-finalize:
-
 #if 1
     ngx_http_lua_socket_tcp_finalize(r, u);
 #endif
+
+    /* since we set u->peer->connection to NULL previously, the connect
+     * operation won't be resumed in the ngx_http_lua_socket_tcp_finalize.
+     * Therefore we need to resume it here.
+     */
+    ngx_http_lua_socket_tcp_resume_conn_op(spool);
 
     lua_pushinteger(L, 1);
     return 1;
@@ -4891,43 +5412,21 @@ finalize:
 
 
 static ngx_int_t
-ngx_http_lua_get_keepalive_peer(ngx_http_request_t *r, lua_State *L,
-    int key_index, ngx_http_lua_socket_tcp_upstream_t *u)
+ngx_http_lua_get_keepalive_peer(ngx_http_request_t *r,
+    ngx_http_lua_socket_tcp_upstream_t *u)
 {
     ngx_http_lua_socket_pool_item_t     *item;
     ngx_http_lua_socket_pool_t          *spool;
     ngx_http_cleanup_t                  *cln;
     ngx_queue_t                         *q;
-    int                                  top;
     ngx_peer_connection_t               *pc;
     ngx_connection_t                    *c;
-
-    top = lua_gettop(L);
-
-    if (key_index < 0) {
-        key_index = top + key_index + 1;
-    }
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "lua tcp socket pool get keepalive peer");
 
     pc = &u->peer;
-
-    lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
-                          socket_pool_key));
-    lua_rawget(L, LUA_REGISTRYINDEX); /* table */
-    lua_pushvalue(L, key_index); /* key */
-    lua_rawget(L, -2);
-
-    spool = lua_touserdata(L, -1);
-    if (spool == NULL) {
-        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                       "lua tcp socket keepalive connection pool not found");
-        lua_settop(L, top);
-        return NGX_DECLINED;
-    }
-
-    u->socket_pool = spool;
+    spool = u->socket_pool;
 
     if (!ngx_queue_empty(&spool->cache)) {
         q = ngx_queue_head(&spool->cache);
@@ -4972,7 +5471,6 @@ ngx_http_lua_get_keepalive_peer(ngx_http_request_t *r, lua_State *L,
             cln = ngx_http_lua_cleanup_add(r, 0);
             if (cln == NULL) {
                 u->ft_type |= NGX_HTTP_LUA_SOCKET_FT_ERROR;
-                lua_settop(L, top);
                 return NGX_ERROR;
             }
 
@@ -4981,15 +5479,11 @@ ngx_http_lua_get_keepalive_peer(ngx_http_request_t *r, lua_State *L,
             u->cleanup = &cln->handler;
         }
 
-        lua_settop(L, top);
-
         return NGX_OK;
     }
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                    "lua tcp socket keepalive: connection pool empty");
-
-    lua_settop(L, top);
 
     return NGX_DECLINED;
 }
@@ -5062,13 +5556,15 @@ close:
 
     ngx_queue_remove(&item->queue);
     ngx_queue_insert_head(&spool->free, &item->queue);
-    spool->active_connections--;
+    spool->connections--;
 
-    dd("keepalive: active connections: %u",
-       (unsigned) spool->active_connections);
+    dd("keepalive: connections: %u", (unsigned) spool->connections);
 
-    if (spool->active_connections == 0) {
+    if (spool->connections == 0) {
         ngx_http_lua_socket_free_pool(ev->log, spool);
+
+    } else {
+        ngx_http_lua_socket_tcp_resume_conn_op(spool);
     }
 
     return NGX_DECLINED;
@@ -5086,8 +5582,7 @@ ngx_http_lua_socket_free_pool(ngx_log_t *log, ngx_http_lua_socket_pool_t *spool)
 
     L = spool->lua_vm;
 
-    lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
-                          socket_pool_key));
+    lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(socket_pool_key));
     lua_rawget(L, LUA_REGISTRYINDEX);
     lua_pushstring(L, (char *) spool->key);
     lua_pushnil(L);
@@ -5099,9 +5594,10 @@ ngx_http_lua_socket_free_pool(ngx_log_t *log, ngx_http_lua_socket_pool_t *spool)
 static void
 ngx_http_lua_socket_shutdown_pool_helper(ngx_http_lua_socket_pool_t *spool)
 {
-    ngx_queue_t                         *q;
-    ngx_connection_t                    *c;
-    ngx_http_lua_socket_pool_item_t     *item;
+    ngx_queue_t                             *q;
+    ngx_connection_t                        *c;
+    ngx_http_lua_socket_pool_item_t         *item;
+    ngx_http_lua_socket_tcp_conn_op_ctx_t   *conn_op_ctx;
 
     while (!ngx_queue_empty(&spool->cache)) {
         q = ngx_queue_head(&spool->cache);
@@ -5115,7 +5611,29 @@ ngx_http_lua_socket_shutdown_pool_helper(ngx_http_lua_socket_pool_t *spool)
         ngx_queue_insert_head(&spool->free, q);
     }
 
-    spool->active_connections = 0;
+    while (!ngx_queue_empty(&spool->cache_connect_op)) {
+        q = ngx_queue_head(&spool->cache_connect_op);
+        ngx_queue_remove(q);
+        conn_op_ctx = ngx_queue_data(q, ngx_http_lua_socket_tcp_conn_op_ctx_t,
+                                     queue);
+        ngx_http_lua_socket_tcp_free_conn_op_ctx(conn_op_ctx);
+    }
+
+    while (!ngx_queue_empty(&spool->wait_connect_op)) {
+        q = ngx_queue_head(&spool->wait_connect_op);
+        ngx_queue_remove(q);
+        conn_op_ctx = ngx_queue_data(q, ngx_http_lua_socket_tcp_conn_op_ctx_t,
+                                     queue);
+
+        if (conn_op_ctx->event.timer_set) {
+            ngx_del_timer(&conn_op_ctx->event);
+        }
+
+        ngx_http_lua_socket_tcp_free_conn_op_ctx(conn_op_ctx);
+    }
+
+    /* spool->connections will be decreased down to zero in
+     * ngx_http_lua_socket_tcp_finalize */
 }
 
 
@@ -5370,6 +5888,13 @@ static ngx_int_t ngx_http_lua_socket_insert_buffer(ngx_http_request_t *r,
 
 
 static ngx_int_t
+ngx_http_lua_socket_tcp_conn_op_resume(ngx_http_request_t *r)
+{
+    return ngx_http_lua_socket_tcp_resume_helper(r, SOCKET_OP_RESUME_CONN);
+}
+
+
+static ngx_int_t
 ngx_http_lua_socket_tcp_conn_resume(ngx_http_request_t *r)
 {
     return ngx_http_lua_socket_tcp_resume_helper(r, SOCKET_OP_CONNECT);
@@ -5393,13 +5918,14 @@ ngx_http_lua_socket_tcp_write_resume(ngx_http_request_t *r)
 static ngx_int_t
 ngx_http_lua_socket_tcp_resume_helper(ngx_http_request_t *r, int socket_op)
 {
-    int                          nret;
-    lua_State                   *vm;
-    ngx_int_t                    rc;
-    ngx_uint_t                   nreqs;
-    ngx_connection_t            *c;
-    ngx_http_lua_ctx_t          *ctx;
-    ngx_http_lua_co_ctx_t       *coctx;
+    int                                    nret;
+    lua_State                             *vm;
+    ngx_int_t                              rc;
+    ngx_uint_t                             nreqs;
+    ngx_connection_t                      *c;
+    ngx_http_lua_ctx_t                    *ctx;
+    ngx_http_lua_co_ctx_t                 *coctx;
+    ngx_http_lua_socket_tcp_conn_op_ctx_t *conn_op_ctx;
 
     ngx_http_lua_socket_tcp_retval_handler  prepare_retvals;
 
@@ -5419,15 +5945,22 @@ ngx_http_lua_socket_tcp_resume_helper(ngx_http_request_t *r, int socket_op)
 
     dd("coctx: %p", coctx);
 
-    u = coctx->data;
-
     switch (socket_op) {
+
+    case SOCKET_OP_RESUME_CONN:
+        conn_op_ctx = coctx->data;
+        u = conn_op_ctx->u;
+        prepare_retvals = u->write_prepare_retvals;
+        break;
+
     case SOCKET_OP_CONNECT:
     case SOCKET_OP_WRITE:
+        u = coctx->data;
         prepare_retvals = u->write_prepare_retvals;
         break;
 
     case SOCKET_OP_READ:
+        u = coctx->data;
         prepare_retvals = u->read_prepare_retvals;
         break;
 
@@ -5441,6 +5974,15 @@ ngx_http_lua_socket_tcp_resume_helper(ngx_http_request_t *r, int socket_op)
                    "u:%p", prepare_retvals, u);
 
     nret = prepare_retvals(r, u, ctx->cur_co_ctx->co);
+    if (socket_op == SOCKET_OP_CONNECT
+        && nret > 1
+        && !u->conn_closed
+        && u->socket_pool != NULL)
+    {
+        u->socket_pool->connections--;
+        ngx_http_lua_socket_tcp_resume_conn_op(u->socket_pool);
+    }
+
     if (nret == NGX_AGAIN) {
         return NGX_DONE;
     }
@@ -5485,6 +6027,11 @@ ngx_http_lua_tcp_resolve_cleanup(void *data)
     u = coctx->data;
     if (u == NULL) {
         return;
+    }
+
+    if (u->socket_pool != NULL) {
+        u->socket_pool->connections--;
+        ngx_http_lua_socket_tcp_resume_conn_op(u->socket_pool);
     }
 
     rctx = u->resolved->ctx;

--- a/src/ngx_http_lua_socket_tcp.h
+++ b/src/ngx_http_lua_socket_tcp.h
@@ -36,15 +36,37 @@ typedef void (*ngx_http_lua_socket_tcp_upstream_handler_pt)
 
 
 typedef struct {
+    ngx_event_t                         event;
+    ngx_queue_t                         queue;
+    ngx_str_t                           host;
+    ngx_http_cleanup_pt                *cleanup;
+    ngx_http_lua_socket_tcp_upstream_t *u;
+    in_port_t                           port;
+} ngx_http_lua_socket_tcp_conn_op_ctx_t;
+
+
+#define ngx_http_lua_socket_tcp_free_conn_op_ctx(conn_op_ctx)                \
+    ngx_free(conn_op_ctx->host.data);                                        \
+    ngx_free(conn_op_ctx)
+
+
+typedef struct {
     lua_State                         *lua_vm;
 
-    /* active connections == out-of-pool reused connections
-     *                       + in-pool connections */
-    ngx_uint_t                         active_connections;
+    ngx_int_t                          size;
+    ngx_queue_t                        cache_connect_op;
+    ngx_queue_t                        wait_connect_op;
+
+    /* connections == active connections + pending connect operations,
+     * while active connections == out-of-pool reused connections
+     *                             + in-pool connections */
+    ngx_int_t                          connections;
 
     /* queues of ngx_http_lua_socket_pool_item_t: */
     ngx_queue_t                        cache;
     ngx_queue_t                        free;
+
+    ngx_int_t                          backlog;
 
     u_char                             key[1];
 
@@ -104,6 +126,7 @@ struct ngx_http_lua_socket_tcp_upstream_s {
     unsigned                         raw_downstream:1;
     unsigned                         read_closed:1;
     unsigned                         write_closed:1;
+    unsigned                         conn_closed:1;
 #if (NGX_HTTP_SSL)
     unsigned                         ssl_verify:1;
     unsigned                         ssl_session_reuse:1;

--- a/t/068-socket-keepalive.t
+++ b/t/068-socket-keepalive.t
@@ -4,13 +4,14 @@ use Test::Nginx::Socket::Lua;
 
 #repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 5 + 9);
+plan tests => repeat_each() * (blocks() * 4 + 33);
 
 our $HtmlDir = html_dir;
 
 $ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
 $ENV{TEST_NGINX_HTML_DIR} = $HtmlDir;
 $ENV{TEST_NGINX_REDIS_PORT} ||= 6379;
+$ENV{TEST_NGINX_RESOLVER} ||= '8.8.8.8';
 
 $ENV{LUA_PATH} ||=
     '/usr/local/openresty-debug/lualib/?.lua;/usr/local/openresty/lualib/?.lua;;';
@@ -701,7 +702,35 @@ qr/lua tcp socket connection pool size: 25\b/]
 
 
 
-=== TEST 10: sock:keepalive_timeout(0) means unlimited
+=== TEST 10: setkeepalive() 'pool_size' should be greater than zero
+--- config
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+        content_by_lua_block {
+            local sock, err = ngx.socket.connect("127.0.0.1", ngx.var.port)
+            if not sock then
+                ngx.say(err)
+                return
+            end
+
+            local ok, err = pcall(sock.setkeepalive, sock, 0, 0)
+            if not ok then
+                ngx.say(err)
+                return
+            end
+            ngx.say(ok)
+        }
+    }
+--- request
+GET /t
+--- response_body
+bad argument #3 to '?' (bad "pool_size" option value: 0)
+--- no_error_log
+[error]
+
+
+
+=== TEST 11: sock:keepalive_timeout(0) means unlimited
 --- config
    server_tokens off;
    location /t {
@@ -776,7 +805,7 @@ qr/lua tcp socket connection pool size: 30\b/]
 
 
 
-=== TEST 11: sanity (uds)
+=== TEST 12: sanity (uds)
 --- http_config eval
 "
     lua_package_path '$::HtmlDir/?.lua;./?.lua';
@@ -858,7 +887,7 @@ received response of 119 bytes
 
 
 
-=== TEST 12: github issue #108: ngx.locaiton.capture + redis.set_keepalive
+=== TEST 13: github issue #108: ngx.locaiton.capture + redis.set_keepalive
 --- http_config eval
     qq{
         lua_package_path "$::HtmlDir/?.lua;;";
@@ -905,7 +934,7 @@ lua tcp socket get keepalive peer: using connection
 
 
 
-=== TEST 13: github issue #110: ngx.exit with HTTP_NOT_FOUND causes worker process to exit
+=== TEST 14: github issue #110: ngx.exit with HTTP_NOT_FOUND causes worker process to exit
 --- http_config eval
     "lua_package_path '$::HtmlDir/?.lua;./?.lua';"
 --- config
@@ -964,7 +993,7 @@ Not found, dear...
 
 
 
-=== TEST 14: custom pools (different pool for the same host:port) - tcp
+=== TEST 15: custom pools (different pool for the same host:port) - tcp
 --- http_config eval
     "lua_package_path '$::HtmlDir/?.lua;./?.lua';"
 --- config
@@ -1012,7 +1041,7 @@ lua tcp socket keepalive create connection pool for key "B"
 
 
 
-=== TEST 15: custom pools (same pool for different host:port) - tcp
+=== TEST 16: custom pools (same pool for different host:port) - tcp
 --- http_config eval
     "lua_package_path '$::HtmlDir/?.lua;./?.lua';"
 --- config
@@ -1059,7 +1088,7 @@ lua tcp socket get keepalive peer: using connection
 
 
 
-=== TEST 16: custom pools (different pool for the same host:port) - unix
+=== TEST 17: custom pools (different pool for the same host:port) - unix
 --- http_config eval
 "
     lua_package_path '$::HtmlDir/?.lua;./?.lua';
@@ -1119,7 +1148,7 @@ lua tcp socket keepalive create connection pool for key "B"
 
 
 
-=== TEST 17: custom pools (same pool for the same path) - unix
+=== TEST 18: custom pools (same pool for the same path) - unix
 --- http_config eval
 "
     lua_package_path '$::HtmlDir/?.lua;./?.lua';
@@ -1174,7 +1203,7 @@ lua tcp socket get keepalive peer: using connection
 
 
 
-=== TEST 18: numeric pool option value
+=== TEST 19: numeric pool option value
 --- http_config eval
     "lua_package_path '$::HtmlDir/?.lua;./?.lua';"
 --- config
@@ -1221,7 +1250,7 @@ lua tcp socket get keepalive peer: using connection
 
 
 
-=== TEST 19: nil pool option value
+=== TEST 20: nil pool option value
 --- http_config eval
     "lua_package_path '$::HtmlDir/?.lua;./?.lua';"
 --- config
@@ -1264,7 +1293,7 @@ connected: 1, reused: 0
 
 
 
-=== TEST 20: (bad) table pool option value
+=== TEST 21: (bad) table pool option value
 --- http_config eval
     "lua_package_path '$::HtmlDir/?.lua;./?.lua';"
 --- config
@@ -1305,7 +1334,7 @@ bad argument #3 to 'connect' (bad "pool" option type: table)
 
 
 
-=== TEST 21: (bad) boolean pool option value
+=== TEST 22: (bad) boolean pool option value
 --- http_config eval
     "lua_package_path '$::HtmlDir/?.lua;./?.lua';"
 --- config
@@ -1346,7 +1375,7 @@ bad argument #3 to 'connect' (bad "pool" option type: boolean)
 
 
 
-=== TEST 22: clear the redis store
+=== TEST 23: clear the redis store
 --- config
     location /t {
         redis2_query flushall;
@@ -1363,7 +1392,7 @@ bad argument #3 to 'connect' (bad "pool" option type: boolean)
 
 
 
-=== TEST 23: bug in send(): clear the chain writer ctx
+=== TEST 24: bug in send(): clear the chain writer ctx
 --- http_config eval
     "lua_package_path '$::HtmlDir/?.lua;./?.lua';"
 --- config
@@ -1478,7 +1507,7 @@ done
 
 
 
-=== TEST 24: setkeepalive() with explicit nil args
+=== TEST 25: setkeepalive() with explicit nil args
 --- config
    server_tokens off;
    location /t {
@@ -1551,3 +1580,1258 @@ done
 "lua tcp socket keepalive timeout: 100 ms",
 qr/lua tcp socket connection pool size: 30\b/]
 --- timeout: 4
+
+
+
+=== TEST 26: conn queuing: connect() verifies the options for connection pool
+--- config
+    location /t {
+        set $port $TEST_NGINX_SERVER_PORT;
+
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            local function check_opts_for_connect(opts)
+                local ok, err = pcall(function()
+                    sock:connect("127.0.0.1", ngx.var.port, opts)
+                end)
+                if not ok then
+                    ngx.say(err)
+                else
+                    ngx.say("ok")
+                end
+            end
+
+            check_opts_for_connect({pool_size = 'a'})
+            check_opts_for_connect({pool_size = 0})
+            check_opts_for_connect({backlog = -1})
+            check_opts_for_connect({backlog = 0})
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+.+ 'connect' \(bad "pool_size" option type: string\)
+.+ 'connect' \(bad "pool_size" option value: 0\)
+.+ 'connect' \(bad "backlog" option value: -1\)
+ok
+--- no_error_log
+[error]
+
+
+
+=== TEST 27: conn queuing: connect() can specify 'pool_size' which overrides setkeepalive()
+--- config
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local function go()
+                local sock = ngx.socket.tcp()
+                local ok, err = sock:connect("127.0.0.1", port, {pool_size = 1})
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok, ", reused: ", sock:getreusedtimes())
+
+                local req = "flush_all\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send request: ", err)
+                    return
+                end
+                ngx.say("request sent: ", bytes)
+
+                local line, err, part = sock:receive()
+                if line then
+                    ngx.say("received: ", line)
+                else
+                    ngx.say("failed to receive a line: ", err, " [", part, "]")
+                end
+
+                local ok, err = sock:setkeepalive(0, 20)
+                if not ok then
+                    ngx.say("failed to set reusable: ", err)
+                end
+            end
+
+            -- reuse ok
+            go()
+            go()
+
+            local sock1 = ngx.socket.connect("127.0.0.1", port)
+            local sock2 = ngx.socket.connect("127.0.0.1", port)
+            local ok, err = sock1:setkeepalive(0, 20)
+            if not ok then
+                ngx.say(err)
+            end
+            local ok, err = sock2:setkeepalive(0, 20)
+            if not ok then
+                ngx.say(err)
+            end
+
+            -- the pool_size is 1 instead of 20
+            sock1 = ngx.socket.connect("127.0.0.1", port)
+            sock2 = ngx.socket.connect("127.0.0.1", port)
+            ngx.say("reused: ", sock1:getreusedtimes())
+            ngx.say("reused: ", sock2:getreusedtimes())
+            sock1:setkeepalive(0, 20)
+            sock2:setkeepalive(0, 20)
+        }
+    }
+--- request
+GET /t
+--- response_body
+connected: 1, reused: 0
+request sent: 11
+received: OK
+connected: 1, reused: 1
+request sent: 11
+received: OK
+reused: 1
+reused: 0
+--- no_error_log eval
+["[error]",
+"lua tcp socket keepalive: free connection pool for ",
+"lua tcp socket connection pool size: 20"]
+--- error_log eval
+[qq{lua tcp socket keepalive create connection pool for key "127.0.0.1:$ENV{TEST_NGINX_MEMCACHED_PORT}"},
+"lua tcp socket connection pool size: 1",
+]
+
+
+
+=== TEST 28: conn queuing: connect() can specify 'pool_size' for unix domain socket
+--- http_config eval
+"
+    server {
+        listen unix:$::HtmlDir/nginx.sock;
+    }
+"
+--- config
+    location /t {
+        content_by_lua_block {
+            local path = "unix:" .. "$TEST_NGINX_HTML_DIR/nginx.sock";
+            local function go()
+                local sock = ngx.socket.tcp()
+                local ok, err = sock:connect(path, {pool_size = 1})
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok, ", reused: ", sock:getreusedtimes())
+
+                local ok, err = sock:setkeepalive(0, 20)
+                if not ok then
+                    ngx.say("failed to set reusable: ", err)
+                end
+            end
+
+            go()
+            go()
+
+            local sock1 = ngx.socket.connect(path)
+            local sock2 = ngx.socket.connect(path)
+            local ok, err = sock1:setkeepalive(0, 20)
+            if not ok then
+                ngx.say(err)
+            end
+            local ok, err = sock2:setkeepalive(0, 20)
+            if not ok then
+                ngx.say(err)
+            end
+
+            -- the pool_size is 1 instead of 20
+            sock1 = ngx.socket.connect(path)
+            sock2 = ngx.socket.connect(path)
+            ngx.say("reused: ", sock1:getreusedtimes())
+            ngx.say("reused: ", sock2:getreusedtimes())
+            sock1:setkeepalive(0, 20)
+            sock2:setkeepalive(0, 20)
+        }
+    }
+--- request
+GET /t
+--- response_body
+connected: 1, reused: 0
+connected: 1, reused: 1
+reused: 1
+reused: 0
+--- no_error_log eval
+["[error]",
+"lua tcp socket keepalive: free connection pool for ",
+"lua tcp socket connection pool size: 20"]
+--- error_log eval
+["lua tcp socket get keepalive peer: using connection",
+'lua tcp socket keepalive create connection pool for key "unix:',
+"lua tcp socket connection pool size: 1",
+]
+
+
+
+=== TEST 29: conn queuing: connect() can specify 'pool_size' for custom pool
+--- config
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local function go(pool)
+                local sock = ngx.socket.tcp()
+                local ok, err = sock:connect("127.0.0.1", port, {pool = pool, pool_size = 1})
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", pool, ", reused: ", sock:getreusedtimes())
+
+                local ok, err = sock:setkeepalive(0, 20)
+                if not ok then
+                    ngx.say("failed to set reusable: ", err)
+                end
+            end
+
+            go('A')
+            go('B')
+            go('A')
+            go('B')
+
+            local sock1 = ngx.socket.connect("127.0.0.1", port, {pool = 'A'})
+            local sock2 = ngx.socket.connect("127.0.0.1", port, {pool = 'A'})
+            local ok, err = sock1:setkeepalive(0, 20)
+            if not ok then
+                ngx.say(err)
+            end
+            local ok, err = sock2:setkeepalive(0, 20)
+            if not ok then
+                ngx.say(err)
+            end
+
+            -- the pool_size is 1 instead of 20
+            sock1 = ngx.socket.connect("127.0.0.1", port, {pool = 'A'})
+            sock2 = ngx.socket.connect("127.0.0.1", port, {pool = 'A'})
+            ngx.say("reused: ", sock1:getreusedtimes())
+            ngx.say("reused: ", sock2:getreusedtimes())
+            sock1:setkeepalive(0, 20)
+            sock2:setkeepalive(0, 20)
+        }
+    }
+--- request
+GET /t
+--- response_body
+connected: A, reused: 0
+connected: B, reused: 0
+connected: A, reused: 1
+connected: B, reused: 1
+reused: 1
+reused: 0
+--- no_error_log eval
+["[error]",
+"lua tcp socket keepalive: free connection pool for ",
+"lua tcp socket connection pool size: 20"]
+--- error_log eval
+[qq{lua tcp socket keepalive create connection pool for key "A"},
+qq{lua tcp socket keepalive create connection pool for key "B"},
+"lua tcp socket connection pool size: 1",
+]
+
+
+
+=== TEST 30: conn queuing: connect() uses lua_socket_pool_size as default if 'backlog' is given
+--- config
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+        lua_socket_pool_size 1234;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local opts = {backlog = 0}
+            local sock, err = ngx.socket.connect("127.0.0.1", port, opts)
+            if not sock then
+                ngx.say(err)
+            else
+                ngx.say("ok")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- error_log
+lua tcp socket connection pool size: 1234
+--- no_error_log
+[error]
+
+
+
+=== TEST 31: conn queuing: more connect operations than 'backlog' size
+--- config
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local opts = {pool_size = 2, backlog = 0}
+            local sock = ngx.socket.connect("127.0.0.1", port, opts)
+            local not_reused_socket, err = ngx.socket.connect("127.0.0.1", port, opts)
+            if not not_reused_socket then
+                ngx.say(err)
+                return
+            end
+            -- burst
+            local ok, err = ngx.socket.connect("127.0.0.1", port, opts)
+            if not ok then
+                ngx.say(err)
+            end
+
+            local ok, err = sock:setkeepalive()
+            if not ok then
+                ngx.say(err)
+                return
+            end
+
+            ok, err = sock:connect("127.0.0.1", port, opts)
+            if not ok then
+                ngx.say(err)
+            end
+            ngx.say("reused: ", sock:getreusedtimes())
+            -- both queue and pool is full
+            ok, err = ngx.socket.connect("127.0.0.1", port, opts)
+            if not ok then
+                ngx.say(err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+too many waiting connect operations
+reused: 1
+too many waiting connect operations
+--- no_error_log
+[error]
+
+
+
+=== TEST 32: conn queuing: once 'pool_size' is reached and pool has 'backlog'
+--- config
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local opts = {pool_size = 2, backlog = 2}
+            local sock1 = ngx.socket.connect("127.0.0.1", port, opts)
+
+            ngx.timer.at(0, function(premature)
+                local sock2, err = ngx.socket.connect("127.0.0.1", port, opts)
+                if not sock2 then
+                    ngx.log(ngx.ERR, err)
+                    return
+                end
+
+                ngx.log(ngx.WARN, "start to handle timer")
+                ngx.sleep(0.1)
+                sock2:close()
+                -- resume connect operation
+                ngx.log(ngx.WARN, "continue to handle timer")
+            end)
+
+            ngx.sleep(0.05)
+            ngx.log(ngx.WARN, "start to handle cosocket")
+            local sock3, err = ngx.socket.connect("127.0.0.1", port, opts)
+            if not sock3 then
+                ngx.say(err)
+                return
+            end
+            ngx.log(ngx.WARN, "continue to handle cosocket")
+
+            local req = "flush_all\r\n"
+            local bytes, err = sock3:send(req)
+            if not bytes then
+                ngx.say("failed to send request: ", err)
+                return
+            end
+            ngx.say("request sent: ", bytes)
+
+            local line, err, part = sock3:receive()
+            if line then
+                ngx.say("received: ", line)
+            else
+                ngx.say("failed to receive a line: ", err, " [", part, "]")
+            end
+
+            local ok, err = sock3:setkeepalive()
+            if not ok then
+                ngx.say("failed to set reusable: ", err)
+            end
+            ngx.say("setkeepalive: OK")
+        }
+    }
+--- request
+GET /t
+--- response_body
+request sent: 11
+received: OK
+setkeepalive: OK
+--- no_error_log
+[error]
+--- error_log
+lua tcp socket queue connect operation for connection pool "127.0.0.1
+--- grep_error_log eval: qr/(start|continue) to handle \w+/
+--- grep_error_log_out
+start to handle timer
+start to handle cosocket
+continue to handle timer
+continue to handle cosocket
+
+
+
+=== TEST 33: conn queuing: do not count failed connect operations
+--- config
+    resolver $TEST_NGINX_RESOLVER ipv6=off;
+    resolver_timeout 3s;
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local opts = {pool = "test", pool_size = 1, backlog = 0}
+
+            local sock = ngx.socket.tcp()
+            sock:settimeouts(100, 3000, 3000)
+            local ok, err = sock:connect("agentzh.org", 12345, opts)
+            if not ok then
+                ngx.say(err)
+            end
+
+            local sock, err = ngx.socket.connect("127.0.0.1", port, opts)
+            if not sock then
+                ngx.say(err)
+            end
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- error_log
+lua tcp socket connect timed out, when connecting to
+--- response_body
+timeout
+ok
+
+
+
+=== TEST 34: conn queuing: connect until backlog is reached
+--- config
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local opts = {pool_size = 1, backlog = 1}
+            local sock1 = ngx.socket.connect("127.0.0.1", port, opts)
+
+            ngx.timer.at(0.01, function(premature)
+                ngx.log(ngx.WARN, "start to handle timer")
+                local sock2, err = ngx.socket.connect("127.0.0.1", port, opts)
+                if not sock2 then
+                    ngx.log(ngx.ERR, err)
+                    return
+                end
+
+                ngx.sleep(0.02)
+                local ok, err = sock2:close()
+                if not ok then
+                    ngx.log(ngx.ERR, err)
+                end
+                ngx.log(ngx.WARN, "continue to handle timer")
+            end)
+
+            ngx.sleep(0.02)
+            local sock3, err = ngx.socket.connect("127.0.0.1", port, opts)
+            if not sock3 then
+                ngx.say(err)
+            end
+            local ok, err = sock1:setkeepalive()
+            if not ok then
+                ngx.say(err)
+                return
+            end
+            ngx.sleep(0.01) -- run sock2
+
+            ngx.log(ngx.WARN, "start to handle cosocket")
+            local sock3, err = ngx.socket.connect("127.0.0.1", port, opts)
+            if not sock3 then
+                ngx.say(err)
+                return
+            end
+            ngx.log(ngx.WARN, "continue to handle cosocket")
+
+            local ok, err = sock3:setkeepalive()
+            if not ok then
+                ngx.say(err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+too many waiting connect operations
+--- no_error_log
+[error]
+--- error_log
+lua tcp socket queue connect operation for connection pool "127.0.0.1
+--- grep_error_log eval: qr/queue connect operation for connection pool|(start|continue) to handle \w+/
+--- grep_error_log_out
+start to handle timer
+queue connect operation for connection pool
+start to handle cosocket
+queue connect operation for connection pool
+continue to handle timer
+continue to handle cosocket
+
+
+
+=== TEST 35: conn queuing: memory reuse for host in queueing connect operation ctx
+--- config
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local opts = {pool = "test", pool_size = 1, backlog = 3}
+            local sock = ngx.socket.connect("127.0.0.1", port, opts)
+
+            ngx.timer.at(0.01, function(premature)
+                local sock, err = ngx.socket.connect("0.0.0.0", port, opts)
+                if not sock then
+                    ngx.log(ngx.ERR, err)
+                    return
+                end
+
+                local ok, err = sock:close()
+                if not ok then
+                    ngx.log(ngx.ERR, err)
+                end
+            end)
+
+            ngx.timer.at(0.015, function(premature)
+                local sock, err = ngx.socket.connect("127.0.0.1", port, opts)
+                if not sock then
+                    ngx.log(ngx.ERR, err)
+                    return
+                end
+
+                local ok, err = sock:close()
+                if not ok then
+                    ngx.log(ngx.ERR, err)
+                end
+            end)
+
+            ngx.timer.at(0.02, function(premature)
+                local sock, err = ngx.socket.connect("0.0.0.0", port, opts)
+                if not sock then
+                    ngx.log(ngx.ERR, err)
+                    return
+                end
+
+                local ok, err = sock:close()
+                if not ok then
+                    ngx.log(ngx.ERR, err)
+                end
+            end)
+
+            ngx.sleep(0.03)
+            local ok, err = sock:setkeepalive()
+            if not ok then
+                ngx.say(err)
+                return
+            end
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- no_error_log
+[error]
+--- grep_error_log eval: qr/queue connect operation for connection pool/
+--- grep_error_log_out
+queue connect operation for connection pool
+queue connect operation for connection pool
+queue connect operation for connection pool
+
+
+
+=== TEST 36: conn queuing: connect() returns error after connect operation resumed
+--- config
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local opts = {pool = "test", pool_size = 1, backlog = 1}
+            local sock = ngx.socket.connect("127.0.0.1", port, opts)
+
+            ngx.timer.at(0, function(premature)
+                local sock, err = ngx.socket.connect("", port, opts)
+                if not sock then
+                    ngx.log(ngx.WARN, err)
+                end
+            end)
+
+            ngx.sleep(0.01)
+            -- use 'close' to force parsing host instead of reusing conn
+            local ok, err = sock:close()
+            if not ok then
+                ngx.say(err)
+                return
+            end
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- no_error_log
+[error]
+--- error_log
+failed to parse host name
+--- grep_error_log eval: qr/queue connect operation for connection pool/
+--- grep_error_log_out
+queue connect operation for connection pool
+
+
+
+=== TEST 37: conn queuing: in uthread
+--- config
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local opts = {pool_size = 1, backlog = 2}
+
+            local conn_sock = function()
+                local sock, err = ngx.socket.connect("127.0.0.1", port, opts)
+                if not sock then
+                    ngx.say(err)
+                    return
+                end
+                ngx.say("start to handle uthread")
+
+                ngx.sleep(0.01)
+                sock:close()
+                ngx.say("continue to handle other uthread")
+            end
+
+            local sock, err = ngx.socket.connect("127.0.0.1", port, opts)
+            if not sock then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local co1 = ngx.thread.spawn(conn_sock)
+            local co2 = ngx.thread.spawn(conn_sock)
+            local co3 = ngx.thread.spawn(conn_sock)
+
+            local ok, err = sock:setkeepalive()
+            if not ok then
+                ngx.log(ngx.ERR, err)
+            end
+
+            ngx.thread.wait(co1)
+            ngx.thread.wait(co2)
+            ngx.thread.wait(co3)
+            ngx.say("all uthreads ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+too many waiting connect operations
+start to handle uthread
+continue to handle other uthread
+start to handle uthread
+continue to handle other uthread
+all uthreads ok
+--- no_error_log
+[error]
+--- grep_error_log eval: qr/queue connect operation for connection pool/
+--- grep_error_log_out
+queue connect operation for connection pool
+queue connect operation for connection pool
+
+
+
+=== TEST 38: conn queuing: in access_by_lua
+--- config
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        access_by_lua_block {
+            local port = ngx.var.port
+            local opts = {pool_size = 1, backlog = 2}
+
+            local conn_sock = function()
+                local sock, err = ngx.socket.connect("127.0.0.1", port, opts)
+                if not sock then
+                    ngx.say(err)
+                    return
+                end
+                ngx.say("start to handle uthread")
+
+                ngx.sleep(0.01)
+                sock:close()
+                ngx.say("continue to handle other uthread")
+            end
+
+            local sock, err = ngx.socket.connect("127.0.0.1", port, opts)
+            if not sock then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local co1 = ngx.thread.spawn(conn_sock)
+            local co2 = ngx.thread.spawn(conn_sock)
+            local co3 = ngx.thread.spawn(conn_sock)
+
+            local ok, err = sock:setkeepalive()
+            if not ok then
+                ngx.log(ngx.ERR, err)
+            end
+
+            ngx.thread.wait(co1)
+            ngx.thread.wait(co2)
+            ngx.thread.wait(co3)
+            ngx.say("all uthreads ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+too many waiting connect operations
+start to handle uthread
+continue to handle other uthread
+start to handle uthread
+continue to handle other uthread
+all uthreads ok
+--- no_error_log
+[error]
+--- grep_error_log eval: qr/queue connect operation for connection pool/
+--- grep_error_log_out
+queue connect operation for connection pool
+queue connect operation for connection pool
+
+
+
+=== TEST 39: conn queuing: in rewrite_by_lua
+--- config
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        rewrite_by_lua_block {
+            local port = ngx.var.port
+            local opts = {pool_size = 1, backlog = 2}
+
+            local conn_sock = function()
+                local sock, err = ngx.socket.connect("127.0.0.1", port, opts)
+                if not sock then
+                    ngx.say(err)
+                    return
+                end
+                ngx.say("start to handle uthread")
+
+                ngx.sleep(0.01)
+                sock:close()
+                ngx.say("continue to handle other uthread")
+            end
+
+            local sock, err = ngx.socket.connect("127.0.0.1", port, opts)
+            if not sock then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local co1 = ngx.thread.spawn(conn_sock)
+            local co2 = ngx.thread.spawn(conn_sock)
+            local co3 = ngx.thread.spawn(conn_sock)
+
+            local ok, err = sock:setkeepalive()
+            if not ok then
+                ngx.log(ngx.ERR, err)
+            end
+
+            ngx.thread.wait(co1)
+            ngx.thread.wait(co2)
+            ngx.thread.wait(co3)
+            ngx.say("all uthreads ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+too many waiting connect operations
+start to handle uthread
+continue to handle other uthread
+start to handle uthread
+continue to handle other uthread
+all uthreads ok
+--- no_error_log
+[error]
+--- grep_error_log eval: qr/queue connect operation for connection pool/
+--- grep_error_log_out
+queue connect operation for connection pool
+queue connect operation for connection pool
+
+
+
+=== TEST 40: conn queuing: in subrequest
+--- config
+    set $port $TEST_NGINX_MEMCACHED_PORT;
+
+    location /t {
+        content_by_lua_block {
+            local port = ngx.var.port
+            ngx.timer.at(0, function()
+                local opts = {pool_size = 1, backlog = 2}
+                local sock, err = ngx.socket.connect("127.0.0.1", port, opts)
+                if not sock then
+                    ngx.log(ngx.ERR, err)
+                    return
+                end
+
+                ngx.sleep(0.1)
+                local ok, err = sock:setkeepalive()
+                if not ok then
+                    ngx.log(ngx.ERR, err)
+                end
+            end)
+
+            ngx.sleep(0.01)
+            local res1, res2, res3 = ngx.location.capture_multi{
+                {"/conn"}, {"/conn"}, {"/conn"}
+            }
+            ngx.say(res1.body)
+            ngx.say(res2.body)
+            ngx.say(res3.body)
+        }
+    }
+
+    location /conn {
+        content_by_lua_block {
+            local port = ngx.var.port
+            local sock, err = ngx.socket.connect("127.0.0.1", port)
+            if not sock then
+                ngx.print(err)
+                return
+            end
+            local ok, err = sock:setkeepalive()
+            if not ok then
+                ngx.print(err)
+            else
+                ngx.print("ok")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+ok
+too many waiting connect operations
+--- no_error_log
+[error]
+--- grep_error_log eval: qr/queue connect operation for connection pool/
+--- grep_error_log_out
+queue connect operation for connection pool
+queue connect operation for connection pool
+
+
+
+=== TEST 41: conn queuing: timeouts when 'connect_timeout' is reached
+--- config
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local opts = {pool_size = 1, backlog = 1}
+            local sock1 = ngx.socket.connect("127.0.0.1", port, opts)
+
+            local sock2 = ngx.socket.tcp()
+            sock2:settimeouts(10, 3000, 3000)
+            local ok, err = sock2:connect("127.0.0.1", port, opts)
+            if not ok then
+                ngx.say(err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+timeout
+--- error_log eval
+"lua tcp socket queued connect timed out, when trying to connect to 127.0.0.1:$ENV{TEST_NGINX_MEMCACHED_PORT}"
+
+
+
+=== TEST 42: conn queuing: set timeout via lua_socket_connect_timeout
+--- config
+    lua_socket_connect_timeout 10ms;
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local opts = {pool_size = 1, backlog = 1}
+            local sock1 = ngx.socket.connect("127.0.0.1", port, opts)
+
+            local sock2 = ngx.socket.tcp()
+            local ok, err = sock2:connect("127.0.0.1", port, opts)
+            if not ok then
+                ngx.say(err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+timeout
+--- error_log eval
+"lua tcp socket queued connect timed out, when trying to connect to 127.0.0.1:$ENV{TEST_NGINX_MEMCACHED_PORT}"
+
+
+
+=== TEST 43: conn queuing: client aborting while connect operation is queued
+--- config
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local opts = {pool_size = 1, backlog = 1}
+            local sock1 = ngx.socket.connect("127.0.0.1", port, opts)
+
+            local sock2 = ngx.socket.tcp()
+            sock2:settimeouts(3000, 3000, 3000)
+            local ok, err = sock2:connect("127.0.0.1", port, opts)
+            if not ok then
+                ngx.say(err)
+            end
+        }
+    }
+--- request
+GET /t
+--- ignore_response
+--- timeout: 0.1
+--- abort
+--- no_error_log
+[error]
+
+
+
+=== TEST 44: conn queuing: resume next connect operation if resumed connect failed immediately
+--- config
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local opts = {pool = "test", pool_size = 1, backlog = 2}
+
+            local conn_sock = function(should_timeout)
+                local sock = ngx.socket.tcp()
+                local ok, err
+                if should_timeout then
+                    ok, err = sock:connect("", port, opts)
+                else
+                    ok, err = sock:connect("127.0.0.1", port, opts)
+                end
+                if not ok then
+                    ngx.say(err)
+                    return
+                end
+                ngx.say("connected in uthread")
+                sock:close()
+            end
+
+            local sock, err = ngx.socket.connect("127.0.0.1", port, opts)
+            if not sock then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local co1 = ngx.thread.spawn(conn_sock, true)
+            local co2 = ngx.thread.spawn(conn_sock)
+
+            local ok, err = sock:close()
+            if not ok then
+                ngx.log(ngx.ERR, err)
+            end
+
+            ngx.thread.wait(co1)
+            ngx.thread.wait(co2)
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+failed to parse host name "": no host
+connected in uthread
+ok
+--- no_error_log
+[error]
+
+
+
+=== TEST 45: conn queuing: resume connect operation if resumed connect failed (timeout)
+--- config
+    resolver $TEST_NGINX_RESOLVER ipv6=off;
+    resolver_timeout 3s;
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local opts = {pool = "test", pool_size = 1, backlog = 1}
+
+            local conn_sock = function(should_timeout)
+                local sock = ngx.socket.tcp()
+                local ok, err
+                if should_timeout then
+                    sock:settimeouts(100, 3000, 3000)
+                    ok, err = sock:connect("agentzh.org", 12345, opts)
+                else
+                    ok, err = sock:connect("127.0.0.1", port, opts)
+                end
+                if not ok then
+                    ngx.say(err)
+                    return
+                end
+                ngx.say("connected in uthread")
+                sock:close()
+            end
+
+            local co1 = ngx.thread.spawn(conn_sock, true)
+            local co2 = ngx.thread.spawn(conn_sock)
+
+            ngx.thread.wait(co1)
+            ngx.thread.wait(co2)
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+timeout
+connected in uthread
+ok
+--- error_log
+queue connect operation for connection pool "test"
+lua tcp socket connect timed out, when connecting to
+
+
+
+=== TEST 46: conn queuing: resume connect operation if resumed connect failed (could not be resolved)
+--- config
+    resolver 127.0.0.1 ipv6=off;
+    resolver_timeout 100ms;
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local opts = {pool = "test", pool_size = 1, backlog = 1}
+
+            local conn_sock = function(should_timeout)
+                local sock = ngx.socket.tcp()
+                local ok, err
+                if should_timeout then
+                    sock:settimeouts(100, 3000, 3000)
+                    ok, err = sock:connect("agentzh.org", 12345, opts)
+                else
+                    ok, err = sock:connect("127.0.0.1", port, opts)
+                end
+                if not ok then
+                    ngx.say(err)
+                    return
+                end
+                ngx.say("connected in uthread")
+                sock:close()
+            end
+
+            local co1 = ngx.thread.spawn(conn_sock, true)
+            local co2 = ngx.thread.spawn(conn_sock)
+
+            ngx.thread.wait(co1)
+            ngx.thread.wait(co2)
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+agentzh.org could not be resolved (110: Operation timed out)
+connected in uthread
+ok
+--- error_log
+queue connect operation for connection pool "test"
+
+
+
+=== TEST 47: conn queuing: resume connect operation if resumed connect failed (connection refused)
+--- config
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            local port = ngx.var.port
+            local opts = {pool = "test", pool_size = 1, backlog = 1}
+
+            local conn_sock = function(should_timeout)
+                local sock = ngx.socket.tcp()
+                local ok, err
+                if should_timeout then
+                    sock:settimeouts(100, 3000, 3000)
+                    ok, err = sock:connect("127.0.0.1", 62345, opts)
+                else
+                    ok, err = sock:connect("127.0.0.1", port, opts)
+                end
+                if not ok then
+                    ngx.say(err)
+                    return
+                end
+                ngx.say("connected in uthread")
+                sock:close()
+            end
+
+            local co1 = ngx.thread.spawn(conn_sock, true)
+            local co2 = ngx.thread.spawn(conn_sock)
+
+            ngx.thread.wait(co1)
+            ngx.thread.wait(co2)
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+connection refused
+connected in uthread
+ok
+--- error_log
+queue connect operation for connection pool "test"
+
+
+
+=== TEST 48: conn queuing: resume connect operation if resumed connect failed (uthread aborted while resolving)
+--- http_config
+    lua_package_path '../lua-resty-core/lib/?.lua;../lua-resty-lrucache/lib/?.lua;;';
+--- config
+    resolver 127.0.0.1 ipv6=off;
+    resolver_timeout 100s;
+    set $port $TEST_NGINX_MEMCACHED_PORT;
+
+    location /sub {
+        content_by_lua_block {
+            local semaphore = require "ngx.semaphore"
+            local sem = semaphore.new()
+
+            local function f()
+                sem:wait(0.1)
+                ngx.exit(0)
+            end
+
+            local opts = {pool = "test", pool_size = 1, backlog = 1}
+            local port = ngx.var.port
+            ngx.timer.at(0, function()
+                sem:post()
+                local sock2, err = ngx.socket.connect("127.0.0.1", port, opts)
+                package.loaded.for_timer_to_resume:post()
+                if not sock2 then
+                    ngx.log(ngx.ALERT, "resume connect failed: ", err)
+                    return
+                end
+
+                ngx.log(ngx.INFO, "resume success")
+            end)
+
+            ngx.thread.spawn(f)
+            local sock1, err = ngx.socket.connect("openresty.org", 80, opts)
+            if not sock1 then
+                ngx.say(err)
+                return
+            end
+        }
+    }
+
+    location /t {
+        content_by_lua_block {
+            local semaphore = require "ngx.semaphore"
+            local for_timer_to_resume = semaphore.new()
+            package.loaded.for_timer_to_resume = for_timer_to_resume
+
+            ngx.location.capture("/sub")
+            for_timer_to_resume:wait(0.1)
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[alert]
+--- error_log
+resume success
+
+
+
+=== TEST 49: conn queuing: resume connect operation if resumed connect failed (uthread killed while resolving)
+--- config
+    resolver 127.0.0.1 ipv6=off;
+    resolver_timeout 100s;
+    set $port $TEST_NGINX_MEMCACHED_PORT;
+
+    location /t {
+        content_by_lua_block {
+            local opts = {pool = "test", pool_size = 1, backlog = 1}
+            local port = ngx.var.port
+
+            local function resolve()
+                local sock1, err = ngx.socket.connect("openresty.org", 80, opts)
+                if not sock1 then
+                    ngx.say(err)
+                    return
+                end
+            end
+
+            local th = ngx.thread.spawn(resolve)
+            local ok, err = ngx.thread.kill(th)
+            if not ok then
+                ngx.log(ngx.ALERT, "kill thread failed: ", err)
+                return
+            end
+
+            local sock2, err = ngx.socket.connect("127.0.0.1", port, opts)
+            if not sock2 then
+                ngx.log(ngx.ALERT, "resume connect failed: ", err)
+                return
+            end
+
+            ngx.log(ngx.INFO, "resume success")
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[alert]
+--- error_log
+resume success


### PR DESCRIPTION
Now we could pass 'pool_size' and 'backlog' options in connect method to
specify the pool size and the queue size of connection pool.

When there is more connect operations than the pool_size, new connect
operation will be queued until former connect operation fails or
connection finalizes.

When there is more queueing connect operations than the backlog, new
connect operation will be dropped.

This pr also migrated connection pool creation to connect method.
Note that the meaning of `active_connections` is changed from the previous
setkeepalive mechanism. The connection pool is destroyed only if all related
connections closed now.

The implementation of tcp cosocket is quite complex, therefore both strict
code review and extreme testing are required before merging this feature into
master.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
