### PR TITLE
change the type of shdict expire to uint64

### DIFF
--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -2212,7 +2212,7 @@ ngx_http_lua_find_zone(u_char *name_data, size_t name_len)
 int
 ngx_http_lua_ffi_shdict_store(ngx_shm_zone_t *zone, int op, u_char *key,
     size_t key_len, int value_type, u_char *str_value_buf,
-    size_t str_value_len, double num_value, int exptime, int user_flags,
+    size_t str_value_len, double num_value, uint64_t exptime, int user_flags,
     char **errmsg, int *forcible)
 {
     int                          i, n;


### PR DESCRIPTION
when use the new shdict api in resty/core，the expire may not process correctly，it use type int to story expire but not uint64 as before。when the expire is large，for example 10000000，it goes wrong。I also change the function in resty.core.shdict

