### PR TITLE
feature: Add api to fetch raw nginx ssl pointer

### DIFF
--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -1319,6 +1319,17 @@ failed:
 }
 
 
+ngx_ssl_conn_t *
+ngx_http_lua_ffi_get_ssl_pointer(ngx_http_request_t *r)
+{
+    if (r->connection == NULL || r->connection->ssl == NULL) {
+        return NULL;
+    }
+
+    return r->connection->ssl->connection;
+}
+
+
 #endif  /* NGX_LUA_NO_FFI_API */
 
 

--- a/t/140-ssl-c-api.t
+++ b/t/140-ssl-c-api.t
@@ -57,6 +57,8 @@ ffi.cdef[[
     int ngx_http_lua_ffi_set_priv_key(void *r,
         void *cdata, char **err);
 
+    void *ngx_http_lua_ffi_get_ssl_pointer(void *r);
+
     void ngx_http_lua_ffi_free_cert(void *cdata);
 
     void ngx_http_lua_ffi_free_priv_key(void *cdata);
@@ -807,6 +809,126 @@ close: 1 nil
 
 --- error_log
 lua ssl server name: "test.com"
+
+--- no_error_log
+[error]
+[alert]
+
+
+
+=== TEST 6: Raw SSL pointer
+--- http_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+
+        ssl_certificate_by_lua_block {
+            collectgarbage()
+
+            local ffi = require "ffi"
+            require "defines"
+
+            local r = getfenv(0).__ngx_req
+            if not r then
+                ngx.log(ngx.ERR, "no request found")
+                return
+            end
+
+            local ssl = ffi.C.ngx_http_lua_ffi_get_ssl_pointer(r);
+            if ssl == nil then
+                ngx.log(ngx.ERR, "failed to retrieve SSL*")
+                return
+            end
+
+            ffi.cdef[[
+                const char *SSL_get_servername(const void *, const int);
+            ]]
+            local libssl = ffi.load "ssl"
+            local TLSEXT_NAMETYPE_host_name = 0
+            local sni = ffi.string(libssl.SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name))
+            ngx.log(ngx.INFO, "SNI is ", sni)
+        }
+
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block { ngx.status = 201 ngx.say("foo") ngx.exit(201) }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /foo HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to receive response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+sent http request: 56 bytes.
+received: HTTP/1.1 201 Created
+received: Server: nginx
+received: Content-Type: text/plain
+received: Content-Length: 4
+received: Connection: close
+received: 
+received: foo
+close: 1 nil
+
+--- error_log
+SNI is test.com
 
 --- no_error_log
 [error]


### PR DESCRIPTION
This allows introspection of the `SSL*` object from lua code.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
