### PR TITLE
style: replace ngx_http_parse_time with ngx_parse_http_time

### DIFF
--- a/src/ngx_http_lua_headers_out.c
+++ b/src/ngx_http_lua_headers_out.c
@@ -415,7 +415,7 @@ static ngx_int_t ngx_http_set_last_modified_header(ngx_http_request_t *r,
         return ngx_http_clear_last_modified_header(r, hv, value);
     }
 
-    r->headers_out.last_modified_time = ngx_http_parse_time(value->data,
+    r->headers_out.last_modified_time = ngx_parse_http_time(value->data,
                                                             value->len);
 
     dd("last modified time: %d", (int) r->headers_out.last_modified_time);

--- a/src/ngx_http_lua_time.c
+++ b/src/ngx_http_lua_time.c
@@ -172,7 +172,7 @@ ngx_http_lua_ngx_parse_http_time(lua_State *L)
 
     p = (u_char *) luaL_checklstring(L, 1, &len);
 
-    time = ngx_http_parse_time(p, len);
+    time = ngx_parse_http_time(p, len);
     if (time == NGX_ERROR) {
         lua_pushnil(L);
         return 1;
@@ -340,8 +340,8 @@ void
 ngx_http_lua_ffi_parse_http_time(const u_char *str, size_t len,
     long *time)
 {
-    /* ngx_http_parse_time doesn't modify 'str' actually */
-    *time = ngx_http_parse_time((u_char *) str, len);
+    /* ngx_parse_http_time doesn't modify 'str' actually */
+    *time = ngx_parse_http_time((u_char *) str, len);
 }
 #endif /* NGX_LUA_NO_FFI_API */
 


### PR DESCRIPTION
The former is a compatibility definition for the latter introduced in Nginx 8b6fa4842133. Both uses are in place in the codebase; for consistency let's just use the function definition to keep things aligned.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
