### PR TITLE
optimize: removed a duplicated include directive in ngx_http_lua_regex.c

### DIFF
--- a/src/ngx_http_lua_regex.c
+++ b/src/ngx_http_lua_regex.c
@@ -15,7 +15,6 @@
 #include "ngx_http_lua_regex.h"
 #include "ngx_http_lua_pcrefix.h"
 #include "ngx_http_lua_script.h"
-#include "ngx_http_lua_pcrefix.h"
 #include "ngx_http_lua_util.h"
 
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

Sister PR at https://github.com/openresty/meta-lua-nginx-module/pull/42