### PR TITLE
optimize: don't calculate hash when clearing the header.

### DIFF
--- a/src/ngx_http_lua_headers_out.c
+++ b/src/ngx_http_lua_headers_out.c
@@ -485,7 +485,10 @@ ngx_http_lua_set_output_header(ngx_http_request_t *r, ngx_str_t key,
 
     dd("set header value: %.*s", (int) value.len, value.data);
 
-    hv.hash = ngx_hash_key_lc(key.data, key.len);
+    if (value.len > 0) {
+        hv.hash = ngx_hash_key_lc(key.data, key.len);
+    }
+
     hv.key = key;
 
     hv.offset = 0;

--- a/src/ngx_http_lua_headers_out.c
+++ b/src/ngx_http_lua_headers_out.c
@@ -487,6 +487,9 @@ ngx_http_lua_set_output_header(ngx_http_request_t *r, ngx_str_t key,
 
     if (value.len > 0) {
         hv.hash = ngx_hash_key_lc(key.data, key.len);
+
+    } else {
+        hv.hash = 0;
     }
 
     hv.key = key;


### PR DESCRIPTION
The `hash` will be set to `0` later when clearing the header. By saving the extra hash operation we could save the cost of `ngx.header.HEADER = nil` by 10%.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
