### PR TITLE
optimize: don't calculate hash when clearing the request header.

### DIFF
--- a/src/ngx_http_lua_headers_in.c
+++ b/src/ngx_http_lua_headers_in.c
@@ -664,7 +664,10 @@ ngx_http_lua_set_input_header(ngx_http_request_t *r, ngx_str_t key,
 
     dd("set header value: %.*s", (int) value.len, value.data);
 
-    hv.hash = ngx_hash_key_lc(key.data, key.len);
+    if (value.len > 0) {
+        hv.hash = ngx_hash_key_lc(key.data, key.len);
+    }
+
     hv.key = key;
 
     hv.offset = 0;

--- a/src/ngx_http_lua_headers_in.c
+++ b/src/ngx_http_lua_headers_in.c
@@ -666,6 +666,9 @@ ngx_http_lua_set_input_header(ngx_http_request_t *r, ngx_str_t key,
 
     if (value.len > 0) {
         hv.hash = ngx_hash_key_lc(key.data, key.len);
+
+    } else {
+        hv.hash = 0;
     }
 
     hv.key = key;


### PR DESCRIPTION
This pr is similar with #1318, but for clearing request header. Save the cost by more than 10%.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
