### PR TITLE
bugfix: when variable is cacheable and indexed, setting the request

### DIFF
--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -227,6 +227,8 @@ struct ngx_http_lua_main_conf_s {
     ngx_int_t            busy_buf_ptr_count;
 #endif
 
+    ngx_int_t            host_index;
+
     unsigned             requires_header_filter:1;
     unsigned             requires_body_filter:1;
     unsigned             requires_capture_filter:1;

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -227,7 +227,7 @@ struct ngx_http_lua_main_conf_s {
     ngx_int_t            busy_buf_ptr_count;
 #endif
 
-    ngx_int_t            host_index;
+    ngx_int_t            host_var_index;
 
     unsigned             requires_header_filter:1;
     unsigned             requires_body_filter:1;

--- a/src/ngx_http_lua_headers_in.c
+++ b/src/ngx_http_lua_headers_in.c
@@ -433,8 +433,8 @@ ngx_http_set_host_header(ngx_http_request_t *r, ngx_http_lua_header_val_t *hv,
     ngx_str_t *value)
 {
     ngx_str_t                    host;
-    ngx_http_variable_value_t   *var;
     ngx_http_lua_main_conf_t    *lmcf;
+    ngx_http_variable_value_t   *var;
 
     dd("server new value len: %d", (int) value->len);
 
@@ -453,13 +453,8 @@ ngx_http_set_host_header(ngx_http_request_t *r, ngx_http_lua_header_val_t *hv,
         r->headers_in.server = *value;
     }
 
-    var = ngx_http_get_indexed_variable(r, lmcf->host_index);
-    if (var == NULL) {
-        return NGX_ERROR;
-    }
-
-    /* force next lookup of $host to re-evaluate */
-    var->valid = 0;
+    var = &r->variables[lmcf->host_index];
+    var->valid = var->not_found = 0;
 
     return ngx_http_set_builtin_header(r, hv, value);
 }

--- a/src/ngx_http_lua_headers_in.c
+++ b/src/ngx_http_lua_headers_in.c
@@ -453,8 +453,9 @@ ngx_http_set_host_header(ngx_http_request_t *r, ngx_http_lua_header_val_t *hv,
         r->headers_in.server = *value;
     }
 
-    var = &r->variables[lmcf->host_index];
-    var->valid = var->not_found = 0;
+    var = &r->variables[lmcf->host_var_index];
+    var->valid = 0;
+    var->not_found = 0;
 
     return ngx_http_set_builtin_header(r, hv, value);
 }

--- a/src/ngx_http_lua_headers_in.c
+++ b/src/ngx_http_lua_headers_in.c
@@ -432,9 +432,13 @@ static ngx_int_t
 ngx_http_set_host_header(ngx_http_request_t *r, ngx_http_lua_header_val_t *hv,
     ngx_str_t *value)
 {
-    ngx_str_t host;
+    ngx_str_t                    host;
+    ngx_http_variable_value_t   *var;
+    ngx_http_lua_main_conf_t    *lmcf;
 
     dd("server new value len: %d", (int) value->len);
+
+    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
 
     if (value->len) {
         host= *value;
@@ -448,6 +452,14 @@ ngx_http_set_host_header(ngx_http_request_t *r, ngx_http_lua_header_val_t *hv,
     } else {
         r->headers_in.server = *value;
     }
+
+    var = ngx_http_get_indexed_variable(r, lmcf->host_index);
+    if (var == NULL) {
+        return NGX_ERROR;
+    }
+
+    /* force next lookup of $host to re-evaluate */
+    var->valid = 0;
 
     return ngx_http_set_builtin_header(r, hv, value);
 }

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -642,8 +642,8 @@ ngx_http_lua_init(ngx_conf_t *cf)
 
     lmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_lua_module);
 
-    lmcf->host_index = ngx_http_get_variable_index(cf, &name);
-    if (lmcf->host_index == NGX_ERROR) {
+    lmcf->host_var_index = ngx_http_get_variable_index(cf, &name);
+    if (lmcf->host_var_index == NGX_ERROR) {
         return NGX_ERROR;
     }
 

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -638,8 +638,14 @@ ngx_http_lua_init(ngx_conf_t *cf)
 #if !defined(NGX_LUA_NO_FFI_API) || nginx_version >= 1011011
     ngx_pool_cleanup_t         *cln;
 #endif
+    ngx_str_t                   name = ngx_string("host");
 
     lmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_lua_module);
+
+    lmcf->host_index = ngx_http_get_variable_index(cf, &name);
+    if (lmcf->host_index == NGX_ERROR) {
+        return NGX_ERROR;
+    }
 
     if (ngx_http_lua_prev_cycle != ngx_cycle) {
         ngx_http_lua_prev_cycle = ngx_cycle;

--- a/t/028-req-header.t
+++ b/t/028-req-header.t
@@ -8,7 +8,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (2 * blocks() + 43);
+plan tests => repeat_each() * (2 * blocks() + 42);
 
 #no_diff();
 no_long_string();
@@ -2007,4 +2007,26 @@ found 3 headers.
 --- timeout: 4
 --- no_error_log
 lua exceeding request header limit
+[error]
+
+
+
+=== TEST 61: setting Host header clears cached $host variable
+--- config
+    location /req-header {
+        # this makes $host indexed and cacheable
+        set $foo $host;
+
+        content_by_lua_block {
+            ngx.say(ngx.var.host)
+            ngx.req.set_header("Host", "new");
+            ngx.say(ngx.var.host)
+        }
+    }
+--- request
+GET /req-header
+--- response_body
+localhost
+new
+--- no_error_log
 [error]

--- a/t/028-req-header.t
+++ b/t/028-req-header.t
@@ -8,7 +8,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (2 * blocks() + 42);
+plan tests => repeat_each() * (2 * blocks() + 44);
 
 #no_diff();
 no_long_string();


### PR DESCRIPTION
"Host" header should clear any existing cached $host variable value so
that subsequent read returns expected result.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
