### PR TITLE
bugfix: populate conf file name when running init_worker_by_lua*

### DIFF
--- a/src/ngx_http_lua_initworkerby.c
+++ b/src/ngx_http_lua_initworkerby.c
@@ -166,6 +166,13 @@ ngx_http_lua_init_worker(ngx_cycle_t *cycle)
     conf.pool = fake_cycle->pool;
     conf.log = cycle->log;
 
+    conf.conf_file = ngx_pcalloc(cycle->pool, sizeof(ngx_conf_file_t));
+    if (conf.conf_file == NULL) {
+        goto failed;
+    }
+
+    conf.conf_file->file.name = cycle->conf_file;
+
     http_ctx.loc_conf = ngx_pcalloc(conf.pool,
                                     sizeof(void *) * ngx_http_max_module);
     if (http_ctx.loc_conf == NULL) {


### PR DESCRIPTION
As of NGINX 1.15.0, it is required to populate this field, because it
is used by the HTTP core module.

Otherwise OpenResty crashes when executing the init_worker_by_lua*
callbacks.

Fixes #1348.

---

I'm not 100% sure this is the correct fix. There might be a way to avoid allocating the `ngx_conf_file_t` by reusing it from somewhere else, but I couldn't find one.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
