### PR TITLE
bugfix: a segmentation fault might occur when SSL renegotiation happens

### DIFF
--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -201,6 +201,20 @@ ngx_http_lua_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
 
     c = ngx_ssl_get_connection(ssl_conn);
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+
+#if !defined SSL_OP_NO_RENEGOTIATION || nginx_version < 1015002
+
+    if (c->ssl->renegotiation) {
+        ngx_log_error(NGX_LOG_WARN, c->log, 0,
+                      "lua_certificate_by_lua: SSL renegotiation refused");
+        return 0;
+    }
+
+#endif
+
+#endif
+
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
                    "ssl cert: connection reusable: %ud", c->reusable);
 


### PR DESCRIPTION
Please see #1354 for more details.

Since it is tough to distinguish whether current connection is upgraded
to HTTP/2 in the ngx_http_lua_ssl_cert_handler context. This PR just
returns 0 (marks failed) when SSL renegotiation happens. Nginx already
prohibited the SSL renegotiation, so it is safe.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
