### PR TITLE
fetch keealive peer from last instead of head

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -4902,7 +4902,7 @@ ngx_http_lua_get_keepalive_peer(ngx_http_request_t *r, lua_State *L,
     u->socket_pool = spool;
 
     if (!ngx_queue_empty(&spool->cache)) {
-        q = ngx_queue_head(&spool->cache);
+        q = ngx_queue_last(&spool->cache);
 
         item = ngx_queue_data(q, ngx_http_lua_socket_pool_item_t, queue);
         c = item->connection;


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
In most cases, the expiration time at the last of the queue should be less than that at the head of the queue, so we should give priority to getting peers from the last of the queue to prevent too many expired items.
