### PR TITLE
bugfix: silenced -Wcast-function-type warnings

### DIFF
--- a/src/ngx_http_lua_script.c
+++ b/src/ngx_http_lua_script.c
@@ -329,7 +329,7 @@ ngx_http_lua_script_add_copy_code(ngx_http_lua_script_compile_t *sc,
         return NGX_ERROR;
     }
 
-    code->code = (ngx_http_lua_script_code_pt)
+    code->code = (ngx_http_lua_script_code_pt) (void *)
                  ngx_http_lua_script_copy_len_code;
     code->len = len;
 
@@ -399,7 +399,7 @@ ngx_http_lua_script_add_capture_code(ngx_http_lua_script_compile_t *sc,
         return NGX_ERROR;
     }
 
-    code->code = (ngx_http_lua_script_code_pt)
+    code->code = (ngx_http_lua_script_code_pt) (void *)
                  ngx_http_lua_script_copy_capture_len_code;
     code->n = 2 * n;
 


### PR DESCRIPTION
Cast to intermediate "void *" to lose compiler knowledge about the original
type and pass the warning. This is not a real fix but rather a workaround.

This fixes compilation with GCC 8.

Original fix from NGINX:
https://trac.nginx.org/nginx/changeset/9e25a5380a21240cdb66646f1e20ef7247b646a1

Fixes #1357.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
