### PR TITLE
change: avoided running any init_by_lua* code inside signaller process and when testing Nginx configuration.

### DIFF
--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -647,6 +647,10 @@ ngx_http_lua_init(ngx_conf_t *cf)
 #endif
     ngx_str_t                   name = ngx_string("host");
 
+    if (ngx_process == NGX_PROCESS_SIGNALLER || ngx_test_config) {
+        return NGX_OK;
+    }
+
     lmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_lua_module);
 
     lmcf->host_var_index = ngx_http_get_variable_index(cf, &name);

--- a/t/160-disable-init-by-lua.t
+++ b/t/160-disable-init-by-lua.t
@@ -5,6 +5,7 @@ repeat_each(2);
 plan tests => repeat_each() * (blocks() * 2);
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+
 my $html_dir = $ENV{TEST_NGINX_HTML_DIR};
 my $http_config = <<_EOC_;
     init_by_lua_block {
@@ -15,16 +16,15 @@ my $http_config = <<_EOC_;
                 }
                 http {
                     init_by_lua_block {
-                        -- if the code in the init_by_lua* is run, there
-                        -- will be a string contains the 'error'
                         ngx.log(ngx.ERR, "run init_by_lua")
                     }
                 }
             ]]
 
             assert(os.execute("mkdir -p $html_dir/logs"))
+
             local conf_file = "$html_dir/nginx.conf"
-            local f, err = io.open(conf_file, 'w')
+            local f, err = io.open(conf_file, "w")
             if not f then
                 ngx.log(ngx.ERR, err)
                 return
@@ -53,10 +53,9 @@ add_block_preprocessor(sub {
     if (!defined $block->request) {
         $block->set_value("request", "GET /t");
     }
-
 });
 
-log_level("debug");
+log_level("warn");
 no_long_string();
 run_tests();
 
@@ -76,7 +75,7 @@ __DATA__
                 return
             end
 
-            local out, err = p:read('*a')
+            local out, err = p:read("*a")
             if not out then
                 ngx.log(ngx.ERR, err)
 
@@ -86,11 +85,11 @@ __DATA__
         }
     }
 --- no_error_log eval
-qr/\[error\] .+ (?!:nginx.pid" failed \(2: No such file or directory\))$/
+qr/\[error\] .*? init_by_lua:\d+: run init_by_lua/
 
 
 
-=== TEST 2: ensure init_by_lua* is not run when testing Nginx configuration
+=== TEST 2: init_by_lua* does not run when testing Nginx configuration
 --- config
     location = /t {
         content_by_lua_block {
@@ -104,7 +103,7 @@ qr/\[error\] .+ (?!:nginx.pid" failed \(2: No such file or directory\))$/
                 return
             end
 
-            local out, err = p:read('*a')
+            local out, err = p:read("*a")
             if not out then
                 ngx.log(ngx.ERR, err)
 
@@ -119,7 +118,7 @@ qr/\[error\] .+ (?!:nginx.pid" failed \(2: No such file or directory\))$/
                 return
             end
 
-            local out, err = p:read('*a')
+            local out, err = p:read("*a")
             if not out then
                 ngx.log(ngx.ERR, err)
 
@@ -128,5 +127,5 @@ qr/\[error\] .+ (?!:nginx.pid" failed \(2: No such file or directory\))$/
             end
         }
     }
---- no_error_log
-[error]
+--- no_error_log eval
+qr/\[error\] .*? init_by_lua:\d+: run init_by_lua/

--- a/t/160-disable-init-by-lua.t
+++ b/t/160-disable-init-by-lua.t
@@ -1,0 +1,132 @@
+use Test::Nginx::Socket::Lua;
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 2);
+
+$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+my $html_dir = $ENV{TEST_NGINX_HTML_DIR};
+my $http_config = <<_EOC_;
+    init_by_lua_block {
+        function set_up_ngx_tmp_conf()
+            local conf = [[
+                events {
+                    worker_connections 64;
+                }
+                http {
+                    init_by_lua_block {
+                        -- if the code in the init_by_lua* is run, there
+                        -- will be a string contains the 'error'
+                        ngx.log(ngx.ERR, "run init_by_lua")
+                    }
+                }
+            ]]
+
+            assert(os.execute("mkdir -p $html_dir/logs"))
+            local conf_file = "$html_dir/nginx.conf"
+            local f, err = io.open(conf_file, 'w')
+            if not f then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            assert(f:write(conf))
+
+            return conf_file
+        end
+
+        function get_ngx_bin_path()
+            local ffi = require "ffi"
+            ffi.cdef[[char **ngx_argv;]]
+            return ffi.string(ffi.C.ngx_argv[0])
+        end
+    }
+_EOC_
+
+add_block_preprocessor(sub {
+    my $block = shift;
+
+    if (!defined $block->http_config) {
+        $block->set_value("http_config", $http_config);
+    }
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+});
+
+log_level("debug");
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: ensure init_by_lua* is not run in signaller process
+--- config
+    location = /t {
+        content_by_lua_block {
+            local conf_file = set_up_ngx_tmp_conf()
+            local nginx = get_ngx_bin_path()
+
+            local cmd = nginx .. " -p $TEST_NGINX_HTML_DIR -c " .. conf_file .. " -s reopen"
+            local p, err = io.popen(cmd)
+            if not p then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local out, err = p:read('*a')
+            if not out then
+                ngx.log(ngx.ERR, err)
+
+            else
+                ngx.log(ngx.WARN, out)
+            end
+        }
+    }
+--- no_error_log eval
+qr/\[error\] .+ (?!:nginx.pid" failed \(2: No such file or directory\))$/
+
+
+
+=== TEST 2: ensure init_by_lua* is not run when testing Nginx configuration
+--- config
+    location = /t {
+        content_by_lua_block {
+            local conf_file = set_up_ngx_tmp_conf()
+            local nginx = get_ngx_bin_path()
+
+            local cmd = nginx .. " -p $TEST_NGINX_HTML_DIR -c " .. conf_file .. " -t"
+            local p, err = io.popen(cmd)
+            if not p then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local out, err = p:read('*a')
+            if not out then
+                ngx.log(ngx.ERR, err)
+
+            else
+                ngx.log(ngx.WARN, out)
+            end
+
+            local cmd = nginx .. " -p $TEST_NGINX_HTML_DIR -c " .. conf_file .. " -T"
+            local p, err = io.popen(cmd)
+            if not p then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local out, err = p:read('*a')
+            if not out then
+                ngx.log(ngx.ERR, err)
+
+            else
+                ngx.log(ngx.WARN, out)
+            end
+        }
+    }
+--- no_error_log
+[error]


### PR DESCRIPTION
Previously, when Nginx is run as a signaller like `nginx -p . -s stop`, the code in `init_by_lua*` will be executed. Now this probably unexpected behavior is avoided.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
