### PR TITLE
misc: updated _G write guard message to be more accurate.

### DIFF
--- a/t/001-set.t
+++ b/t/001-set.t
@@ -613,9 +613,9 @@ GET /lua
 \z
 --- no_error_log
 [error]
---- grep_error_log eval: qr/(old foo: \d+|write to the lua global variable '\w+')/
+--- grep_error_log eval: qr/(old foo: \d+|writing a global lua variable \('\w+'\))/
 --- grep_error_log_out eval
-["write to the lua global variable 'foo'\n", "old foo: 1\n"]
+["writing a global lua variable \('foo'\)\n", "old foo: 1\n"]
 
 
 

--- a/t/158-global-var.t
+++ b/t/158-global-var.t
@@ -60,9 +60,9 @@ __DATA__
 --- response_body_like chomp
 \A[12]\n\z
 --- grep_error_log eval
-qr/(old foo: \d+|\[\w+\].*?http lua attempting to write to the lua global variable '[^'\s]+'|set_by_lua:\d+: in main chunk, )/
+qr/(old foo: \d+|\[\w+\].*?writing a global lua variable \('[^'\s]+'\)|set_by_lua:\d+: in main chunk, )/
 --- grep_error_log_out eval
-[qr/\A\[warn\] .*?http lua attempting to write to the lua global variable 'foo'
+[qr/\A\[warn\] .*?writing a global lua variable \('foo'\)
 set_by_lua:3: in main chunk, \n\z/, "old foo: 1\n"]
 
 
@@ -83,9 +83,9 @@ set_by_lua:3: in main chunk, \n\z/, "old foo: 1\n"]
 --- response_body_like chomp
 \A[12]\n\z
 --- grep_error_log eval
-qr/(old foo: \d+|\[\w+\].*?http lua attempting to write to the lua global variable '[^'\s]+'|\w+_by_lua\(.*?\):\d+: in main chunk, )/
+qr/(old foo: \d+|\[\w+\].*?writing a global lua variable \('[^'\s]+'\)|\w+_by_lua\(.*?\):\d+: in main chunk, )/
 --- grep_error_log_out eval
-[qr/\A\[warn\] .*?http lua attempting to write to the lua global variable 'foo'
+[qr/\A\[warn\] .*?writing a global lua variable \('foo'\)
 rewrite_by_lua\(nginx\.conf:48\):3: in main chunk, \n\z/, "old foo: 1\n"]
 
 
@@ -106,9 +106,9 @@ rewrite_by_lua\(nginx\.conf:48\):3: in main chunk, \n\z/, "old foo: 1\n"]
 --- response_body_like chomp
 \A[12]\n\z
 --- grep_error_log eval
-qr/(old foo: \d+|\[\w+\].*?http lua attempting to write to the lua global variable '[^'\s]+'|\w+_by_lua\(.*?\):\d+: in main chunk, )/
+qr/(old foo: \d+|\[\w+\].*?writing a global lua variable \('[^'\s]+'\)|\w+_by_lua\(.*?\):\d+: in main chunk, )/
 --- grep_error_log_out eval
-[qr/\A\[warn\] .*?http lua attempting to write to the lua global variable 'foo'
+[qr/\A\[warn\] .*?writing a global lua variable \('foo'\)
 access_by_lua\(nginx\.conf:48\):3: in main chunk, \n\z/, "old foo: 1\n"]
 
 
@@ -129,9 +129,9 @@ access_by_lua\(nginx\.conf:48\):3: in main chunk, \n\z/, "old foo: 1\n"]
 --- response_body_like chomp
 \A[12]\n\z
 --- grep_error_log eval
-qr/(old foo: \d+|\[\w+\].*?http lua attempting to write to the lua global variable '[^'\s]+'|\w+_by_lua\(.*?\):\d+: in main chunk, )/
+qr/(old foo: \d+|\[\w+\].*?writing a global lua variable \('[^'\s]+'\)|\w+_by_lua\(.*?\):\d+: in main chunk, )/
 --- grep_error_log_out eval
-[qr/\A\[warn\] .*?http lua attempting to write to the lua global variable 'foo'
+[qr/\A\[warn\] .*?writing a global lua variable \('foo'\)
 content_by_lua\(nginx\.conf:48\):3: in main chunk, \n\z/, "old foo: 1\n"]
 
 
@@ -154,9 +154,9 @@ content_by_lua\(nginx\.conf:48\):3: in main chunk, \n\z/, "old foo: 1\n"]
 --- response_body_like chomp
 \A(?:nil|1)\n\z
 --- grep_error_log eval
-qr/(old foo: \d+|\[\w+\].*?http lua attempting to write to the lua global variable '[^'\s]+'|\w+_by_lua:\d+: in main chunk, )/
+qr/(old foo: \d+|\[\w+\].*?writing a global lua variable \('[^'\s]+'\)|\w+_by_lua:\d+: in main chunk, )/
 --- grep_error_log_out eval
-[qr/\A\[warn\] .*?http lua attempting to write to the lua global variable 'foo'
+[qr/\A\[warn\] .*?writing a global lua variable \('foo'\)
 header_filter_by_lua:3: in main chunk, \n\z/, "old foo: 1\n"]
 
 
@@ -179,9 +179,9 @@ header_filter_by_lua:3: in main chunk, \n\z/, "old foo: 1\n"]
 --- response_body_like chomp
 \A(?:nil|2)\n\z
 --- grep_error_log eval
-qr/(old foo: \d+|\[\w+\].*?http lua attempting to write to the lua global variable '[^'\s]+'|\w+_by_lua:\d+: in main chunk, )/
+qr/(old foo: \d+|\[\w+\].*?writing a global lua variable \('[^'\s]+'\)|\w+_by_lua:\d+: in main chunk, )/
 --- grep_error_log_out eval
-[qr/\[warn\] .*?http lua attempting to write to the lua global variable 'foo'
+[qr/\[warn\] .*?writing a global lua variable \('foo'\)
 body_filter_by_lua:3: in main chunk, 
 old foo: 1\n\z/, "old foo: 2\nold foo: 3\n"]
 
@@ -204,9 +204,9 @@ old foo: 1\n\z/, "old foo: 2\nold foo: 3\n"]
 --- response_body_like chomp
 \A(?:nil|1)\n\z
 --- grep_error_log eval
-qr/(old foo: \d+|\[\w+\].*?http lua attempting to write to the lua global variable '[^'\s]+'|\w+_by_lua\(.*?\):\d+: in main chunk)/
+qr/(old foo: \d+|\[\w+\].*?writing a global lua variable \('[^'\s]+'\)|\w+_by_lua\(.*?\):\d+: in main chunk)/
 --- grep_error_log_out eval
-[qr/\A\[warn\] .*?http lua attempting to write to the lua global variable 'foo'
+[qr/\A\[warn\] .*?writing a global lua variable \('foo'\)
 log_by_lua\(nginx\.conf:50\):3: in main chunk\n\z/, "old foo: 1\n"]
 
 
@@ -297,9 +297,9 @@ log_by_lua\(nginx\.conf:50\):3: in main chunk\n\z/, "old foo: 1\n"]
 --- response_body_like chomp
 \A[12]done\n\z
 --- grep_error_log eval
-qr/(old foo: \d+|\[\w+\].*?http lua attempting to write to the lua global variable '[^'\s]+'|\w+_by_lua:\d+: in main chunk)/
+qr/(old foo: \d+|\[\w+\].*?writing a global lua variable \('[^'\s]+'\)|\w+_by_lua:\d+: in main chunk)/
 --- grep_error_log_out eval
-[qr/\A\[warn\] .*?http lua attempting to write to the lua global variable 'foo'
+[qr/\A\[warn\] .*?writing a global lua variable \('foo'\)
 ssl_certificate_by_lua:3: in main chunk\n\z/, "old foo: 1\n"]
 
 
@@ -329,9 +329,9 @@ ssl_certificate_by_lua:3: in main chunk\n\z/, "old foo: 1\n"]
 --- response_body_like chomp
 \A[12]\n\z
 --- grep_error_log eval
-qr/(old foo: \d+|\[\w+\].*?http lua attempting to write to the lua global variable '[^'\s]+'|\w+_by_lua\(.*?\):\d+: in\b)/
+qr/(old foo: \d+|\[\w+\].*?writing a global lua variable \('[^'\s]+'\)|\w+_by_lua\(.*?\):\d+: in\b)/
 --- grep_error_log_out eval
-[qr/\A\[warn\] .*?http lua attempting to write to the lua global variable 'foo'
+[qr/\A\[warn\] .*?writing a global lua variable \('foo'\)
 content_by_lua\(nginx\.conf:56\):4: in\n\z/, "old foo: 1\n"]
 
 
@@ -478,9 +478,9 @@ setting global variable
 --- response_body_like chomp
 \A[12]\n\z
 --- grep_error_log eval
-qr/(old foo: \d+|write to the lua global variable '\w+')/
+qr/(old foo: \d+|writing a global lua variable \('\w+'\))/
 --- grep_error_log_out eval
-["write to the lua global variable 'foo'\n", "old foo: 1\n"]
+["writing a global lua variable \('foo'\)\n", "old foo: 1\n"]
 
 
 
@@ -505,6 +505,6 @@ qr/(old foo: \d+|write to the lua global variable '\w+')/
 --- error_code: 502
 --- error_log eval
 qr/\[crit\].*?\Qconnect() to 0.0.0.1:80 failed\E/
---- grep_error_log eval: qr/(old foo: \d+|write to the lua global variable '\w+')/
+--- grep_error_log eval: qr/(old foo: \d+|writing a global lua variable \('\w+'\))/
 --- grep_error_log_out eval
-["write to the lua global variable 'foo'\n", "old foo: 1\n"]
+["writing a global lua variable \('foo'\)\n", "old foo: 1\n"]


### PR DESCRIPTION
> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

* more appropriate message ("writing" instead of "attempting to")
* remove http/lua prefix (`ngx.log` will inject `[lua]` and `stream [lua]`
  already)
* remove unused cached global
* cache `tostring` global locally
