### PR TITLE
bugfix: ngx.process: process.type() didn't return 'master' in master …

### DIFF
--- a/src/ngx_http_lua_worker.c
+++ b/src/ngx_http_lua_worker.c
@@ -153,6 +153,8 @@ ngx_http_lua_ffi_master_pid(void)
 int
 ngx_http_lua_ffi_get_process_type(void)
 {
+    ngx_core_conf_t  *ccf;
+
 #if defined(HAVE_PRIVILEGED_PROCESS_PATCH) && !NGX_WIN32
     if (ngx_process == NGX_PROCESS_HELPER) {
         if (ngx_is_privileged_agent) {
@@ -160,6 +162,15 @@ ngx_http_lua_ffi_get_process_type(void)
         }
     }
 #endif
+
+    if (ngx_process == NGX_PROCESS_SINGLE) {
+        ccf = (ngx_core_conf_t *) ngx_get_conf(ngx_cycle->conf_ctx,
+                                               ngx_core_module);
+
+        if (ccf->master) {
+            return NGX_PROCESS_MASTER;
+        }
+    }
 
     return ngx_process;
 }


### PR DESCRIPTION
…process.

Previously, process.type() always returned 'single' in master process
despite whether Nginx is running in single process mode or not.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
