### PR TITLE
Clarify ngx.timer.every callback argument conventions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7977,6 +7977,9 @@ Similar to the [ngx.timer.at](#ngxtimerat) API function, but
 1. `delay` *cannot* be zero,
 1. timer will be created every `delay` seconds until the current Nginx worker process starts exiting.
 
+Like [ngx.timer.at](#ngxtimerat), the `callback` argument will be called
+automatically with the arguments `premature`, `user_arg1`, `user_arg2`, etc.
+
 When success, returns a "conditional true" value (but not a `true`). Otherwise, returns a "conditional false" value and a string describing the error.
 
 This API also respect the [lua_max_pending_timers](#lua_max_pending_timers) and [lua_max_running_timers](#lua_max_running_timers).


### PR DESCRIPTION
I hereby grant the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

------

We recently implemented a new `ngx.timer.every` timer in our codebase and didn't realize that the calling conventions of `ngx.timer.every`'s callback also include the `premature` argument. When we were implementing the feature, we actually interpreted the docs such that we thought `premature` was only used for `at` timers.

Here's a quick clarification to those docs to make clear that the way the `callback` is called is the same as for `ngx.timer.at`.