### PR TITLE
tests: require: hardened lua_path and lua_cpath regexes.

### DIFF
--- a/t/004-require.t
+++ b/t/004-require.t
@@ -85,7 +85,7 @@ hello, foo
 --- request
 GET /main
 --- user_files
---- response_body_like: ^[^;]+/servroot/html/\?.so$
+--- response_body_like: ^[^;]+/servroot/html/\?\.so$
 
 
 
@@ -100,7 +100,7 @@ GET /main
     }
 --- request
 GET /main
---- response_body_like: ^[^;]+/servroot/html/\?.lua;.+\.lua;$
+--- response_body_like: ^[^;]+/servroot/html/\?\.lua;(.+\.lua)?;*$
 
 
 
@@ -115,7 +115,7 @@ GET /main
     }
 --- request
 GET /main
---- response_body_like: ^[^;]+/servroot/html/\?.so;.+\.so;$
+--- response_body_like: ^[^;]+/servroot/html/\?\.so;(.+\.so)?;*$
 
 
 
@@ -130,7 +130,7 @@ GET /main
     }
 --- request
 GET /main
---- response_body_like: ^.+\.lua;[^;]+/servroot/html/\?.lua$
+--- response_body_like: ^(.+\.lua)?;*?[^;]+/servroot/html/\?\.lua$
 
 
 
@@ -145,7 +145,7 @@ GET /main
     }
 --- request
 GET /main
---- response_body_like: ^.+\.so;[^;]+/servroot/html/\?.so$
+--- response_body_like: ^(.+\.so)?;*?[^;]+/servroot/html/\?\.so$
 
 
 


### PR DESCRIPTION
> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

Those regexes used to not play nice with existing `LUA_PATH` and `LUA_CPATH` environment variables, especially empty path segments `;;` (which can happen anywhere in those paths) or in cases where those variables are empty (in which case `;;` is left unchanged from the specified `lua_package_*path`). We also made the regexes slightly more robust in other subtle ways.