### PR TITLE
bugfix: the lightuserdata mask was broken in WIN64.

### DIFF
--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -140,7 +140,7 @@ typedef struct {
 #endif
 
 
-#if (NGX_PTR_SIZE >= 8)
+#if (NGX_PTR_SIZE >= 8 && !defined(_WIN64))
 #define ngx_http_lua_lightudata_mask(ludata)                                 \
     ((void *) ((uintptr_t) (&ngx_http_lua_##ludata) & ((1UL << 47) - 1)))
 


### PR DESCRIPTION
In WIN64, the pointer type is 64 bits but the long type is 32 bits.
Since WIN64 only supports x64 and IA64, we could confirm that it doesn't
need the mask.

If we need the mask in the future, we might need to use a C compiler
which supports C99 (like MSVC 2013+ or any other modern C compiler) to build
the WIN64 version.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
