### PR TITLE
Generalise shared-dict argument error message

### DIFF
--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -470,7 +470,7 @@ ngx_http_lua_shdict_get_helper(lua_State *L, int get_stale)
 
     if (n != 2) {
         return luaL_error(L, "expecting exactly two arguments, "
-                          "but only seen %d", n);
+                          "but received %d", n);
     }
 
     if (lua_type(L, 1) != LUA_TTABLE) {


### PR DESCRIPTION
Have reworded the error message for the lua_shared_dict directive to ensure there is no confusion when there are more than 2 arguments passed into it. 
The confusion here was around the use of the word 'only' which suggests you have received less arguments than required amount, however when passed 3 or more this causes the error message to become confusing.
```
failed to run set_by_lua*: set_by_lua:3: expecting exactly two arguments, but only seen 3
```
Have replaced, 'only seen' with 'received' to ensure that the error message is more generic and doesnt lead to confusion when reading the message.

I hereby grant the copyright of the changes in this pull request to the authors of the lua-nginx-module project.
