### PR TITLE
change: avoided generating Content-Type header when getting response …

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4147,25 +4147,6 @@ to be returned when reading `ngx.header.Foo`.
 
 Note that `ngx.header` is not a normal Lua table and as such, it is not possible to iterate through it using the Lua `ipairs` function.
 
-Note: if the current response does not have a Content-Type header, but you use
-`ngx.header` to attempt retrieving it, a side effect will be that a
-Content-Type header will be created and returned according to your nginx
-configuration.
-
-For example:
-
-```nginx
-
- location = /t {
-     default_type text/html;
-     content_by_lua_block {
-         -- even if the response had no Content-Type header,
-         -- it will now have: Content-Type: text/html
-         ngx.say(ngx.header['Content-Type'])
-     }
- }
-```
-
 For reading *request* headers, use the [ngx.req.get_headers](#ngxreqget_headers) function instead.
 
 [Back to TOC](#nginx-api-for-lua)
@@ -4189,24 +4170,6 @@ Returns a Lua table holding all the current response headers for the current req
  for k, v in pairs(h) do
      ...
  end
-```
-
-Note: if the current response does not have a Content-Type header, but you use
-`ngx.resp.get_headers` to attempt retrieving it, a side effect will
-be that a Content-Type header will be created and returned according to your
-nginx configuration.
-
-For example:
-
-```nginx
-
- location = /t {
-     default_type text/html;
-     content_by_lua_block {
-         -- the Content-Type header will be text/html
-         ngx.say(ngx.resp.get_headers()['Content-Type'])
-     }
- }
 ```
 
 This function has the same signature as [ngx.req.get_headers](#ngxreqget_headers) except getting response headers instead of request headers.

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -3433,24 +3433,6 @@ to be returned when reading <code>ngx.header.Foo</code>.
 
 Note that <code>ngx.header</code> is not a normal Lua table and as such, it is not possible to iterate through it using the Lua <code>ipairs</code> function.
 
-Note: if the current response does not have a Content-Type header, but you use
-<code>ngx.header</code> to attempt retrieving it, a side effect will be that a
-Content-Type header will be created and returned according to your nginx
-configuration.
-
-For example:
-
-<geshi lang="nginx">
-    location = /t {
-        default_type text/html;
-        content_by_lua_block {
-            -- even if the response had no Content-Type header,
-            -- it will now have: Content-Type: text/html
-            ngx.say(ngx.header['Content-Type'])
-        }
-    }
-</geshi>
-
 For reading ''request'' headers, use the [[#ngx.req.get_headers|ngx.req.get_headers]] function instead.
 
 == ngx.resp.get_headers ==
@@ -3470,23 +3452,6 @@ end
 for k, v in pairs(h) do
     ...
 end
-</geshi>
-
-Note: if the current response does not have a Content-Type header, but you use
-<code>ngx.resp.get_headers</code>, a side effect will be that a Content-Type
-header will be created and returned according to your nginx configuration.
-
-For example:
-
-<geshi lang="nginx">
-    location = /t {
-        default_type text/html;
-        content_by_lua_block {
-            -- even if the response had no Content-Type header,
-            -- it will now have: Content-Type: text/html
-            ngx.say(ngx.resp.get_headers()['Content-Type'])
-        }
-    }
 </geshi>
 
 This function has the same signature as [[#ngx.req.get_headers|ngx.req.get_headers]] except getting response headers instead of request headers.

--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -505,7 +505,6 @@ ngx_http_lua_ngx_resp_get_headers(lua_State *L)
     ngx_table_elt_t    *header;
     ngx_http_request_t *r;
     ngx_http_lua_ctx_t *ctx;
-    ngx_int_t           rc;
     u_char             *lowcase_key = NULL;
     size_t              lowcase_key_sz = 0;
     ngx_uint_t          i;
@@ -560,17 +559,6 @@ ngx_http_lua_ngx_resp_get_headers(lua_State *L)
                               headers_metatable_key));
         lua_rawget(L, LUA_REGISTRYINDEX);
         lua_setmetatable(L, -2);
-    }
-
-    if (!r->headers_out.content_type.len) {
-        rc = ngx_http_lua_set_content_type(r, ctx);
-        if (rc != NGX_OK) {
-            return luaL_error(L,
-                              "failed to set default content type: %d",
-                              (int) rc);
-        }
-
-        ctx->headers_set = 1;
     }
 
 #if 1
@@ -1405,21 +1393,12 @@ ngx_http_lua_ffi_get_resp_header(ngx_http_request_t *r,
         break;
 
     case 12:
-        if (ngx_strncasecmp(key_buf, (u_char *) "Content-Type", 12) == 0) {
-            if (!r->headers_out.content_type.len) {
-                if (ngx_http_lua_set_content_type(r, ctx) != NGX_OK) {
-                    *errmsg = "failed to set default content type";
-                    return NGX_ERROR;
-                }
-
-                ctx->headers_set = 1;
-            }
-
-            if (r->headers_out.content_type.len) {
-                values[0].data = r->headers_out.content_type.data;
-                values[0].len = r->headers_out.content_type.len;
-                return 1;
-            }
+        if (ngx_strncasecmp(key_buf, (u_char *) "Content-Type", 12) == 0
+            && r->headers_out.content_type.len)
+        {
+            values[0].data = r->headers_out.content_type.data;
+            values[0].len = r->headers_out.content_type.len;
+            return 1;
         }
 
         break;

--- a/src/ngx_http_lua_headers_out.c
+++ b/src/ngx_http_lua_headers_out.c
@@ -536,7 +536,6 @@ ngx_http_lua_get_output_header(lua_State *L, ngx_http_request_t *r,
 {
     ngx_table_elt_t            *h;
     ngx_list_part_t            *part;
-    ngx_int_t                   rc;
     ngx_uint_t                  i;
     unsigned                    found;
 
@@ -555,23 +554,12 @@ ngx_http_lua_get_output_header(lua_State *L, ngx_http_request_t *r,
         break;
 
     case 12:
-        if (ngx_strncasecmp(key->data, (u_char *) "Content-Type", 12) == 0) {
-            if (r->headers_out.content_type.len == 0) {
-                rc = ngx_http_lua_set_content_type(r, ctx);
-                if (rc != NGX_OK) {
-                    return luaL_error(L,
-                                      "failed to set default content type: %d",
-                                      (int) rc);
-                }
-
-                ctx->headers_set = 1;
-            }
-
-            if (r->headers_out.content_type.len) {
-                lua_pushlstring(L, (char *) r->headers_out.content_type.data,
-                                r->headers_out.content_type.len);
-                return 1;
-            }
+        if (ngx_strncasecmp(key->data, (u_char *) "Content-Type", 12) == 0
+            && r->headers_out.content_type.len)
+        {
+            lua_pushlstring(L, (char *) r->headers_out.content_type.data,
+                            r->headers_out.content_type.len);
+            return 1;
         }
 
         break;


### PR DESCRIPTION
…headers.

The previous behavior assumed that Nginx will always generate the
Content-Type header if it is missing.
However, in some cases, like the upstream response doesn't have the Content-Type
header, Nginx will not generate the Content-Type header. So generating
Content-Type header when getting response headers may create an unexpected
Content-Type header in the response.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
