### PR TITLE
improve: supported the link response header

### DIFF
--- a/src/ngx_http_lua_headers_out.c
+++ b/src/ngx_http_lua_headers_out.c
@@ -106,6 +106,14 @@ static ngx_http_lua_set_header_t  ngx_http_lua_set_handlers[] = {
                  offsetof(ngx_http_headers_out_t, cache_control),
                  ngx_http_set_builtin_multi_header },
 
+#if nginx_version >= 1013010
+
+    { ngx_string("Link"),
+                 offsetof(ngx_http_headers_out_t, link),
+                 ngx_http_set_builtin_multi_header },
+
+#endif
+
     { ngx_null_string, 0, ngx_http_set_header }
 };
 


### PR DESCRIPTION
Since Nginx/1.13.10. The `Link` header was treated as a common header and
equipped with a shortcut pointer (`r->headers_out.link`). Currently this module doesn't
follow this behavior. Consequently, `Link` header set by this module
(e.g. in `header_filter_by_lua*`) cannot be referenced from
`r->headers_out.link`.  It may cause some inconsistent problems. For instance,
the HTTP/2 server push preload option, see #1458 for details.

This Commit placed the Link header inside `ngx_http_lua_set_handlers[]`.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
