### PR TITLE
bugfix: avoided running init_by_lua* when test Nginx configuration wh…

### DIFF
--- a/src/ngx_http_lua_api.c
+++ b/src/ngx_http_lua_api.c
@@ -195,7 +195,7 @@ ngx_http_lua_shared_memory_init(ngx_shm_zone_t *shm_zone, void *data)
     lmcf->shm_zones_inited++;
 
     if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts
-        && lmcf->init_handler)
+        && lmcf->init_handler && !ngx_test_config)
     {
         saved_cycle = ngx_cycle;
         ngx_cycle = ctx->cycle;

--- a/t/160-disable-init-by-lua.t
+++ b/t/160-disable-init-by-lua.t
@@ -9,17 +9,19 @@ $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 my $html_dir = $ENV{TEST_NGINX_HTML_DIR};
 my $http_config = <<_EOC_;
     init_by_lua_block {
-        function set_up_ngx_tmp_conf()
-            local conf = [[
-                events {
-                    worker_connections 64;
-                }
-                http {
-                    init_by_lua_block {
-                        ngx.log(ngx.ERR, "run init_by_lua")
+        function set_up_ngx_tmp_conf(conf)
+            if conf == nil then
+                conf = [[
+                    events {
+                        worker_connections 64;
                     }
-                }
-            ]]
+                    http {
+                        init_by_lua_block {
+                            ngx.log(ngx.ERR, "run init_by_lua")
+                        }
+                    }
+                ]]
+            end
 
             assert(os.execute("mkdir -p $html_dir/logs"))
 
@@ -129,3 +131,57 @@ qr/\[error\] .*? init_by_lua:\d+: run init_by_lua/
     }
 --- no_error_log eval
 qr/\[error\] .*? init_by_lua:\d+: run init_by_lua/
+
+
+
+=== TEST 3: init_by_lua* does not run when testing Nginx configuration which contains 'lua_shared_dict' (GitHub #1462)
+--- config
+    location = /t {
+        content_by_lua_block {
+            local conf = [[
+                events {
+                    worker_connections 64;
+                }
+                http {
+                    lua_shared_dict test 64k;
+                    init_by_lua_block {
+                        ngx.log(ngx.ERR, "run init_by_lua with lua_shared_dict")
+                    }
+                }
+            ]]
+            local conf_file = set_up_ngx_tmp_conf(conf)
+            local nginx = get_ngx_bin_path()
+
+            local cmd = nginx .. " -p $TEST_NGINX_HTML_DIR -c " .. conf_file .. " -t"
+            local p, err = io.popen(cmd)
+            if not p then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local out, err = p:read("*a")
+            if not out then
+                ngx.log(ngx.ERR, err)
+
+            else
+                ngx.log(ngx.WARN, out)
+            end
+
+            local cmd = nginx .. " -p $TEST_NGINX_HTML_DIR -c " .. conf_file .. " -T"
+            local p, err = io.popen(cmd)
+            if not p then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local out, err = p:read("*a")
+            if not out then
+                ngx.log(ngx.ERR, err)
+
+            else
+                ngx.log(ngx.WARN, out)
+            end
+        }
+    }
+--- no_error_log eval
+qr/\[error\] .*? init_by_lua:\d+: run init_by_lua with lua_shared_dict/


### PR DESCRIPTION
…ich contains lua_shared_dict directive.

In commit 7c2b58e, we avoided running init_by_lua* in signaller processes
and when testing the Nginx configuration. However, when the Nginx
configuration contains lua_shared_dict directive, the execution of
init_by_lua* will be postponded when testing the configuration.
This case was not handled and led to the segmentation fault reported in
GitHub issue #1462.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
