### PR TITLE
tests: t/160-disable-init-by-lua.t: hardened test suite to prevent false positives.

### DIFF
--- a/t/160-disable-init-by-lua.t
+++ b/t/160-disable-init-by-lua.t
@@ -2,7 +2,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 2);
+plan tests => repeat_each() * (blocks() * 3);
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 
@@ -57,6 +57,7 @@ add_block_preprocessor(sub {
     }
 });
 
+env_to_nginx("PATH");
 log_level("warn");
 no_long_string();
 run_tests();
@@ -86,6 +87,8 @@ __DATA__
             end
         }
     }
+--- error_log
+failed (2: No such file or directory)
 --- no_error_log eval
 qr/\[error\] .*? init_by_lua:\d+: run init_by_lua/
 
@@ -129,6 +132,8 @@ qr/\[error\] .*? init_by_lua:\d+: run init_by_lua/
             end
         }
     }
+--- error_log
+test is successful
 --- no_error_log eval
 qr/\[error\] .*? init_by_lua:\d+: run init_by_lua/
 
@@ -183,5 +188,7 @@ qr/\[error\] .*? init_by_lua:\d+: run init_by_lua/
             end
         }
     }
+--- error_log
+test is successful
 --- no_error_log eval
 qr/\[error\] .*? init_by_lua:\d+: run init_by_lua with lua_shared_dict/


### PR DESCRIPTION
The test cases was not testing the result of the `nginx -t/-T/reopen`
commands, and was thus not catching the segfault regression fixed by
055bb17, only that the string `run init_by_lua` was not present.

We avoid testing the exit code due to incompatibilities between Lua
versions in the os.execute/io.popen APIs.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
