### PR TITLE
bugfix: inlined Lua code snippets in nginx.conf failed to use the Lua…

### DIFF
--- a/src/ngx_http_lua_cache.c
+++ b/src/ngx_http_lua_cache.c
@@ -156,7 +156,8 @@ ngx_http_lua_cache_loadbuffer(ngx_log_t *log, lua_State *L,
 
     n = lua_gettop(L);
 
-    dd("XXX cache key: [%s]", cache_key);
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0,
+                   "looking up Lua code cache with key '%s'", cache_key);
 
     rc = ngx_http_lua_cache_load_code(log, L, (char *) cache_key);
     if (rc == NGX_OK) {
@@ -240,7 +241,8 @@ ngx_http_lua_cache_loadfile(ngx_log_t *log, lua_State *L,
         dd("CACHE file key already pre-calculated");
     }
 
-    dd("XXX cache key for file: [%s]", cache_key);
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0,
+                   "looking up Lua code cache with key '%s'", cache_key);
 
     rc = ngx_http_lua_cache_load_code(log, L, (char *) cache_key);
     if (rc == NGX_OK) {

--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -1304,11 +1304,12 @@ ngx_http_lua_gen_chunk_name(ngx_conf_t *cf, const char *tag, size_t tag_len,
 
 found:
 
-    ngx_snprintf(out, len, "=%*s(%*s:%d)%Z",
-                 tag_len, tag, cf->conf_file->file.name.data
-                               + cf->conf_file->file.name.len - p,
-                 p, cf->conf_file->line);
-    *chunkname_len = len;
+    p = ngx_snprintf(out, len, "=%*s(%*s:%d)%Z",
+                     tag_len, tag, cf->conf_file->file.name.data
+                     + cf->conf_file->file.name.len - p,
+                     p, cf->conf_file->line);
+
+    *chunkname_len = p - out - 1;  /* exclude the trailing '\0' byte */
 
     return out;
 }

--- a/t/025-codecache.t
+++ b/t/025-codecache.t
@@ -4,7 +4,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * 155;
+plan tests => repeat_each() * 163;
 
 #$ENV{LUA_PATH} = $ENV{HOME} . '/work/JSON4Lua-0.9.30/json/?.lua';
 
@@ -1244,3 +1244,133 @@ qr/\[alert\] \S+ lua_code_cache is off; this will hurt performance/,
 "decrementing the reference count for Lua VM: 1",
 "lua close the global Lua VM",
 ]
+
+
+
+=== TEST 32: make sure inline code keys are correct
+GitHub issue #1428
+--- config
+include ../html/a/proxy.conf;
+include ../html/b/proxy.conf;
+include ../html/c/proxy.conf;
+
+location /t {
+    echo_location /a/;
+    echo_location /b/;
+    echo_location /a/;
+    echo_location /c/;
+}
+
+--- user_files
+>>> a/proxy.conf
+location /a/ {
+    content_by_lua_block { ngx.say("/a/ is called") }
+}
+
+>>> b/proxy.conf
+location /b/ {
+    content_by_lua_block { ngx.say("/b/ is called") }
+}
+
+>>> c/proxy.conf
+location /c/ {
+    content_by_lua_block { ngx.say("/b/ is called") }
+}
+
+--- request
+GET /t
+--- response_body
+/a/ is called
+/b/ is called
+/a/ is called
+/b/ is called
+--- grep_error_log eval: qr/looking up Lua code cache with key '.*?'/
+--- grep_error_log_out eval
+[
+"looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_3c7137b8371d10bc148c8f8bb3042ee6'
+looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_1dfe09105792ef65c8d576cc486d5e04'
+looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_3c7137b8371d10bc148c8f8bb3042ee6'
+looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_1dfe09105792ef65c8d576cc486d5e04'
+",
+"looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_3c7137b8371d10bc148c8f8bb3042ee6'
+looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_1dfe09105792ef65c8d576cc486d5e04'
+looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_3c7137b8371d10bc148c8f8bb3042ee6'
+looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_1dfe09105792ef65c8d576cc486d5e04'
+looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_3c7137b8371d10bc148c8f8bb3042ee6'
+looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_1dfe09105792ef65c8d576cc486d5e04'
+looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_3c7137b8371d10bc148c8f8bb3042ee6'
+looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_1dfe09105792ef65c8d576cc486d5e04'
+"]
+--- log_level: debug
+--- no_error_log
+[error]
+
+
+
+=== TEST 33: make sure Lua code file keys are correct
+GitHub issue #1428
+--- config
+include ../html/a/proxy.conf;
+include ../html/b/proxy.conf;
+include ../html/c/proxy.conf;
+
+location /t {
+    echo_location /a/;
+    echo_location /b/;
+    echo_location /a/;
+    echo_location /c/;
+}
+
+--- user_files
+>>> a.lua
+ngx.say("/a/ is called")
+
+>>> b.lua
+ngx.say("/b/ is called")
+
+>>> c.lua
+ngx.say("/b/ is called")
+
+>>> a/proxy.conf
+location /a/ {
+    content_by_lua_file html/a.lua;
+}
+
+>>> b/proxy.conf
+location /b/ {
+    content_by_lua_file html/b.lua;
+}
+
+>>> c/proxy.conf
+location /c/ {
+    content_by_lua_file html/c.lua;
+}
+
+--- request
+GET /t
+--- response_body
+/a/ is called
+/b/ is called
+/a/ is called
+/b/ is called
+--- grep_error_log eval: qr/looking up Lua code cache with key '.*?'/
+--- grep_error_log_out eval
+[
+"looking up Lua code cache with key 'nhlf_48a9a7def61143c003a7de1644e026e4'
+looking up Lua code cache with key 'nhlf_68f5f4e946c3efd1cc206452b807e8b6'
+looking up Lua code cache with key 'nhlf_48a9a7def61143c003a7de1644e026e4'
+looking up Lua code cache with key 'nhlf_042c9b3a136fbacbbd0e4b9ad10896b7'
+",
+"looking up Lua code cache with key 'nhlf_48a9a7def61143c003a7de1644e026e4'
+looking up Lua code cache with key 'nhlf_68f5f4e946c3efd1cc206452b807e8b6'
+looking up Lua code cache with key 'nhlf_48a9a7def61143c003a7de1644e026e4'
+looking up Lua code cache with key 'nhlf_042c9b3a136fbacbbd0e4b9ad10896b7'
+looking up Lua code cache with key 'nhlf_48a9a7def61143c003a7de1644e026e4'
+looking up Lua code cache with key 'nhlf_68f5f4e946c3efd1cc206452b807e8b6'
+looking up Lua code cache with key 'nhlf_48a9a7def61143c003a7de1644e026e4'
+looking up Lua code cache with key 'nhlf_042c9b3a136fbacbbd0e4b9ad10896b7'
+"
+]
+--- log_level: debug
+--- no_error_log
+[error]


### PR DESCRIPTION
… source checksum as part of the Lua code cache key. thanks Oleg A. Mamontov for the report in #1428.

Fix #1428.

optimize: now we exclude the current nginx config file info from the cache keys for inlined Lua code snippets in nginx config files.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
