### PR TITLE
tests: 159-sa-restart.t: avoided sending SIGWINCH to the test nginx worker process.

### DIFF
--- a/t/159-sa-restart.t
+++ b/t/159-sa-restart.t
@@ -20,7 +20,7 @@ add_block_preprocessor(sub {
                 --"INT",
                 "IO",
                 "CHLD",
-                "WINCH",
+                --"WINCH",
             }
 
             for _, signame in ipairs(signals) do


### PR DESCRIPTION
The handler for this signal falls-through to a graceful shutdown in
daemonized worker processes.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
