### PR TITLE
optimize: avoided using strings as code cache keys.

### DIFF
--- a/src/ngx_http_lua_accessby.c
+++ b/src/ngx_http_lua_accessby.c
@@ -179,7 +179,7 @@ ngx_http_lua_access_handler_inline(ngx_http_request_t *r)
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->access_src.value.data,
                                        llcf->access_src.value.len,
-                                       llcf->access_src_key,
+                                       &llcf->access_src_ref,
                                        (const char *) llcf->access_chunkname);
 
     if (rc != NGX_OK) {
@@ -217,7 +217,7 @@ ngx_http_lua_access_handler_file(ngx_http_request_t *r)
 
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
-                                     llcf->access_src_key);
+                                     &llcf->access_src_ref);
     if (rc != NGX_OK) {
         if (rc < NGX_HTTP_SPECIAL_RESPONSE) {
             return NGX_HTTP_INTERNAL_SERVER_ERROR;

--- a/src/ngx_http_lua_bodyfilterby.c
+++ b/src/ngx_http_lua_bodyfilterby.c
@@ -162,7 +162,7 @@ ngx_http_lua_body_filter_inline(ngx_http_request_t *r, ngx_chain_t *in)
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->body_filter_src.value.data,
                                        llcf->body_filter_src.value.len,
-                                       llcf->body_filter_src_key,
+                                       &llcf->body_filter_src_ref,
                                        "=body_filter_by_lua");
     if (rc != NGX_OK) {
         return NGX_ERROR;
@@ -209,7 +209,7 @@ ngx_http_lua_body_filter_file(ngx_http_request_t *r, ngx_chain_t *in)
 
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
-                                     llcf->body_filter_src_key);
+                                     &llcf->body_filter_src_ref);
     if (rc != NGX_OK) {
         return NGX_ERROR;
     }

--- a/src/ngx_http_lua_cache.h
+++ b/src/ngx_http_lua_cache.h
@@ -13,10 +13,9 @@
 
 
 ngx_int_t ngx_http_lua_cache_loadbuffer(ngx_log_t *log, lua_State *L,
-    const u_char *src, size_t src_len, const u_char *cache_key,
-    const char *name);
+    const u_char *src, size_t src_len, int *ref, const char *name);
 ngx_int_t ngx_http_lua_cache_loadfile(ngx_log_t *log, lua_State *L,
-    const u_char *script, const u_char *cache_key);
+    const u_char *script, int *ref);
 
 
 #endif /* _NGX_HTTP_LUA_CACHE_H_INCLUDED_ */

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -102,7 +102,7 @@
 #if defined(NDK) && NDK
 typedef struct {
     size_t       size;
-    u_char      *key;
+    int          ref;
     ngx_str_t    script;
 } ngx_http_lua_set_var_data_t;
 #endif
@@ -278,23 +278,22 @@ union ngx_http_lua_srv_conf_u {
     struct {
         ngx_http_lua_srv_conf_handler_pt     ssl_cert_handler;
         ngx_str_t                            ssl_cert_src;
-        u_char                              *ssl_cert_src_key;
+        int                                  ssl_cert_src_ref;
 
         ngx_http_lua_srv_conf_handler_pt     ssl_sess_store_handler;
         ngx_str_t                            ssl_sess_store_src;
-        u_char                              *ssl_sess_store_src_key;
+        int                                  ssl_sess_store_src_ref;
 
         ngx_http_lua_srv_conf_handler_pt     ssl_sess_fetch_handler;
         ngx_str_t                            ssl_sess_fetch_src;
-        u_char                              *ssl_sess_fetch_src_key;
+        int                                  ssl_sess_fetch_src_ref;
     } srv;
 #endif
 
     struct {
-        ngx_str_t           src;
-        u_char             *src_key;
-
         ngx_http_lua_srv_conf_handler_pt  handler;
+        ngx_str_t                         src;
+        int                               src_ref;
     } balancer;
 };
 
@@ -329,40 +328,36 @@ typedef struct {
     ngx_http_complex_value_t rewrite_src;    /*  rewrite_by_lua
                                                 inline script/script
                                                 file path */
-
-    u_char                  *rewrite_src_key; /* cached key for rewrite_src */
+    int                      rewrite_src_ref;
 
     u_char                  *access_chunkname;
     ngx_http_complex_value_t access_src;     /*  access_by_lua
                                                 inline script/script
                                                 file path */
-
-    u_char                  *access_src_key; /* cached key for access_src */
+    int                      access_src_ref;
 
     u_char                  *content_chunkname;
     ngx_http_complex_value_t content_src;    /*  content_by_lua
                                                 inline script/script
                                                 file path */
 
-    u_char                 *content_src_key; /* cached key for content_src */
+    int                      content_src_ref;
 
 
     u_char                      *log_chunkname;
     ngx_http_complex_value_t     log_src;     /* log_by_lua inline script/script
                                                  file path */
-
-    u_char                      *log_src_key; /* cached key for log_src */
+    int                          log_src_ref;
 
     ngx_http_complex_value_t header_filter_src;  /*  header_filter_by_lua
                                                      inline script/script
                                                      file path */
 
-    u_char                 *header_filter_src_key;
-                                    /* cached key for header_filter_src */
+    int                      header_filter_src_ref;
 
 
     ngx_http_complex_value_t         body_filter_src;
-    u_char                          *body_filter_src_key;
+    int                              body_filter_src_ref;
 
     ngx_msec_t                       keepalive_timeout;
     ngx_msec_t                       connect_timeout;

--- a/src/ngx_http_lua_contentby.c
+++ b/src/ngx_http_lua_contentby.c
@@ -271,7 +271,7 @@ ngx_http_lua_content_handler_file(ngx_http_request_t *r)
 
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
-                                     llcf->content_src_key);
+                                     &llcf->content_src_ref);
     if (rc != NGX_OK) {
         if (rc < NGX_HTTP_SPECIAL_RESPONSE) {
             return NGX_HTTP_INTERNAL_SERVER_ERROR;
@@ -302,7 +302,7 @@ ngx_http_lua_content_handler_inline(ngx_http_request_t *r)
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->content_src.value.data,
                                        llcf->content_src.value.len,
-                                       llcf->content_src_key,
+                                       &llcf->content_src_ref,
                                        (const char *)
                                        llcf->content_chunkname);
     if (rc != NGX_OK) {

--- a/src/ngx_http_lua_headerfilterby.c
+++ b/src/ngx_http_lua_headerfilterby.c
@@ -172,7 +172,7 @@ ngx_http_lua_header_filter_inline(ngx_http_request_t *r)
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->header_filter_src.value.data,
                                        llcf->header_filter_src.value.len,
-                                       llcf->header_filter_src_key,
+                                       &llcf->header_filter_src_ref,
                                        "=header_filter_by_lua");
     if (rc != NGX_OK) {
         return NGX_ERROR;
@@ -213,7 +213,7 @@ ngx_http_lua_header_filter_file(ngx_http_request_t *r)
 
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
-                                     llcf->header_filter_src_key);
+                                     &llcf->header_filter_src_ref);
     if (rc != NGX_OK) {
         return NGX_ERROR;
     }

--- a/src/ngx_http_lua_logby.c
+++ b/src/ngx_http_lua_logby.c
@@ -154,7 +154,7 @@ ngx_http_lua_log_handler_inline(ngx_http_request_t *r)
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->log_src.value.data,
                                        llcf->log_src.value.len,
-                                       llcf->log_src_key,
+                                       &llcf->log_src_ref,
                                        (const char *) llcf->log_chunkname);
     if (rc != NGX_OK) {
         return NGX_ERROR;
@@ -190,7 +190,7 @@ ngx_http_lua_log_handler_file(ngx_http_request_t *r)
 
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
-                                     llcf->log_src_key);
+                                     &llcf->log_src_ref);
     if (rc != NGX_OK) {
         return NGX_ERROR;
     }

--- a/src/ngx_http_lua_rewriteby.c
+++ b/src/ngx_http_lua_rewriteby.c
@@ -184,9 +184,8 @@ ngx_http_lua_rewrite_handler_inline(ngx_http_request_t *r)
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->rewrite_src.value.data,
                                        llcf->rewrite_src.value.len,
-                                       llcf->rewrite_src_key,
-                                       (const char *)
-                                       llcf->rewrite_chunkname);
+                                       &llcf->rewrite_src_ref,
+                                       (const char *) llcf->rewrite_chunkname);
     if (rc != NGX_OK) {
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
@@ -221,7 +220,7 @@ ngx_http_lua_rewrite_handler_file(ngx_http_request_t *r)
 
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
-                                     llcf->rewrite_src_key);
+                                     &llcf->rewrite_src_ref);
     if (rc != NGX_OK) {
         if (rc < NGX_HTTP_SPECIAL_RESPONSE) {
             return NGX_HTTP_INTERNAL_SERVER_ERROR;

--- a/src/ngx_http_lua_ssl_session_fetchby.c
+++ b/src/ngx_http_lua_ssl_session_fetchby.c
@@ -41,7 +41,7 @@ ngx_http_lua_ssl_sess_fetch_handler_file(ngx_http_request_t *r,
 
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L,
                                      lscf->srv.ssl_sess_fetch_src.data,
-                                     lscf->srv.ssl_sess_fetch_src_key);
+                                     &lscf->srv.ssl_sess_fetch_src_ref);
     if (rc != NGX_OK) {
         return rc;
     }
@@ -63,7 +63,7 @@ ngx_http_lua_ssl_sess_fetch_handler_inline(ngx_http_request_t *r,
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        lscf->srv.ssl_sess_fetch_src.data,
                                        lscf->srv.ssl_sess_fetch_src.len,
-                                       lscf->srv.ssl_sess_fetch_src_key,
+                                       &lscf->srv.ssl_sess_fetch_src_ref,
                                        "=ssl_session_fetch_by_lua_block");
     if (rc != NGX_OK) {
         return rc;
@@ -100,7 +100,6 @@ char *
 ngx_http_lua_ssl_sess_fetch_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf)
 {
-    u_char                      *p;
     u_char                      *name;
     ngx_str_t                   *value;
     ngx_http_lua_srv_conf_t     *lscf = conf;
@@ -137,36 +136,10 @@ ngx_http_lua_ssl_sess_fetch_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
         lscf->srv.ssl_sess_fetch_src.data = name;
         lscf->srv.ssl_sess_fetch_src.len = ngx_strlen(name);
 
-        p = ngx_palloc(cf->pool, NGX_HTTP_LUA_FILE_KEY_LEN + 1);
-        if (p == NULL) {
-            return NGX_CONF_ERROR;
-        }
-
-        lscf->srv.ssl_sess_fetch_src_key = p;
-
-        p = ngx_copy(p, NGX_HTTP_LUA_FILE_TAG, NGX_HTTP_LUA_FILE_TAG_LEN);
-        p = ngx_http_lua_digest_hex(p, value[1].data, value[1].len);
-        *p = '\0';
-
     } else {
         /* inlined Lua code */
 
         lscf->srv.ssl_sess_fetch_src = value[1];
-
-        p = ngx_palloc(cf->pool,
-                       sizeof("ssl_session_fetch_by_lua") +
-                       NGX_HTTP_LUA_INLINE_KEY_LEN);
-        if (p == NULL) {
-            return NGX_CONF_ERROR;
-        }
-
-        lscf->srv.ssl_sess_fetch_src_key = p;
-
-        p = ngx_copy(p, "ssl_session_fetch_by_lua",
-                     sizeof("ssl_session_fetch_by_lua") - 1);
-        p = ngx_copy(p, NGX_HTTP_LUA_INLINE_TAG, NGX_HTTP_LUA_INLINE_TAG_LEN);
-        p = ngx_http_lua_digest_hex(p, value[1].data, value[1].len);
-        *p = '\0';
     }
 
     return NGX_CONF_OK;

--- a/src/ngx_http_lua_ssl_session_storeby.c
+++ b/src/ngx_http_lua_ssl_session_storeby.c
@@ -39,7 +39,7 @@ ngx_http_lua_ssl_sess_store_handler_file(ngx_http_request_t *r,
 
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L,
                                      lscf->srv.ssl_sess_store_src.data,
-                                     lscf->srv.ssl_sess_store_src_key);
+                                     &lscf->srv.ssl_sess_store_src_ref);
     if (rc != NGX_OK) {
         return rc;
     }
@@ -61,7 +61,7 @@ ngx_http_lua_ssl_sess_store_handler_inline(ngx_http_request_t *r,
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        lscf->srv.ssl_sess_store_src.data,
                                        lscf->srv.ssl_sess_store_src.len,
-                                       lscf->srv.ssl_sess_store_src_key,
+                                       &lscf->srv.ssl_sess_store_src_ref,
                                        "=ssl_session_store_by_lua_block");
     if (rc != NGX_OK) {
         return rc;
@@ -98,7 +98,6 @@ char *
 ngx_http_lua_ssl_sess_store_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf)
 {
-    u_char                      *p;
     u_char                      *name;
     ngx_str_t                   *value;
     ngx_http_lua_srv_conf_t     *lscf = conf;
@@ -135,36 +134,10 @@ ngx_http_lua_ssl_sess_store_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
         lscf->srv.ssl_sess_store_src.data = name;
         lscf->srv.ssl_sess_store_src.len = ngx_strlen(name);
 
-        p = ngx_palloc(cf->pool, NGX_HTTP_LUA_FILE_KEY_LEN + 1);
-        if (p == NULL) {
-            return NGX_CONF_ERROR;
-        }
-
-        lscf->srv.ssl_sess_store_src_key = p;
-
-        p = ngx_copy(p, NGX_HTTP_LUA_FILE_TAG, NGX_HTTP_LUA_FILE_TAG_LEN);
-        p = ngx_http_lua_digest_hex(p, value[1].data, value[1].len);
-        *p = '\0';
-
     } else {
         /* inlined Lua code */
 
         lscf->srv.ssl_sess_store_src = value[1];
-
-        p = ngx_palloc(cf->pool,
-                       sizeof("ssl_session_store_by_lua") +
-                       NGX_HTTP_LUA_INLINE_KEY_LEN);
-        if (p == NULL) {
-            return NGX_CONF_ERROR;
-        }
-
-        lscf->srv.ssl_sess_store_src_key = p;
-
-        p = ngx_copy(p, "ssl_session_store_by_lua",
-                     sizeof("ssl_session_store_by_lua") - 1);
-        p = ngx_copy(p, NGX_HTTP_LUA_INLINE_TAG, NGX_HTTP_LUA_INLINE_TAG_LEN);
-        p = ngx_http_lua_digest_hex(p, value[1].data, value[1].len);
-        *p = '\0';
     }
 
     return NGX_CONF_OK;

--- a/t/001-set.t
+++ b/t/001-set.t
@@ -562,7 +562,33 @@ GET /lua?a=5&b=2
 
 
 
-=== TEST 35: lua error (string)
+=== TEST 35: variables in set_by_lua_file's file path
+--- config
+    location ~ ^/lua/(.+)$ {
+        set_by_lua_file $res html/$1.lua;
+        echo $res;
+    }
+
+    location /main {
+        echo_location /lua/a;
+        echo_location /lua/b;
+    }
+--- user_files
+>>> a.lua
+return "a"
+>>> b.lua
+return "b"
+--- request
+GET /main
+--- response_body
+a
+b
+--- no_error_log
+[error]
+
+
+
+=== TEST 36: lua error (string)
 --- config
     location /lua {
         set_by_lua $res 'error("Bad")';
@@ -577,7 +603,7 @@ failed to run set_by_lua*: set_by_lua:1: Bad
 
 
 
-=== TEST 36: lua error (nil)
+=== TEST 37: lua error (nil)
 --- config
     location /lua {
         set_by_lua $res 'error(nil)';
@@ -592,7 +618,7 @@ failed to run set_by_lua*: unknown reason
 
 
 
-=== TEST 37: globals are shared in all requests.
+=== TEST 38: globals are shared in all requests.
 --- config
     location /lua {
         set_by_lua_block $res {
@@ -619,7 +645,7 @@ GET /lua
 
 
 
-=== TEST 38: user modules using ngx.arg
+=== TEST 39: user modules using ngx.arg
 --- http_config
     lua_package_path "$prefix/html/?.lua;;";
 --- config
@@ -643,7 +669,7 @@ GET /lua?a=1&b=2
 
 
 
-=== TEST 39: server scope (inline)
+=== TEST 40: server scope (inline)
 --- config
     location /lua {
         set $a "[$res]";
@@ -659,7 +685,7 @@ GET /lua
 
 
 
-=== TEST 40: server if scope (inline)
+=== TEST 41: server if scope (inline)
 --- config
     location /lua {
         set $a "[$res]";
@@ -677,7 +703,7 @@ GET /lua?name=jim
 
 
 
-=== TEST 41: location if scope (inline)
+=== TEST 42: location if scope (inline)
 --- config
     location /lua {
         if ($arg_name = "jim") {
@@ -695,7 +721,7 @@ GET /lua?name=jim
 
 
 
-=== TEST 42: server scope (file)
+=== TEST 43: server scope (file)
 --- config
     location /lua {
         set $a "[$res]";
@@ -714,7 +740,7 @@ GET /lua
 
 
 
-=== TEST 43: server if scope (file)
+=== TEST 44: server if scope (file)
 --- config
     location /lua {
         set $a "[$res]";
@@ -735,7 +761,7 @@ return 1+1
 
 
 
-=== TEST 44: location if scope (file)
+=== TEST 45: location if scope (file)
 --- config
     location /lua {
         if ($arg_name = "jim") {
@@ -756,7 +782,7 @@ GET /lua?name=jim
 
 
 
-=== TEST 45: backtrace
+=== TEST 46: backtrace
 --- config
     location /t {
         set_by_lua $a '
@@ -787,7 +813,7 @@ in function 'foo'
 
 
 
-=== TEST 46: Lua file does not exist
+=== TEST 47: Lua file does not exist
 --- config
     location /lua {
         set_by_lua_file $a html/test2.lua;

--- a/t/025-codecache.t
+++ b/t/025-codecache.t
@@ -1284,22 +1284,22 @@ GET /t
 /b/ is called
 /a/ is called
 /b/ is called
---- grep_error_log eval: qr/looking up Lua code cache with key '.*?'/
+--- grep_error_log eval: qr/looking up Lua code cache with ref -?\d+/
 --- grep_error_log_out eval
 [
-"looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_3c7137b8371d10bc148c8f8bb3042ee6'
-looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_1dfe09105792ef65c8d576cc486d5e04'
-looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_3c7137b8371d10bc148c8f8bb3042ee6'
-looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_1dfe09105792ef65c8d576cc486d5e04'
+"looking up Lua code cache with ref -1
+looking up Lua code cache with ref -1
+looking up Lua code cache with ref 1
+looking up Lua code cache with ref -1
 ",
-"looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_3c7137b8371d10bc148c8f8bb3042ee6'
-looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_1dfe09105792ef65c8d576cc486d5e04'
-looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_3c7137b8371d10bc148c8f8bb3042ee6'
-looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_1dfe09105792ef65c8d576cc486d5e04'
-looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_3c7137b8371d10bc148c8f8bb3042ee6'
-looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_1dfe09105792ef65c8d576cc486d5e04'
-looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_3c7137b8371d10bc148c8f8bb3042ee6'
-looking up Lua code cache with key '=content_by_lua(proxy.conf:2)nhli_1dfe09105792ef65c8d576cc486d5e04'
+"looking up Lua code cache with ref -1
+looking up Lua code cache with ref -1
+looking up Lua code cache with ref 1
+looking up Lua code cache with ref -1
+looking up Lua code cache with ref 1
+looking up Lua code cache with ref 2
+looking up Lua code cache with ref 1
+looking up Lua code cache with ref 3
 "]
 --- log_level: debug
 --- no_error_log
@@ -1353,22 +1353,22 @@ GET /t
 /b/ is called
 /a/ is called
 /b/ is called
---- grep_error_log eval: qr/looking up Lua code cache with key '.*?'/
+--- grep_error_log eval: qr/looking up Lua file code cache with ref -?\d+/
 --- grep_error_log_out eval
 [
-"looking up Lua code cache with key 'nhlf_48a9a7def61143c003a7de1644e026e4'
-looking up Lua code cache with key 'nhlf_68f5f4e946c3efd1cc206452b807e8b6'
-looking up Lua code cache with key 'nhlf_48a9a7def61143c003a7de1644e026e4'
-looking up Lua code cache with key 'nhlf_042c9b3a136fbacbbd0e4b9ad10896b7'
+"looking up Lua file code cache with ref -1
+looking up Lua file code cache with ref -1
+looking up Lua file code cache with ref 1
+looking up Lua file code cache with ref -1
 ",
-"looking up Lua code cache with key 'nhlf_48a9a7def61143c003a7de1644e026e4'
-looking up Lua code cache with key 'nhlf_68f5f4e946c3efd1cc206452b807e8b6'
-looking up Lua code cache with key 'nhlf_48a9a7def61143c003a7de1644e026e4'
-looking up Lua code cache with key 'nhlf_042c9b3a136fbacbbd0e4b9ad10896b7'
-looking up Lua code cache with key 'nhlf_48a9a7def61143c003a7de1644e026e4'
-looking up Lua code cache with key 'nhlf_68f5f4e946c3efd1cc206452b807e8b6'
-looking up Lua code cache with key 'nhlf_48a9a7def61143c003a7de1644e026e4'
-looking up Lua code cache with key 'nhlf_042c9b3a136fbacbbd0e4b9ad10896b7'
+"looking up Lua file code cache with ref -1
+looking up Lua file code cache with ref -1
+looking up Lua file code cache with ref 1
+looking up Lua file code cache with ref -1
+looking up Lua file code cache with ref 1
+looking up Lua file code cache with ref 2
+looking up Lua file code cache with ref 1
+looking up Lua file code cache with ref 3
 "
 ]
 --- log_level: debug


### PR DESCRIPTION
This optimization takes advantage of the `luaL_ref()` C API to generate
unique references for Lua buffers (inline and file). This avoids runtime
calls to `lj_str_new()` while invoking Lua handler.

By doing so, we observe reduced CPU utilization and increased throughput
(~2% to ~5% in preliminary tests) in a simplistic hello world handler.
Other benefits of this patch include the simplification of the code
cache keys generation and reduced memory consumption.

In this implementation, a `LUA_REFNIL` code cache reference means that the
associated chunk has not been cached yet. A `LUA_NOREF` code cache
reference applies to Lua file paths and means that this particular file
path has nginx variables and should thus generate its own cache key
(identical to the current implementation).

This patch also fixes an isue with `set_by_lua_file` handlers if those
were specified with nginx variables. We added a new test case for this
behavior which fails on the master branch of this repository (v0.10.14),
but passes with this patch.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
