### PR TITLE
bugfix: ngx.pipe: fixed a segfault when error_log is configured to us…

### DIFF
--- a/src/ngx_http_lua_pipe.c
+++ b/src/ngx_http_lua_pipe.c
@@ -703,8 +703,8 @@ ngx_http_lua_ffi_pipe_spawn(ngx_http_lua_ffi_pipe_proc_t *proc,
                           "pipe fd");
         }
 
-        errlog_fd = ngx_cycle->log->file->fd;
-        if (errlog_fd == STDERR_FILENO) {
+        if (ngx_cycle->log->file && ngx_cycle->log->file->fd == STDERR_FILENO) {
+            errlog_fd = ngx_cycle->log->file->fd;
             temp_errlog_fd = dup(errlog_fd);
 
             if (temp_errlog_fd == -1) {


### PR DESCRIPTION
…e syslog.

Fix https://github.com/openresty/lua-resty-shell/issues/7.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
