### PR TITLE
tests: removed no-longer needed drizzle upstream block in init.t.

### DIFF
--- a/t/000--init.t
+++ b/t/000--init.t
@@ -10,11 +10,6 @@ $ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
 $ENV{TEST_NGINX_MYSQL_PORT} ||= 3306;
 
 our $http_config = <<'_EOC_';
-    upstream database {
-        drizzle_server 127.0.0.1:$TEST_NGINX_MYSQL_PORT protocol=mysql
-                       dbname=ngx_test user=ngx_test password=ngx_test;
-    }
-
     lua_package_path "../lua-resty-mysql/lib/?.lua;;";
 _EOC_
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
