### PR TITLE
feature: supported async SSL session fetch callback with OpenSSL 1.1.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,9 @@ env:
     - DRIZZLE_VER=2011.07.21
     - TEST_NGINX_SLEEP=0.006
   matrix:
-    - NGINX_VERSION=1.15.8 OPENSSL_VER=1.0.2s OPENSSL_OPT="" OPENSSL_PATCH_VER=1.0.2h
-    - NGINX_VERSION=1.15.8 OPENSSL_VER=1.1.0k OPENSSL_OPT="" OPENSSL_PATCH_VER=1.1.0d
-    # TODO: when adding an OpenSSL version >= 1.1.1, please add "enable-tls1_3"
-    # to $OPENSSL_OPT.
+    - NGINX_VERSION=1.15.8 OPENSSL_VER=1.0.2s OPENSSL_PATCH_VER=1.0.2h
+    - NGINX_VERSION=1.15.8 OPENSSL_VER=1.1.0k OPENSSL_PATCH_VER=1.1.0d
+    - NGINX_VERSION=1.15.8 OPENSSL_VER=1.1.1c OPENSSL_PATCH_VER=""
 
 services:
  - memcache
@@ -116,8 +115,8 @@ script:
   - cd ..
   - tar zxf download-cache/openssl-$OPENSSL_VER.tar.gz
   - cd openssl-$OPENSSL_VER/
-  - patch -p1 < ../../openresty/patches/openssl-$OPENSSL_PATCH_VER-sess_set_get_cb_yield.patch
-  - ./config no-threads shared enable-ssl3 enable-ssl3-method $OPENSSL_OPT -g --prefix=$OPENSSL_PREFIX -DPURIFY > build.log 2>&1 || (cat build.log && exit 1)
+  - if [ -n "$OPENSSL_PATCH_VER" ]; then patch -p1 < ../../openresty/patches/openssl-$OPENSSL_PATCH_VER-sess_set_get_cb_yield.patch; fi
+  - ./config no-threads shared enable-ssl3 enable-ssl3-method -g --prefix=$OPENSSL_PREFIX -DPURIFY > build.log 2>&1 || (cat build.log && exit 1)
   - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make PATH=$PATH install_sw > build.log 2>&1 || (cat build.log && exit 1)
   - cd ..

--- a/README.markdown
+++ b/README.markdown
@@ -2623,15 +2623,18 @@ But do not forget to comment this line out before publishing your site to the wo
 If you are using the [official pre-built packages](http://openresty.org/en/linux-packages.html) for [OpenResty](https://openresty.org/)
 1.11.2.1 or later, then everything should work out of the box.
 
-If you are using OpenSSL libraries not provided by [OpenResty](https://openresty.org),
-then you need to apply the following patch for OpenSSL 1.0.2h or later:
+If you are not using one of the [OpenSSL
+packages](https://openresty.org/en/linux-packages.html) provided by
+[OpenResty](https://openresty.org), you will need to apply patches to OpenSSL
+1.0.2, up to (and including) 1.1.0:
 
-<https://github.com/openresty/openresty/blob/master/patches/openssl-1.0.2h-sess_set_get_cb_yield.patch>
+<https://openresty.org/en/openssl-patches.html>
 
-If you are not using the NGINX core shipped with [OpenResty](https://openresty.org) 1.11.2.1 or later, then you need to
-apply the following patch to the standard NGINX core 1.11.2 or later:
+Similarly, if you are not using the NGINX core shipped with
+[OpenResty](https://openresty.org) 1.11.2.1 or later, you will need to apply
+patches to the standard NGINX core:
 
-<http://openresty.org/download/nginx-1.11.2-nonblocking_ssl_handshake_hooks.patch>
+<https://openresty.org/en/nginx-ssl-patches.html>
 
 This directive was first introduced in the `v0.10.6` release.
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -2219,15 +2219,18 @@ But do not forget to comment this line out before publishing your site to the wo
 If you are using the [official pre-built packages](http://openresty.org/en/linux-packages.html) for [OpenResty](https://openresty.org/)
 1.11.2.1 or later, then everything should work out of the box.
 
-If you are using OpenSSL libraries not provided by [OpenResty](https://openresty.org),
-then you need to apply the following patch for OpenSSL 1.0.2h or later:
+If you are not using one of the [OpenSSL
+packages](https://openresty.org/en/linux-packages.html) provided by
+[OpenResty](https://openresty.org), you will need to apply patches to OpenSSL
+1.0.2, up to (and including) 1.1.0:
 
-https://github.com/openresty/openresty/blob/master/patches/openssl-1.0.2h-sess_set_get_cb_yield.patch
+https://openresty.org/en/openssl-patches.html
 
-If you are not using the NGINX core shipped with [OpenResty](https://openresty.org) 1.11.2.1 or later, then you need to
-apply the following patch to the standard NGINX core 1.11.2 or later:
+Similarly, if you are not using the NGINX core shipped with
+[OpenResty](https://openresty.org) 1.11.2.1 or later, you will need to apply
+patches to the standard NGINX core:
 
-http://openresty.org/download/nginx-1.11.2-nonblocking_ssl_handshake_hooks.patch
+https://openresty.org/en/nginx-ssl-patches.html
 
 This directive was first introduced in the <code>v0.10.6</code> release.
 

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -1077,6 +1077,12 @@ ngx_http_lua_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
             return NGX_CONF_ERROR;
 #else
+#   ifdef HAVE_SSL_CLIENT_HELLO_CB_SUPPORT
+            SSL_CTX_set_client_hello_cb(sscf->ssl.ctx,
+                                        ngx_http_lua_ssl_client_hello_handler,
+                                        NULL);
+#   endif
+
             SSL_CTX_sess_set_get_cb(sscf->ssl.ctx,
                                     ngx_http_lua_ssl_sess_fetch_handler);
 #endif

--- a/src/ngx_http_lua_ssl_session_fetchby.h
+++ b/src/ngx_http_lua_ssl_session_fetchby.h
@@ -30,8 +30,13 @@ ngx_ssl_session_t *ngx_http_lua_ssl_sess_fetch_handler(
     const
 #endif
     u_char *id, int len, int *copy);
+
+#ifdef HAVE_SSL_CLIENT_HELLO_CB_SUPPORT
+int ngx_http_lua_ssl_client_hello_handler(ngx_ssl_conn_t *ssl_conn,
+    int *al, void *arg);
 #endif
 
+#endif /* NGX_HTTP_SSL */
 
 #endif /* _NGX_HTTP_LUA_SSL_SESSION_FETCHBY_H_INCLUDED_ */
 


### PR DESCRIPTION
Fix openresty/openresty#456.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
