### PR TITLE
doc: fix thinko in tcpsocket:receiveany()

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7310,7 +7310,7 @@ Timeout for the reading operation is controlled by the [lua_socket_read_timeout]
 ```lua
 
  sock:settimeouts(1000, 1000, 1000)  -- one second timeout for connect/read/write
- local data, err = sock:receiveany(10 * 1024 * 1024) -- read any data, at most 10K
+ local data, err = sock:receiveany(10 * 1024) -- read any data, at most 10K
  if not data then
      ngx.say("failed to read any data: ", err)
      return

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -6178,7 +6178,7 @@ Timeout for the reading operation is controlled by the [[#lua_socket_read_timeou
 
 <geshi lang="lua">
     sock:settimeouts(1000, 1000, 1000)  -- one second timeout for connect/read/write
-    local data, err = sock:receiveany(10 * 1024 * 1024) -- read any data, at most 10K
+    local data, err = sock:receiveany(10 * 1024) -- read any data, at most 10K
     if not data then
         ngx.say("failed to read any data: ", err)
         return


### PR DESCRIPTION
This is just a really trivial doc change :-)

Originally I wanted to change the documentation of `tcpsocket:receiveany()` to specify that *some* data is always returned, even if none was available at the time the call is made. (Right?) But I punted on that because maybe this is supposed to be implied when saying that the call is *synchronous.* (It wasn't obvious to me so I had to peek at the C code fwiw.)

The one-liner is what was then left on that branch :grin: 

----

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
