### PR TITLE
bugfix: supported OpenSSL 1.1.1 by upgrading the OpenSSL patch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,9 @@ env:
     - DRIZZLE_VER=2011.07.21
     - TEST_NGINX_SLEEP=0.006
   matrix:
-    - NGINX_VERSION=1.15.8 OPENSSL_VER=1.0.2s OPENSSL_OPT="" OPENSSL_PATCH_VER=1.0.2h
-    - NGINX_VERSION=1.15.8 OPENSSL_VER=1.1.0k OPENSSL_OPT="" OPENSSL_PATCH_VER=1.1.0d
-    # TODO: when adding an OpenSSL version >= 1.1.1, please add "enable-tls1_3"
-    # to $OPENSSL_OPT.
+    - NGINX_VERSION=1.15.8 OPENSSL_VER=1.0.2s OPENSSL_PATCH_VER=1.0.2h
+    - NGINX_VERSION=1.15.8 OPENSSL_VER=1.1.0k OPENSSL_PATCH_VER=1.1.0d
+    - NGINX_VERSION=1.15.8 OPENSSL_VER=1.1.1c OPENSSL_PATCH_VER=1.1.1c
 
 services:
  - memcache
@@ -68,7 +67,7 @@ install:
   - if [ ! -f download-cache/pcre-$PCRE_VER.tar.gz ]; then wget -P download-cache http://ftp.cs.stanford.edu/pub/exim/pcre/pcre-$PCRE_VER.tar.gz; fi
   - if [ ! -f download-cache/openssl-$OPENSSL_VER.tar.gz ]; then wget -P download-cache https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz; fi
   - git clone https://github.com/openresty/test-nginx.git
-  - git clone https://github.com/openresty/openresty.git ../openresty
+  - git clone https://github.com/spacewander/openresty.git -b new_way_to_support_openssl_1.1.1 ../openresty
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone https://github.com/openresty/openresty-devel-utils.git
   - git clone https://github.com/openresty/mockeagain.git
@@ -117,7 +116,7 @@ script:
   - tar zxf download-cache/openssl-$OPENSSL_VER.tar.gz
   - cd openssl-$OPENSSL_VER/
   - patch -p1 < ../../openresty/patches/openssl-$OPENSSL_PATCH_VER-sess_set_get_cb_yield.patch
-  - ./config no-threads shared enable-ssl3 enable-ssl3-method $OPENSSL_OPT -g --prefix=$OPENSSL_PREFIX -DPURIFY > build.log 2>&1 || (cat build.log && exit 1)
+  - ./config no-threads shared enable-ssl3 enable-ssl3-method -g --prefix=$OPENSSL_PREFIX -DPURIFY > build.log 2>&1 || (cat build.log && exit 1)
   - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make PATH=$PATH install_sw > build.log 2>&1 || (cat build.log && exit 1)
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,10 @@ env:
     - DRIZZLE_VER=2011.07.21
     - TEST_NGINX_SLEEP=0.006
   matrix:
-    - NGINX_VERSION=1.15.8 OPENSSL_VER=1.0.2s OPENSSL_PATCH_VER=1.0.2h
-    - NGINX_VERSION=1.15.8 OPENSSL_VER=1.1.0k OPENSSL_PATCH_VER=1.1.0d
-    - NGINX_VERSION=1.15.8 OPENSSL_VER=1.1.1c OPENSSL_PATCH_VER=""
+    - NGINX_VERSION=1.15.8 OPENSSL_VER=1.0.2s OPENSSL_OPT="" OPENSSL_PATCH_VER=1.0.2h
+    - NGINX_VERSION=1.15.8 OPENSSL_VER=1.1.0k OPENSSL_OPT="" OPENSSL_PATCH_VER=1.1.0d
+    # TODO: when adding an OpenSSL version >= 1.1.1, please add "enable-tls1_3"
+    # to $OPENSSL_OPT.
 
 services:
  - memcache
@@ -115,8 +116,8 @@ script:
   - cd ..
   - tar zxf download-cache/openssl-$OPENSSL_VER.tar.gz
   - cd openssl-$OPENSSL_VER/
-  - if [ -n "$OPENSSL_PATCH_VER" ]; then patch -p1 < ../../openresty/patches/openssl-$OPENSSL_PATCH_VER-sess_set_get_cb_yield.patch; fi
-  - ./config no-threads shared enable-ssl3 enable-ssl3-method -g --prefix=$OPENSSL_PREFIX -DPURIFY > build.log 2>&1 || (cat build.log && exit 1)
+  - patch -p1 < ../../openresty/patches/openssl-$OPENSSL_PATCH_VER-sess_set_get_cb_yield.patch
+  - ./config no-threads shared enable-ssl3 enable-ssl3-method $OPENSSL_OPT -g --prefix=$OPENSSL_PREFIX -DPURIFY > build.log 2>&1 || (cat build.log && exit 1)
   - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make PATH=$PATH install_sw > build.log 2>&1 || (cat build.log && exit 1)
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ install:
   - if [ ! -f download-cache/drizzle7-$DRIZZLE_VER.tar.gz ]; then wget -P download-cache http://openresty.org/download/drizzle7-$DRIZZLE_VER.tar.gz; fi
   - if [ ! -f download-cache/pcre-$PCRE_VER.tar.gz ]; then wget -P download-cache http://ftp.cs.stanford.edu/pub/exim/pcre/pcre-$PCRE_VER.tar.gz; fi
   - if [ ! -f download-cache/openssl-$OPENSSL_VER.tar.gz ]; then wget -P download-cache https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz; fi
-  - git clone https://github.com/openresty/test-nginx.git
+  - git clone https://github.com/spacewander/test-nginx.git -b skip_openssl
   - git clone https://github.com/spacewander/openresty.git -b new_way_to_support_openssl_1.1.1 ../openresty
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone https://github.com/openresty/openresty-devel-utils.git

--- a/README.markdown
+++ b/README.markdown
@@ -2623,18 +2623,15 @@ But do not forget to comment this line out before publishing your site to the wo
 If you are using the [official pre-built packages](http://openresty.org/en/linux-packages.html) for [OpenResty](https://openresty.org/)
 1.11.2.1 or later, then everything should work out of the box.
 
-If you are not using one of the [OpenSSL
-packages](https://openresty.org/en/linux-packages.html) provided by
-[OpenResty](https://openresty.org), you will need to apply patches to OpenSSL
-1.0.2, up to (and including) 1.1.0:
+If you are using OpenSSL libraries not provided by [OpenResty](https://openresty.org),
+then you need to apply the following patch for OpenSSL 1.0.2h or later:
 
-<https://openresty.org/en/openssl-patches.html>
+<https://github.com/openresty/openresty/blob/master/patches/openssl-1.0.2h-sess_set_get_cb_yield.patch>
 
-Similarly, if you are not using the NGINX core shipped with
-[OpenResty](https://openresty.org) 1.11.2.1 or later, you will need to apply
-patches to the standard NGINX core:
+If you are not using the NGINX core shipped with [OpenResty](https://openresty.org) 1.11.2.1 or later, then you need to
+apply the following patch to the standard NGINX core 1.11.2 or later:
 
-<https://openresty.org/en/nginx-ssl-patches.html>
+<http://openresty.org/download/nginx-1.11.2-nonblocking_ssl_handshake_hooks.patch>
 
 This directive was first introduced in the `v0.10.6` release.
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -2219,18 +2219,15 @@ But do not forget to comment this line out before publishing your site to the wo
 If you are using the [official pre-built packages](http://openresty.org/en/linux-packages.html) for [OpenResty](https://openresty.org/)
 1.11.2.1 or later, then everything should work out of the box.
 
-If you are not using one of the [OpenSSL
-packages](https://openresty.org/en/linux-packages.html) provided by
-[OpenResty](https://openresty.org), you will need to apply patches to OpenSSL
-1.0.2, up to (and including) 1.1.0:
+If you are using OpenSSL libraries not provided by [OpenResty](https://openresty.org),
+then you need to apply the following patch for OpenSSL 1.0.2h or later:
 
-https://openresty.org/en/openssl-patches.html
+https://github.com/openresty/openresty/blob/master/patches/openssl-1.0.2h-sess_set_get_cb_yield.patch
 
-Similarly, if you are not using the NGINX core shipped with
-[OpenResty](https://openresty.org) 1.11.2.1 or later, you will need to apply
-patches to the standard NGINX core:
+If you are not using the NGINX core shipped with [OpenResty](https://openresty.org) 1.11.2.1 or later, then you need to
+apply the following patch to the standard NGINX core 1.11.2 or later:
 
-https://openresty.org/en/nginx-ssl-patches.html
+http://openresty.org/download/nginx-1.11.2-nonblocking_ssl_handshake_hooks.patch
 
 This directive was first introduced in the <code>v0.10.6</code> release.
 

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -1077,12 +1077,6 @@ ngx_http_lua_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
             return NGX_CONF_ERROR;
 #else
-#   ifdef HAVE_SSL_CLIENT_HELLO_CB_SUPPORT
-            SSL_CTX_set_client_hello_cb(sscf->ssl.ctx,
-                                        ngx_http_lua_ssl_client_hello_handler,
-                                        NULL);
-#   endif
-
             SSL_CTX_sess_set_get_cb(sscf->ssl.ctx,
                                     ngx_http_lua_ssl_sess_fetch_handler);
 #endif

--- a/src/ngx_http_lua_ssl_session_fetchby.c
+++ b/src/ngx_http_lua_ssl_session_fetchby.c
@@ -181,6 +181,9 @@ ngx_http_lua_ssl_sess_fetch_handler(ngx_ssl_conn_t *ssl_conn,
 #endif
     u_char *id, int len, int *copy)
 {
+#if defined(TLS1_3_VERSION)
+    int                              version;
+#endif
     lua_State                       *L;
     ngx_int_t                        rc;
     ngx_connection_t                *c, *fc = NULL;
@@ -197,6 +200,16 @@ ngx_http_lua_ssl_sess_fetch_handler(ngx_ssl_conn_t *ssl_conn,
     *copy = 0;
 
     c = ngx_ssl_get_connection(ssl_conn);
+
+#if defined(TLS1_3_VERSION)
+    version = SSL_version(ssl_conn);
+
+    if (version >= TLS1_3_VERSION) {
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                       "ssl session fetch: skipped: TLS version %xd", version);
+        return 0;
+    }
+#endif
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
                    "ssl session fetch: connection reusable: %ud", c->reusable);

--- a/src/ngx_http_lua_ssl_session_fetchby.c
+++ b/src/ngx_http_lua_ssl_session_fetchby.c
@@ -173,12 +173,16 @@ ngx_http_lua_ssl_sess_fetch_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
 }
 
 
-static ngx_int_t
-ngx_http_lua_ssl_sess_fetch_helper(ngx_ssl_conn_t *ssl_conn,
-    const u_char *id, int len)
+/* cached session fetching callback to be set with SSL_CTX_sess_set_get_cb */
+ngx_ssl_session_t *
+ngx_http_lua_ssl_sess_fetch_handler(ngx_ssl_conn_t *ssl_conn,
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+    const
+#endif
+    u_char *id, int len, int *copy)
 {
     lua_State                       *L;
-    ngx_int_t                        rc, res = NGX_ERROR;
+    ngx_int_t                        rc;
     ngx_connection_t                *c, *fc = NULL;
     ngx_http_request_t              *r = NULL;
     ngx_pool_cleanup_t              *cln;
@@ -186,6 +190,11 @@ ngx_http_lua_ssl_sess_fetch_helper(ngx_ssl_conn_t *ssl_conn,
     ngx_http_lua_ssl_ctx_t          *cctx;
     ngx_http_lua_srv_conf_t         *lscf;
     ngx_http_core_loc_conf_t        *clcf;
+
+    /* set copy to 0 as we expect OpenSSL to handle
+     * the memory of returned session */
+
+    *copy = 0;
 
     c = ngx_ssl_get_connection(ssl_conn);
 
@@ -208,10 +217,17 @@ ngx_http_lua_ssl_sess_fetch_helper(ngx_ssl_conn_t *ssl_conn,
                            cctx->exit_code);
 
             dd("lua ssl sess_fetch done, finally");
-            return NGX_OK;
+            return cctx->session;
         }
 
-        return NGX_AGAIN;
+#ifdef SSL_ERROR_PENDING_SESSION
+        return SSL_magic_pending_session_ptr();
+#else
+        ngx_log_error(NGX_LOG_CRIT, c->log, 0,
+                      "lua: cannot yield in sess get cb: "
+                      "missing async sess get cb support in OpenSSL");
+        return NULL;
+#endif
     }
 
     dd("first time");
@@ -313,7 +329,7 @@ ngx_http_lua_ssl_sess_fetch_helper(ngx_ssl_conn_t *ssl_conn,
                        "sess get cb exit code: %d", rc, cctx->exit_code);
 
         c->log->action = "SSL handshaking";
-        return NGX_OK;
+        return cctx->session;
     }
 
     /* rc == NGX_DONE */
@@ -340,13 +356,12 @@ ngx_http_lua_ssl_sess_fetch_helper(ngx_ssl_conn_t *ssl_conn,
 
     *cctx->cleanup = ngx_http_lua_ssl_sess_fetch_aborted;
 
-#if defined(SSL_ERROR_PENDING_SESSION)                                       \
-    || defined(HAVE_SSL_CLIENT_HELLO_CB_SUPPORT)
-
-    return NGX_AGAIN;
-
+#ifdef SSL_ERROR_PENDING_SESSION
+    return SSL_magic_pending_session_ptr();
 #else
-    res = NGX_AGAIN;
+    ngx_log_error(NGX_LOG_CRIT, c->log, 0,
+                  "lua: cannot yield in sess get cb: "
+                  "missing async sess get cb support in OpenSSL");
 
     /* fall through to the "failed" label below */
 #endif
@@ -361,123 +376,8 @@ failed:
         ngx_http_lua_close_fake_connection(fc);
     }
 
-    return res;
-}
-
-
-#ifdef HAVE_SSL_CLIENT_HELLO_CB_SUPPORT
-int
-ngx_http_lua_ssl_client_hello_handler(ngx_ssl_conn_t *ssl_conn,
-    int *al, void *arg)
-{
-    int                len;
-    ngx_int_t          rc;
-    const u_char      *id;
-
-    len = SSL_client_hello_get0_session_id(ssl_conn, &id);
-
-    if (len <= 0) {
-        return SSL_CLIENT_HELLO_SUCCESS;
-    }
-
-    rc = ngx_http_lua_ssl_sess_fetch_helper(ssl_conn, id, len);
-
-    if (rc == NGX_AGAIN) {
-        return SSL_CLIENT_HELLO_RETRY;
-    }
-
-    return SSL_CLIENT_HELLO_SUCCESS;
-}
-
-
-ngx_ssl_session_t *
-ngx_http_lua_ssl_sess_fetch_handler(ngx_ssl_conn_t *ssl_conn,
-    const u_char *id, int len, int *copy)
-{
-    ngx_connection_t                *c;
-    ngx_http_lua_ssl_ctx_t          *cctx;
-
-    /* set copy to 0 as we expect OpenSSL to handle
-     * the memory of returned session */
-
-    *copy = 0;
-
-    c = ngx_ssl_get_connection(ssl_conn);
-
-    cctx = ngx_http_lua_ssl_get_ctx(c->ssl->connection);
-
-    if (cctx && cctx->done) {
-        return cctx->session;
-    }
-
     return NULL;
 }
-
-
-#else
-
-/* cached session fetching callback to be set with SSL_CTX_sess_set_get_cb */
-ngx_ssl_session_t *
-ngx_http_lua_ssl_sess_fetch_handler(ngx_ssl_conn_t *ssl_conn,
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
-    const
-#endif
-    u_char *id, int len, int *copy)
-{
-    ngx_int_t                        rc;
-    ngx_connection_t                *c;
-    ngx_http_lua_ssl_ctx_t          *cctx;
-
-    /* set copy to 0 as we expect OpenSSL to handle
-     * the memory of returned session */
-
-    *copy = 0;
-
-    c = ngx_ssl_get_connection(ssl_conn);
-
-    rc = ngx_http_lua_ssl_sess_fetch_helper(ssl_conn, id, len);
-
-    if (rc == NGX_AGAIN) {
-
-#ifdef SSL_ERROR_PENDING_SESSION
-
-        return SSL_magic_pending_session_ptr();
-
-#else
-
-        ngx_log_error(NGX_LOG_CRIT, c->log, 0,
-                      "lua: cannot yield in sess get cb: "
-#   if OPENSSL_VERSION_NUMBER >= 0x1010100fL
-                      "missing support for yielding during SSL handshake in "
-                      "the nginx core; consider using the OpenResty releases "
-                      "from https://openresty.org/en/download.html or apply "
-                      "the nginx core patches yourself (see "
-                      "https://openresty.org/en/nginx-ssl-patches.html)");
-
-#   else
-                      "missing support for yielding during SSL handshake in "
-                      "linked " OPENSSL_VERSION_TEXT "; consider using the "
-                      "OpenResty releases from "
-                      "https://openresty.org/en/download.html or apply "
-                      "the OpenSSL patches yourself (see "
-                      "https://openresty.org/en/openssl-patches.html)");
-#   endif
-
-        return NULL;
-
-#endif
-    }
-
-    if (rc == NGX_ERROR) {
-        return NULL;
-    }
-
-    /* rc == NGX_OK */
-
-    cctx = ngx_http_lua_ssl_get_ctx(c->ssl->connection);
-    return cctx->session;
-}
-#endif
 
 
 static void

--- a/src/ngx_http_lua_ssl_session_fetchby.c
+++ b/src/ngx_http_lua_ssl_session_fetchby.c
@@ -181,7 +181,7 @@ ngx_http_lua_ssl_sess_fetch_handler(ngx_ssl_conn_t *ssl_conn,
 #endif
     u_char *id, int len, int *copy)
 {
-#if defined(TLS1_3_VERSION)
+#ifdef TLS1_3_VERSION
     int                              version;
 #endif
     lua_State                       *L;
@@ -201,7 +201,7 @@ ngx_http_lua_ssl_sess_fetch_handler(ngx_ssl_conn_t *ssl_conn,
 
     c = ngx_ssl_get_connection(ssl_conn);
 
-#if defined(TLS1_3_VERSION)
+#ifdef TLS1_3_VERSION
     version = SSL_version(ssl_conn);
 
     if (version >= TLS1_3_VERSION) {

--- a/src/ngx_http_lua_ssl_session_fetchby.h
+++ b/src/ngx_http_lua_ssl_session_fetchby.h
@@ -30,13 +30,8 @@ ngx_ssl_session_t *ngx_http_lua_ssl_sess_fetch_handler(
     const
 #endif
     u_char *id, int len, int *copy);
-
-#ifdef HAVE_SSL_CLIENT_HELLO_CB_SUPPORT
-int ngx_http_lua_ssl_client_hello_handler(ngx_ssl_conn_t *ssl_conn,
-    int *al, void *arg);
 #endif
 
-#endif /* NGX_HTTP_SSL */
 
 #endif /* _NGX_HTTP_LUA_SSL_SESSION_FETCHBY_H_INCLUDED_ */
 

--- a/src/ngx_http_lua_ssl_session_storeby.c
+++ b/src/ngx_http_lua_ssl_session_storeby.c
@@ -176,6 +176,9 @@ int
 ngx_http_lua_ssl_sess_store_handler(ngx_ssl_conn_t *ssl_conn,
     ngx_ssl_session_t *sess)
 {
+#if defined(TLS1_3_VERSION)
+    int                              version;
+#endif
     const u_char                    *sess_id;
     unsigned int                     sess_id_len;
     lua_State                       *L;
@@ -188,6 +191,16 @@ ngx_http_lua_ssl_sess_store_handler(ngx_ssl_conn_t *ssl_conn,
     ngx_http_core_loc_conf_t        *clcf;
 
     c = ngx_ssl_get_connection(ssl_conn);
+
+#if defined(TLS1_3_VERSION)
+    version = SSL_version(ssl_conn);
+
+    if (version >= TLS1_3_VERSION) {
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                       "ssl session store: skipped: TLS version %xd", version);
+        return 0;
+    }
+#endif
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
                    "ssl session store: connection reusable: %ud", c->reusable);

--- a/t/142-ssl-session-store.t
+++ b/t/142-ssl-session-store.t
@@ -6,7 +6,7 @@ use File::Basename;
 
 repeat_each(3);
 
-plan tests => repeat_each() * (blocks() * 6 - 1);
+plan tests => repeat_each() * (blocks() * 5 + 11);
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 
@@ -898,6 +898,75 @@ close: 1 nil
 lua ssl server name: "test.com"
 ssl_session_store_by_lua_block:1: ssl session store by lua is running!
 
+--- no_error_log
+[error]
+[alert]
+
+
+
+=== TEST 13: skip ssl_session_store in TLSv1.3
+--- http_config
+    ssl_session_store_by_lua_block { error("should not run") }
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+        ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+        ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_session_tickets off;
+
+        ssl_protocols TLSv1.3;
+        server_tokens off;
+    }
+--- config
+    server_tokens off;
+    resolver $TEST_NGINX_RESOLVER ipv6=off;
+    lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1.3;
+
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(5000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+close: 1 nil
+
+--- TODO: replace the expression below with skip_openssl
+--- skip_eval
+5: `nginx -V 2>&1` !~ /built with OpenSSL 1\.1\.1/
+--- error_log
+ssl session store: skipped: TLS version 304
 --- no_error_log
 [error]
 [alert]

--- a/t/142-ssl-session-store.t
+++ b/t/142-ssl-session-store.t
@@ -962,9 +962,7 @@ connected: 1
 ssl handshake: userdata
 close: 1 nil
 
---- TODO: replace the expression below with skip_openssl
---- skip_eval
-5: `nginx -V 2>&1` !~ /built with OpenSSL 1\.1\.1/
+--- skip_openssl: 5: < 1.1.1
 --- error_log
 ssl session store: skipped: TLS version 304
 --- no_error_log

--- a/t/143-ssl-session-fetch.t
+++ b/t/143-ssl-session-fetch.t
@@ -7,7 +7,7 @@ use File::Basename;
 
 repeat_each(3);
 
-plan tests => repeat_each() * (blocks() * 5 + 15);
+plan tests => repeat_each() * (blocks() * 5 + 16);
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 
@@ -1358,6 +1358,86 @@ ssl session fetch: connection reusable: 1
 reusable connection: 0
 ssl_session_fetch_by_lua_block:1: ssl fetch sess by lua is running!,
 /m,
+]
+
+--- no_error_log
+[error]
+[alert]
+[emerg]
+
+
+
+=== TEST 17: yield when reading early data
+--- http_config
+    ssl_session_fetch_by_lua_block {
+        local begin = ngx.now()
+        ngx.sleep(0.1)
+        print("elapsed in ssl fetch session by lua: ", ngx.now() - begin)
+    }
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+        ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+        ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_session_tickets off;
+        ssl_early_data on;
+
+        server_tokens off;
+    }
+--- config
+    server_tokens off;
+    resolver $TEST_NGINX_RESOLVER ipv6=off;
+    lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+
+    location /t {
+        set $port $TEST_NGINX_MEMCACHED_PORT;
+
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(5000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(package.loaded.session, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                package.loaded.session = sess
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+close: 1 nil
+
+--- grep_error_log eval
+qr/elapsed in ssl fetch session by lua: 0.(?:09|1[01])\d+,/,
+
+--- grep_error_log_out eval
+[
+'',
+qr/elapsed in ssl fetch session by lua: 0.(?:09|1[01])\d+,/,
+qr/elapsed in ssl fetch session by lua: 0.(?:09|1[01])\d+,/,
 ]
 
 --- no_error_log


### PR DESCRIPTION
Previously, we used ClientHello callback to do ssl session fetching
non-blockingly. However, this way can not handle an edge case: the ssl
session resumption via session ticket might fail, and the client falls
back to session ID resumption. The ClientHello callback is run too early
to know if the client will fall back to use session ID resumption.

Therefore, we have to take back the OpenSSL sess_set_get_cb_yield patch and
upgrade it to adapt OpenSSL 1.1.1.

Thanks @yongjianchn and @crasyangel for their help.

Current implementation skips `ssl_session_fetch|store_by_lua*` for TLS 1.3 client. It is possible to support PSK with session ID in TLS 1.3. But it need to modify a number of functions to pass the result up, which will make the patch too complex to maintain. Since PSK with session ticket is supported, supporting PSK with session ID is not so profitable. If someone needs this feature, he/she can submit another pull request.

I have tested the change of `ssl_session_fetch_by_lua*` locally with this test case:

```
=== TEST 17: skip ssl_session_fetch in TLSv1.3
--- http_config
    lua_shared_dict done 16k;
    ssl_session_fetch_by_lua_block { error("should not run") }
    server {
        listen $TEST_NGINX_SERVER_SSL_PORT ssl;
        server_name   test.com;
        ssl_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
        ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
        ssl_protocols TLSv1.3;
        ssl_session_tickets off;
        server_tokens off;

        location / {
            content_by_lua_block {
                ngx.shared.done:set("handshake", true)
            }
        }
    }
--- config
    server_tokens off;
    resolver $TEST_NGINX_RESOLVER ipv6=off;
    lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;

    location /t {
        content_by_lua_block {
            local req = "'GET / HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n'"
            local id = ("1"):rep(32)
            local ngx_pipe = require "ngx.pipe"
            local cmd = "echo -n " .. req .. " | " ..
                "/home/lzx/openssl-1.1.1b/apps/openssl s_client -connect 127.0.0.1:$TEST_NGINX_SERVER_SSL_PORT -tls1_3 -psk_test_id " .. id
            local proc, err = ngx_pipe.spawn({"sh", "-c", cmd})
            if not proc then
                ngx.say(err)
                return
            end

            local step = 0.001
            while step < 2 do
                ngx.sleep(step)
                step = step * 2

                if ngx.shared.done:get("handshake") then
                    local out = proc:stderr_read_all()
                    ngx.log(ngx.INFO, out)
                    ngx.say("ok")
                    return
                end
            end

            ngx.log(ngx.ERR, "openssl client handshake timeout")
        }
    }

--- request
GET /t
--- response_body
ok
--- error_log
ssl session fetch: skipped: TLS version 304
O = OpenResty, OU = OpenResty
--- no_error_log
[error]
[alert]
[emerg]
```

Since `openssl s_client` doesn't support PSK with session ID, I have to modify its source code and add a way to specify a fake session ID in the PSK. Maybe I need to submit this change to `openresty/openssl` as a test dependency? `curl` doesn't support PSK at all.

TODO: update documentation.