### PR TITLE
fix(set_more_tries): fix infinite retry when no available servers and…

### DIFF
--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -692,8 +692,9 @@ ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
 
 #if (nginx_version >= 1007005)
     max_tries = r->upstream->conf->next_upstream_tries;
-    // set a default tries to avoid infinite tries when all peers are not available
-    max_tries = max_tries == 0 ? 3 : max_tries; 
+    // set a default tries to avoid infinite retrying
+    // when all peers are invalid with default proxy_next_upstream_tries
+    max_tries = max_tries == 0 ? 3 : max_tries;
     total = bp->total_tries + r->upstream->peer.tries - 1;
 
     if (max_tries && total + count > max_tries) {

--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -692,6 +692,8 @@ ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
 
 #if (nginx_version >= 1007005)
     max_tries = r->upstream->conf->next_upstream_tries;
+    // set a default tries to avoid infinite tries when all peers are not available
+    max_tries = max_tries == 0 ? 3 : max_tries; 
     total = bp->total_tries + r->upstream->peer.tries - 1;
 
     if (max_tries && total + count > max_tries) {

--- a/t/138-balancer.t
+++ b/t/138-balancer.t
@@ -522,4 +522,3 @@ http next upstream, 2
 http next upstream, 2
 --- error_log
 failed to set more tries: reduced tries due to limit
-[alert]

--- a/t/138-balancer.t
+++ b/t/138-balancer.t
@@ -522,3 +522,4 @@ http next upstream, 2
 http next upstream, 2
 --- error_log
 failed to set more tries: reduced tries due to limit
+

--- a/t/138-balancer.t
+++ b/t/138-balancer.t
@@ -520,7 +520,6 @@ set more tries: reduced tries due to limit
 http next upstream, 2
 http next upstream, 2
 http next upstream, 2
-http next upstream, 2
---- no_error_log
+--- error_log
 failed to set more tries: reduced tries due to limit
 [alert]


### PR DESCRIPTION
set default proxy_next_proxy_tries to 3 to avoid infinite retry when proxy_next_proxy_tries=0 and no
valid servers

fix #1545

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

related issues：https://github.com/openresty/lua-nginx-module/issues/1545