### PR TITLE
 bugfix: ensured the 'pcre_version' symbol is preserved and undefined when PCRE is statically linked.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ install:
   - git clone https://github.com/openresty/rds-json-nginx-module.git ../rds-json-nginx-module
   - git clone https://github.com/openresty/srcache-nginx-module.git ../srcache-nginx-module
   - git clone https://github.com/openresty/redis2-nginx-module.git ../redis2-nginx-module
-  - git clone https://github.com/openresty/lua-resty-core.git ../lua-resty-core
+  - git clone -b chore/bump-api https://github.com/thibaultcha/lua-resty-core.git ../lua-resty-core
   - git clone https://github.com/openresty/lua-resty-lrucache.git ../lua-resty-lrucache
   - git clone https://github.com/openresty/lua-resty-mysql.git ../lua-resty-mysql
   - git clone https://github.com/openresty/stream-lua-nginx-module.git ../stream-lua-nginx-module

--- a/README.markdown
+++ b/README.markdown
@@ -63,7 +63,7 @@ Production ready.
 Version
 =======
 
-This document describes ngx_lua [v0.10.15](https://github.com/openresty/lua-nginx-module/tags) released on March 14th, 2019.
+This document describes ngx_lua [v0.10.16](https://github.com/openresty/lua-nginx-module/tags), which is not released yet.
 
 Synopsis
 ========

--- a/config
+++ b/config
@@ -588,5 +588,27 @@ else
     CORE_LIBS="$CORE_LIBS $ngx_module_libs"
 fi
 
+# ----------------------------------------
+
+if [ $PCRE != NO -a $PCRE != YES ]; then
+    # force pcre_version symbol to be undefined when PCRE is statically linked
+
+    ngx_feature="force undefined symbols (--undefined)"
+    ngx_feature_libs="-Wl,--undefined=printf"
+    ngx_feature_name=
+    ngx_feature_run=no
+    ngx_feature_incs="#include <stdio.h>"
+    ngx_feature_path=
+    ngx_feature_test='printf("hello");'
+
+    . auto/feature
+
+    if [ $ngx_found = yes ]; then
+        CORE_LIBS="$CORE_LIBS -Wl,--undefined=pcre_version"
+    fi
+fi
+
+# ----------------------------------------
+
 #CFLAGS=$"$CFLAGS -DLUA_DEFAULT_PATH='\"/usr/local/openresty/lualib/?.lua\"'"
 #CFLAGS=$"$CFLAGS -DLUA_DEFAULT_CPATH='\"/usr/local/openresty/lualib/?.so\"'"

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -12,7 +12,7 @@ Production ready.
 
 = Version =
 
-This document describes ngx_lua [https://github.com/openresty/lua-nginx-module/tags v0.10.15] released on March 14th, 2019.
+This document describes ngx_lua [https://github.com/openresty/lua-nginx-module/tags v0.10.16], which is not released yet.
 
 = Synopsis =
 <geshi lang="nginx">

--- a/src/api/ngx_http_lua_api.h
+++ b/src/api/ngx_http_lua_api.h
@@ -19,7 +19,7 @@
 /* Public API for other Nginx modules */
 
 
-#define ngx_http_lua_version  10015
+#define ngx_http_lua_version  10016
 
 
 typedef struct {


### PR DESCRIPTION
> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

The API version of this module has been bumped to ensure lua-resty-core's compatibility. Currently, lua-resty-core with a statically linked PCRE prevents `resty.core.regex` and `ngx.re` from loading.

Sister PRs:

- https://github.com/openresty/stream-lua-nginx-module/pull/168
- https://github.com/openresty/lua-resty-core/pull/261