### PR TITLE
 feature: better SSL/TLS handshake control.

### DIFF
--- a/config
+++ b/config
@@ -353,6 +353,7 @@ HTTP_LUA_SRCS=" \
             $ngx_addon_dir/src/ngx_http_lua_timer.c \
             $ngx_addon_dir/src/ngx_http_lua_config.c \
             $ngx_addon_dir/src/ngx_http_lua_worker.c \
+            $ngx_addon_dir/src/ngx_http_lua_ssl_client_helloby.c \
             $ngx_addon_dir/src/ngx_http_lua_ssl_certby.c \
             $ngx_addon_dir/src/ngx_http_lua_ssl_ocsp.c \
             $ngx_addon_dir/src/ngx_http_lua_lex.c \
@@ -417,6 +418,7 @@ HTTP_LUA_DEPS=" \
             $ngx_addon_dir/src/ngx_http_lua_timer.h \
             $ngx_addon_dir/src/ngx_http_lua_config.h \
             $ngx_addon_dir/src/ngx_http_lua_worker.h \
+            $ngx_addon_dir/src/ngx_http_lua_ssl_client_helloby.h \
             $ngx_addon_dir/src/ngx_http_lua_ssl_certby.h \
             $ngx_addon_dir/src/ngx_http_lua_lex.h \
             $ngx_addon_dir/src/ngx_http_lua_balancer.h \

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -119,19 +119,20 @@ typedef struct {
 
 
 /* must be within 16 bit */
-#define NGX_HTTP_LUA_CONTEXT_SET            0x0001
-#define NGX_HTTP_LUA_CONTEXT_REWRITE        0x0002
-#define NGX_HTTP_LUA_CONTEXT_ACCESS         0x0004
-#define NGX_HTTP_LUA_CONTEXT_CONTENT        0x0008
-#define NGX_HTTP_LUA_CONTEXT_LOG            0x0010
-#define NGX_HTTP_LUA_CONTEXT_HEADER_FILTER  0x0020
-#define NGX_HTTP_LUA_CONTEXT_BODY_FILTER    0x0040
-#define NGX_HTTP_LUA_CONTEXT_TIMER          0x0080
-#define NGX_HTTP_LUA_CONTEXT_INIT_WORKER    0x0100
-#define NGX_HTTP_LUA_CONTEXT_BALANCER       0x0200
-#define NGX_HTTP_LUA_CONTEXT_SSL_CERT       0x0400
-#define NGX_HTTP_LUA_CONTEXT_SSL_SESS_STORE 0x0800
-#define NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH 0x1000
+#define NGX_HTTP_LUA_CONTEXT_SET              0x0001
+#define NGX_HTTP_LUA_CONTEXT_REWRITE          0x0002
+#define NGX_HTTP_LUA_CONTEXT_ACCESS           0x0004
+#define NGX_HTTP_LUA_CONTEXT_CONTENT          0x0008
+#define NGX_HTTP_LUA_CONTEXT_LOG              0x0010
+#define NGX_HTTP_LUA_CONTEXT_HEADER_FILTER    0x0020
+#define NGX_HTTP_LUA_CONTEXT_BODY_FILTER      0x0040
+#define NGX_HTTP_LUA_CONTEXT_TIMER            0x0080
+#define NGX_HTTP_LUA_CONTEXT_INIT_WORKER      0x0100
+#define NGX_HTTP_LUA_CONTEXT_BALANCER         0x0200
+#define NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO 0x0400
+#define NGX_HTTP_LUA_CONTEXT_SSL_CERT         0x0800
+#define NGX_HTTP_LUA_CONTEXT_SSL_SESS_STORE   0x1000
+#define NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH   0x2000
 
 
 #ifndef NGX_LUA_NO_FFI_API
@@ -278,6 +279,10 @@ struct ngx_http_lua_main_conf_s {
 union ngx_http_lua_srv_conf_u {
 #if (NGX_HTTP_SSL)
     struct {
+        ngx_http_lua_srv_conf_handler_pt     ssl_client_hello_handler;
+        ngx_str_t                            ssl_client_hello_src;
+        u_char                              *ssl_client_hello_src_key;
+
         ngx_http_lua_srv_conf_handler_pt     ssl_cert_handler;
         ngx_str_t                            ssl_cert_src;
         u_char                              *ssl_cert_src_key;

--- a/src/ngx_http_lua_control.c
+++ b/src/ngx_http_lua_control.c
@@ -322,13 +322,15 @@ ngx_http_lua_ngx_exit(lua_State *L)
                                | NGX_HTTP_LUA_CONTEXT_TIMER
                                | NGX_HTTP_LUA_CONTEXT_HEADER_FILTER
                                | NGX_HTTP_LUA_CONTEXT_BALANCER
+                               | NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO
                                | NGX_HTTP_LUA_CONTEXT_SSL_CERT
                                | NGX_HTTP_LUA_CONTEXT_SSL_SESS_STORE
                                | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH);
 
     rc = (ngx_int_t) luaL_checkinteger(L, 1);
 
-    if (ctx->context & (NGX_HTTP_LUA_CONTEXT_SSL_CERT
+    if (ctx->context & (NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO
+                        | NGX_HTTP_LUA_CONTEXT_SSL_CERT
                         | NGX_HTTP_LUA_CONTEXT_SSL_SESS_STORE
                         | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH))
     {
@@ -474,6 +476,7 @@ ngx_http_lua_ffi_exit(ngx_http_request_t *r, int status, u_char *err,
                                        | NGX_HTTP_LUA_CONTEXT_TIMER
                                        | NGX_HTTP_LUA_CONTEXT_HEADER_FILTER
                                        | NGX_HTTP_LUA_CONTEXT_BALANCER
+                                       | NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO
                                        | NGX_HTTP_LUA_CONTEXT_SSL_CERT
                                        | NGX_HTTP_LUA_CONTEXT_SSL_SESS_STORE
                                        | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH,
@@ -483,7 +486,8 @@ ngx_http_lua_ffi_exit(ngx_http_request_t *r, int status, u_char *err,
         return NGX_ERROR;
     }
 
-    if (ctx->context & (NGX_HTTP_LUA_CONTEXT_SSL_CERT
+    if (ctx->context & (NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO
+                        | NGX_HTTP_LUA_CONTEXT_SSL_CERT
                         | NGX_HTTP_LUA_CONTEXT_SSL_SESS_STORE
                         | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH))
     {

--- a/src/ngx_http_lua_coroutine.c
+++ b/src/ngx_http_lua_coroutine.c
@@ -77,6 +77,7 @@ ngx_http_lua_coroutine_create_helper(lua_State *L, ngx_http_request_t *r,
                                | NGX_HTTP_LUA_CONTEXT_ACCESS
                                | NGX_HTTP_LUA_CONTEXT_CONTENT
                                | NGX_HTTP_LUA_CONTEXT_TIMER
+                               | NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO
                                | NGX_HTTP_LUA_CONTEXT_SSL_CERT
                                | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH);
 
@@ -158,6 +159,7 @@ ngx_http_lua_coroutine_resume(lua_State *L)
                                | NGX_HTTP_LUA_CONTEXT_ACCESS
                                | NGX_HTTP_LUA_CONTEXT_CONTENT
                                | NGX_HTTP_LUA_CONTEXT_TIMER
+                               | NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO
                                | NGX_HTTP_LUA_CONTEXT_SSL_CERT
                                | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH);
 
@@ -219,6 +221,7 @@ ngx_http_lua_coroutine_yield(lua_State *L)
                                | NGX_HTTP_LUA_CONTEXT_ACCESS
                                | NGX_HTTP_LUA_CONTEXT_CONTENT
                                | NGX_HTTP_LUA_CONTEXT_TIMER
+                               | NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO
                                | NGX_HTTP_LUA_CONTEXT_SSL_CERT
                                | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH);
 
@@ -381,6 +384,7 @@ ngx_http_lua_coroutine_status(lua_State *L)
                                | NGX_HTTP_LUA_CONTEXT_ACCESS
                                | NGX_HTTP_LUA_CONTEXT_CONTENT
                                | NGX_HTTP_LUA_CONTEXT_TIMER
+                               | NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO
                                | NGX_HTTP_LUA_CONTEXT_SSL_CERT
                                | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH);
 

--- a/src/ngx_http_lua_phase.c
+++ b/src/ngx_http_lua_phase.c
@@ -80,6 +80,10 @@ ngx_http_lua_ngx_get_phase(lua_State *L)
         lua_pushliteral(L, "balancer");
         break;
 
+    case NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO:
+        lua_pushliteral(L, "ssl_client_hello");
+        break;
+
     case NGX_HTTP_LUA_CONTEXT_SSL_CERT:
         lua_pushliteral(L, "ssl_cert");
         break;

--- a/src/ngx_http_lua_pipe.c
+++ b/src/ngx_http_lua_pipe.c
@@ -1159,6 +1159,7 @@ ngx_http_lua_pipe_get_lua_ctx(ngx_http_request_t *r,
                                         | NGX_HTTP_LUA_CONTEXT_ACCESS
                                         | NGX_HTTP_LUA_CONTEXT_CONTENT
                                         | NGX_HTTP_LUA_CONTEXT_TIMER
+                                        | NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO
                                         | NGX_HTTP_LUA_CONTEXT_SSL_CERT
                                         | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH,
                                         errbuf, errbuf_size);

--- a/src/ngx_http_lua_sleep.c
+++ b/src/ngx_http_lua_sleep.c
@@ -56,6 +56,7 @@ ngx_http_lua_ngx_sleep(lua_State *L)
                                | NGX_HTTP_LUA_CONTEXT_ACCESS
                                | NGX_HTTP_LUA_CONTEXT_CONTENT
                                | NGX_HTTP_LUA_CONTEXT_TIMER
+                               | NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO
                                | NGX_HTTP_LUA_CONTEXT_SSL_CERT
                                | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH);
 

--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -435,6 +435,7 @@ ngx_http_lua_socket_tcp(lua_State *L)
                                | NGX_HTTP_LUA_CONTEXT_ACCESS
                                | NGX_HTTP_LUA_CONTEXT_CONTENT
                                | NGX_HTTP_LUA_CONTEXT_TIMER
+                               | NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO
                                | NGX_HTTP_LUA_CONTEXT_SSL_CERT
                                | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH);
 
@@ -885,6 +886,7 @@ ngx_http_lua_socket_tcp_connect(lua_State *L)
                                | NGX_HTTP_LUA_CONTEXT_ACCESS
                                | NGX_HTTP_LUA_CONTEXT_CONTENT
                                | NGX_HTTP_LUA_CONTEXT_TIMER
+                               | NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO
                                | NGX_HTTP_LUA_CONTEXT_SSL_CERT
                                | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH);
 

--- a/src/ngx_http_lua_ssl.h
+++ b/src/ngx_http_lua_ssl.h
@@ -25,11 +25,12 @@ typedef struct {
     ngx_str_t                session_id;
 
     int                      exit_code;  /* exit code for openssl's
-                                            set_cert_cb callback */
+                                            set_client_hello_cb or set_cert_cb callback */
 
     unsigned                 done:1;
     unsigned                 aborted:1;
 
+    unsigned                 entered_client_hello_handler:1;
     unsigned                 entered_cert_handler:1;
     unsigned                 entered_sess_fetch_handler:1;
 } ngx_http_lua_ssl_ctx_t;

--- a/src/ngx_http_lua_ssl_client_helloby.c
+++ b/src/ngx_http_lua_ssl_client_helloby.c
@@ -1,0 +1,725 @@
+
+/*
+ * Copyright (C) Yichun Zhang (agentzh)
+ */
+
+
+#ifndef DDEBUG
+#define DDEBUG 0
+#endif
+#include "ddebug.h"
+
+
+#if (NGX_HTTP_SSL)
+
+
+#include "ngx_http_lua_cache.h"
+#include "ngx_http_lua_initworkerby.h"
+#include "ngx_http_lua_util.h"
+#include "ngx_http_ssl_module.h"
+#include "ngx_http_lua_contentby.h"
+#include "ngx_http_lua_ssl_client_helloby.h"
+#include "ngx_http_lua_directive.h"
+#include "ngx_http_lua_ssl.h"
+
+
+static void ngx_http_lua_ssl_client_hello_done(void *data);
+static void ngx_http_lua_ssl_client_hello_aborted(void *data);
+static u_char *ngx_http_lua_log_ssl_client_hello_error(ngx_log_t *log, u_char *buf,
+    size_t len);
+static ngx_int_t ngx_http_lua_ssl_client_hello_by_chunk(lua_State *L,
+    ngx_http_request_t *r);
+
+
+ngx_int_t
+ngx_http_lua_ssl_client_hello_handler_file(ngx_http_request_t *r,
+    ngx_http_lua_srv_conf_t *lscf, lua_State *L)
+{
+    ngx_int_t           rc;
+
+    rc = ngx_http_lua_cache_loadfile(r->connection->log, L,
+                                     lscf->srv.ssl_client_hello_src.data,
+                                     lscf->srv.ssl_client_hello_src_key);
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    /*  make sure we have a valid code chunk */
+    ngx_http_lua_assert(lua_isfunction(L, -1));
+
+    return ngx_http_lua_ssl_client_hello_by_chunk(L, r);
+}
+
+
+ngx_int_t
+ngx_http_lua_ssl_client_hello_handler_inline(ngx_http_request_t *r,
+    ngx_http_lua_srv_conf_t *lscf, lua_State *L)
+{
+    ngx_int_t           rc;
+
+    rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
+                                       lscf->srv.ssl_client_hello_src.data,
+                                       lscf->srv.ssl_client_hello_src.len,
+                                       lscf->srv.ssl_client_hello_src_key,
+                                       "=ssl_client_hello_by_lua");
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    /*  make sure we have a valid code chunk */
+    ngx_http_lua_assert(lua_isfunction(L, -1));
+
+    return ngx_http_lua_ssl_client_hello_by_chunk(L, r);
+}
+
+
+char *
+ngx_http_lua_ssl_client_hello_by_lua_block(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf)
+{
+    char        *rv;
+    ngx_conf_t   save;
+
+    save = *cf;
+    cf->handler = ngx_http_lua_ssl_client_hello_by_lua;
+    cf->handler_conf = conf;
+
+    rv = ngx_http_lua_conf_lua_block_parse(cf, cmd);
+
+    *cf = save;
+
+    return rv;
+}
+
+
+char *
+ngx_http_lua_ssl_client_hello_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf)
+{
+#if OPENSSL_VERSION_NUMBER < 0x10101000L
+
+    ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                  "at least OpenSSL 1.0.2e required but found "
+                  OPENSSL_VERSION_TEXT);
+
+    return NGX_CONF_ERROR;
+
+#else
+
+    u_char                      *p;
+    u_char                      *name;
+    ngx_str_t                   *value;
+    ngx_http_lua_srv_conf_t     *lscf = conf;
+
+    /*  must specify a concrete handler */
+    if (cmd->post == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    if (lscf->srv.ssl_client_hello_handler) {
+        return "is duplicate";
+    }
+
+    if (ngx_http_lua_ssl_init(cf->log) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    value = cf->args->elts;
+
+    lscf->srv.ssl_client_hello_handler = (ngx_http_lua_srv_conf_handler_pt) cmd->post;
+
+    if (cmd->post == ngx_http_lua_ssl_client_hello_handler_file) {
+        /* Lua code in an external file */
+
+        name = ngx_http_lua_rebase_path(cf->pool, value[1].data,
+                                        value[1].len);
+        if (name == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        lscf->srv.ssl_client_hello_src.data = name;
+        lscf->srv.ssl_client_hello_src.len = ngx_strlen(name);
+
+        p = ngx_palloc(cf->pool, NGX_HTTP_LUA_FILE_KEY_LEN + 1);
+        if (p == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        lscf->srv.ssl_client_hello_src_key = p;
+
+        p = ngx_copy(p, NGX_HTTP_LUA_FILE_TAG, NGX_HTTP_LUA_FILE_TAG_LEN);
+        p = ngx_http_lua_digest_hex(p, value[1].data, value[1].len);
+        *p = '\0';
+
+    } else {
+        /* inlined Lua code */
+
+        lscf->srv.ssl_client_hello_src = value[1];
+
+        p = ngx_palloc(cf->pool,
+                       sizeof("ssl_client_hello_by_lua") +
+                       NGX_HTTP_LUA_INLINE_KEY_LEN);
+        if (p == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        lscf->srv.ssl_client_hello_src_key = p;
+
+        p = ngx_copy(p, "ssl_client_hello_by_lua",
+                     sizeof("ssl_client_hello_by_lua") - 1);
+        p = ngx_copy(p, NGX_HTTP_LUA_INLINE_TAG, NGX_HTTP_LUA_INLINE_TAG_LEN);
+        p = ngx_http_lua_digest_hex(p, value[1].data, value[1].len);
+        *p = '\0';
+    }
+
+    return NGX_CONF_OK;
+
+#endif  /* OPENSSL_VERSION_NUMBER < 0x10101000L */
+}
+
+
+int
+ngx_http_lua_ssl_client_hello_handler(ngx_ssl_conn_t *ssl_conn, int *al, void *arg)
+{
+    lua_State                       *L;
+    ngx_int_t                        rc;
+    ngx_connection_t                *c, *fc;
+    ngx_http_request_t              *r = NULL;
+    ngx_pool_cleanup_t              *cln;
+    ngx_http_connection_t           *hc;
+    ngx_http_lua_srv_conf_t         *lscf;
+    ngx_http_core_loc_conf_t        *clcf;
+    ngx_http_lua_ssl_ctx_t          *cctx;
+    ngx_http_core_srv_conf_t        *cscf;
+
+    c = ngx_ssl_get_connection(ssl_conn);
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "ssl client hello: connection reusable: %ud", c->reusable);
+
+    cctx = ngx_http_lua_ssl_get_ctx(c->ssl->connection);
+
+    dd("ssl client_hello handler, client_hello-ctx=%p", cctx);
+
+    if (cctx && cctx->entered_client_hello_handler) {
+        /* not the first time */
+
+        if (cctx->done) {
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                           "lua_client_hello_by_lua: client_hello cb exit code: %d",
+                           cctx->exit_code);
+
+            dd("lua ssl client_hello done, finally");
+            return cctx->exit_code;
+        }
+
+        return -1;
+    }
+
+    dd("first time");
+
+    ngx_reusable_connection(c, 0);
+
+    hc = c->data;
+
+    fc = ngx_http_lua_create_fake_connection(NULL);
+    if (fc == NULL) {
+        goto failed;
+    }
+
+    fc->log->handler = ngx_http_lua_log_ssl_client_hello_error;
+    fc->log->data = fc;
+
+    fc->addr_text = c->addr_text;
+    fc->listening = c->listening;
+
+    r = ngx_http_lua_create_fake_request(fc);
+    if (r == NULL) {
+        goto failed;
+    }
+
+    r->main_conf = hc->conf_ctx->main_conf;
+    r->srv_conf = hc->conf_ctx->srv_conf;
+    r->loc_conf = hc->conf_ctx->loc_conf;
+
+    fc->log->file = c->log->file;
+    fc->log->log_level = c->log->log_level;
+    fc->ssl = c->ssl;
+
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+#if defined(nginx_version) && nginx_version >= 1003014
+
+#   if nginx_version >= 1009000
+
+    ngx_set_connection_log(fc, clcf->error_log);
+
+#   else
+
+    ngx_http_set_connection_log(fc, clcf->error_log);
+
+#   endif
+
+#else
+
+    fc->log->file = clcf->error_log->file;
+
+    if (!(fc->log->log_level & NGX_LOG_DEBUG_CONNECTION)) {
+        fc->log->log_level = clcf->error_log->log_level;
+    }
+
+#endif
+
+    if (cctx == NULL) {
+        cctx = ngx_pcalloc(c->pool, sizeof(ngx_http_lua_ssl_ctx_t));
+        if (cctx == NULL) {
+            goto failed;  /* error */
+        }
+    }
+
+    cctx->exit_code = 1;  /* successful by default */
+    cctx->connection = c;
+    cctx->request = r;
+    cctx->entered_client_hello_handler = 1;
+    cctx->done = 0;
+
+    dd("setting cctx");
+
+    if (SSL_set_ex_data(c->ssl->connection, ngx_http_lua_ssl_ctx_index, cctx)
+        == 0)
+    {
+        ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "SSL_set_ex_data() failed");
+        goto failed;
+    }
+
+    lscf = ngx_http_get_module_srv_conf(r, ngx_http_lua_module);
+
+    /* TODO honor lua_code_cache off */
+    L = ngx_http_lua_get_lua_vm(r, NULL);
+
+    c->log->action = "loading SSL client_hello by lua";
+
+    if (lscf->srv.ssl_client_hello_handler == NULL) {
+        cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+
+        ngx_log_error(NGX_LOG_ALERT, c->log, 0,
+                      "no ssl_client_hello_by_lua* defined in "
+                      "server %V", &cscf->server_name);
+
+        goto failed;
+    }
+
+    rc = lscf->srv.ssl_client_hello_handler(r, lscf, L);
+
+    if (rc >= NGX_OK || rc == NGX_ERROR) {
+        cctx->done = 1;
+
+        if (cctx->cleanup) {
+            *cctx->cleanup = NULL;
+        }
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                       "lua_client_hello_by_lua: handler return value: %i, "
+                       "client_hello cb exit code: %d", rc, cctx->exit_code);
+
+        c->log->action = "SSL handshaking";
+        return cctx->exit_code;
+    }
+
+    /* rc == NGX_DONE */
+
+    cln = ngx_pool_cleanup_add(fc->pool, 0);
+    if (cln == NULL) {
+        goto failed;
+    }
+
+    cln->handler = ngx_http_lua_ssl_client_hello_done;
+    cln->data = cctx;
+
+    if (cctx->cleanup == NULL) {
+        cln = ngx_pool_cleanup_add(c->pool, 0);
+        if (cln == NULL) {
+            goto failed;
+        }
+
+        cln->data = cctx;
+        cctx->cleanup = &cln->handler;
+    }
+
+    *cctx->cleanup = ngx_http_lua_ssl_client_hello_aborted;
+
+    return -1;
+
+#if 1
+failed:
+
+    if (r && r->pool) {
+        ngx_http_lua_free_fake_request(r);
+    }
+
+    if (fc) {
+        ngx_http_lua_close_fake_connection(fc);
+    }
+
+    return 0;
+#endif
+}
+
+
+static void
+ngx_http_lua_ssl_client_hello_done(void *data)
+{
+    ngx_connection_t                *c;
+    ngx_http_lua_ssl_ctx_t          *cctx = data;
+
+    dd("lua ssl client_hello done");
+
+    if (cctx->aborted) {
+        return;
+    }
+
+    ngx_http_lua_assert(cctx->done == 0);
+
+    cctx->done = 1;
+
+    if (cctx->cleanup) {
+        *cctx->cleanup = NULL;
+    }
+
+    c = cctx->connection;
+
+    c->log->action = "SSL handshaking";
+
+    ngx_post_event(c->write, &ngx_posted_events);
+}
+
+
+static void
+ngx_http_lua_ssl_client_hello_aborted(void *data)
+{
+    ngx_http_lua_ssl_ctx_t      *cctx = data;
+
+    dd("lua ssl client_hello done");
+
+    if (cctx->done) {
+        /* completed successfully already */
+        return;
+    }
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, cctx->connection->log, 0,
+                   "lua_client_hello_by_lua: client_hello cb aborted");
+
+    cctx->aborted = 1;
+    cctx->request->connection->ssl = NULL;
+
+    ngx_http_lua_finalize_fake_request(cctx->request, NGX_ERROR);
+}
+
+
+static u_char *
+ngx_http_lua_log_ssl_client_hello_error(ngx_log_t *log, u_char *buf, size_t len)
+{
+    u_char              *p;
+    ngx_connection_t    *c;
+
+    if (log->action) {
+        p = ngx_snprintf(buf, len, " while %s", log->action);
+        len -= p - buf;
+        buf = p;
+    }
+
+    p = ngx_snprintf(buf, len, ", context: ssl_client_hello_by_lua*");
+    len -= p - buf;
+    buf = p;
+
+    c = log->data;
+
+    if (c->addr_text.len) {
+        p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
+        len -= p - buf;
+        buf = p;
+    }
+
+    if (c && c->listening && c->listening->addr_text.len) {
+        p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
+        /* len -= p - buf; */
+        buf = p;
+    }
+
+    return buf;
+}
+
+
+static ngx_int_t
+ngx_http_lua_ssl_client_hello_by_chunk(lua_State *L, ngx_http_request_t *r)
+{
+    int                      co_ref;
+    ngx_int_t                rc;
+    lua_State               *co;
+    ngx_http_lua_ctx_t      *ctx;
+    ngx_http_cleanup_t      *cln;
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+
+    if (ctx == NULL) {
+        ctx = ngx_http_lua_create_ctx(r);
+        if (ctx == NULL) {
+            rc = NGX_ERROR;
+            ngx_http_lua_finalize_request(r, rc);
+            return rc;
+        }
+
+    } else {
+        dd("reset ctx");
+        ngx_http_lua_reset_ctx(r, L, ctx);
+    }
+
+    ctx->entered_content_phase = 1;
+
+    /*  {{{ new coroutine to handle request */
+    co = ngx_http_lua_new_thread(r, L, &co_ref);
+
+    if (co == NULL) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "lua: failed to create new coroutine to handle request");
+
+        rc = NGX_ERROR;
+        ngx_http_lua_finalize_request(r, rc);
+        return rc;
+    }
+
+    /*  move code closure to new coroutine */
+    lua_xmove(L, co, 1);
+
+#ifndef OPENRESTY_LUAJIT
+    /*  set closure's env table to new coroutine's globals table */
+    ngx_http_lua_get_globals_table(co);
+    lua_setfenv(co, -2);
+#endif
+
+    /* save nginx request in coroutine globals table */
+    ngx_http_lua_set_req(co, r);
+
+    ctx->cur_co_ctx = &ctx->entry_co_ctx;
+    ctx->cur_co_ctx->co = co;
+    ctx->cur_co_ctx->co_ref = co_ref;
+#ifdef NGX_LUA_USE_ASSERT
+    ctx->cur_co_ctx->co_top = 1;
+#endif
+
+    /* register request cleanup hooks */
+    if (ctx->cleanup == NULL) {
+        cln = ngx_http_cleanup_add(r, 0);
+        if (cln == NULL) {
+            rc = NGX_ERROR;
+            ngx_http_lua_finalize_request(r, rc);
+            return rc;
+        }
+
+        cln->handler = ngx_http_lua_request_cleanup_handler;
+        cln->data = ctx;
+        ctx->cleanup = &cln->handler;
+    }
+
+    ctx->context = NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO;
+
+    rc = ngx_http_lua_run_thread(L, r, ctx, 0);
+
+    if (rc == NGX_ERROR || rc >= NGX_OK) {
+        /* do nothing */
+
+    } else if (rc == NGX_AGAIN) {
+        rc = ngx_http_lua_content_run_posted_threads(L, r, ctx, 0);
+
+    } else if (rc == NGX_DONE) {
+        rc = ngx_http_lua_content_run_posted_threads(L, r, ctx, 1);
+
+    } else {
+        rc = NGX_OK;
+    }
+
+    ngx_http_lua_finalize_request(r, rc);
+    return rc;
+}
+
+
+#ifndef NGX_LUA_NO_FFI_API
+
+int
+ngx_http_lua_ffi_ssl_client_server_name(ngx_http_request_t *r, char **name,
+    size_t *namelen, char **err)
+{
+    ngx_ssl_conn_t          *ssl_conn;
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+    const unsigned char     *p;
+    size_t                   remaining, len;
+#endif
+
+    if (r->connection == NULL || r->connection->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = r->connection->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+
+#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
+
+#   if OPENSSL_VERSION_NUMBER >= 0x10101000L
+    remaining = 0;
+
+    if (!SSL_client_hello_get0_ext(ssl_conn, TLSEXT_TYPE_server_name, &p,
+                                   &remaining) ||
+        remaining <= 2) {
+        *err = "SSL_AD_UNRECOGNIZED_NAME";
+        return NGX_ERROR;
+    }
+
+    len = (*(p++) << 8);
+    len += *(p++);
+    if (len + 2 != remaining) {
+        *err = "SSL_AD_UNRECOGNIZED_NAME";
+        return NGX_ERROR;
+    }
+    remaining = len;
+
+    if (remaining == 0 || *p++ != TLSEXT_NAMETYPE_host_name) {
+        *err = "SSL_AD_UNRECOGNIZED_NAME";
+        return NGX_ERROR;
+    }
+    remaining--;
+
+    if (remaining <= 2) {
+        *err = "SSL_AD_UNRECOGNIZED_NAME";
+        return NGX_ERROR;
+    }
+    len = (*(p++) << 8);
+    len += *(p++);
+    if (len + 2 > remaining) {
+        *err = "SSL_AD_UNRECOGNIZED_NAME";
+        return NGX_ERROR;
+    }
+    remaining = len;
+
+    *name = (char *) p;
+    *namelen = len;
+
+     return NGX_OK;
+
+#   else
+    *err = "OpenSSL too old to";
+    return NGX_ERROR;
+
+#   endif
+
+#else
+
+    *err = "no TLS extension support";
+    return NGX_ERROR;
+
+#endif
+}
+
+
+int
+ngx_http_lua_ffi_ssl_set_protocols(ngx_http_request_t *r,
+    int protocols, char **err)
+{
+
+    ngx_ssl_conn_t    *ssl_conn;
+
+    if (r->connection == NULL || r->connection->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = r->connection->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+
+#if OPENSSL_VERSION_NUMBER >= 0x009080dfL
+    /* only in 0.9.8m+ */
+    SSL_clear_options(ssl_conn,
+                          SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1);
+#endif
+
+    if (!(protocols & NGX_SSL_SSLv2)) {
+        SSL_set_options(ssl_conn, SSL_OP_NO_SSLv2);
+    }
+    if (!(protocols & NGX_SSL_SSLv3)) {
+        SSL_set_options(ssl_conn, SSL_OP_NO_SSLv3);
+    }
+    if (!(protocols & NGX_SSL_TLSv1)) {
+        SSL_set_options(ssl_conn, SSL_OP_NO_TLSv1);
+    }
+#ifdef SSL_OP_NO_TLSv1_1
+    SSL_clear_options(ssl_conn, SSL_OP_NO_TLSv1_1);
+    if (!(protocols & NGX_SSL_TLSv1_1)) {
+        SSL_set_options(ssl_conn, SSL_OP_NO_TLSv1_1);
+    }
+#endif
+#ifdef SSL_OP_NO_TLSv1_2
+    SSL_clear_options(ssl_conn, SSL_OP_NO_TLSv1_2);
+    if (!(protocols & NGX_SSL_TLSv1_2)) {
+        SSL_set_options(ssl_conn, SSL_OP_NO_TLSv1_2);
+    }
+#endif
+#ifdef SSL_OP_NO_TLSv1_3
+    SSL_clear_options(ssl_conn, SSL_OP_NO_TLSv1_3);
+    if (!(protocols & NGX_SSL_TLSv1_3)) {
+        SSL_set_options(ssl_conn, SSL_OP_NO_TLSv1_3);
+    }
+#endif
+
+    return NGX_OK;
+}
+
+
+int
+ngx_http_lua_ffi_ssl_set_ciphers(ngx_http_request_t *r,
+    u_char *cdata, char **err)
+{
+    char              *ciphers = NULL;
+    ngx_ssl_conn_t    *ssl_conn;
+
+    if (r->connection == NULL || r->connection->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = r->connection->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+
+    ciphers = (char *)cdata;
+    if (ciphers == NULL) {
+        *err = "invalid ciphers failed";
+        goto failed;
+    }
+
+    if (SSL_set_cipher_list(ssl_conn, ciphers) == 0) {
+        *err = "SSL_set_cipher_list() failed";
+        goto failed;
+    }
+
+    return NGX_OK;
+
+failed:
+
+    ERR_clear_error();
+
+    return NGX_ERROR;
+}
+
+
+#endif  /* NGX_LUA_NO_FFI_API */
+
+
+#endif /* NGX_HTTP_SSL */

--- a/src/ngx_http_lua_ssl_client_helloby.h
+++ b/src/ngx_http_lua_ssl_client_helloby.h
@@ -1,0 +1,36 @@
+
+/*
+ * Copyright (C) Yichun Zhang (agentzh)
+ */
+
+
+#ifndef _NGX_HTTP_LUA_SSL_CLIENT_HELLOBY_H_INCLUDED_
+#define _NGX_HTTP_LUA_SSL_CLIENT_HELLOBY_H_INCLUDED_
+
+
+#include "ngx_http_lua_common.h"
+
+
+#if (NGX_HTTP_SSL)
+
+ngx_int_t ngx_http_lua_ssl_client_hello_handler_inline(ngx_http_request_t *r,
+    ngx_http_lua_srv_conf_t *lscf, lua_State *L);
+
+ngx_int_t ngx_http_lua_ssl_client_hello_handler_file(ngx_http_request_t *r,
+    ngx_http_lua_srv_conf_t *lscf, lua_State *L);
+
+char *ngx_http_lua_ssl_client_hello_by_lua_block(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+
+char *ngx_http_lua_ssl_client_hello_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+
+int ngx_http_lua_ssl_client_hello_handler(ngx_ssl_conn_t *ssl_conn, int *al, void *arg);
+
+
+#endif  /* NGX_HTTP_SSL */
+
+
+#endif /* _NGX_HTTP_LUA_SSL_CERTBY_H_INCLUDED_ */
+
+/* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/src/ngx_http_lua_util.h
+++ b/src/ngx_http_lua_util.h
@@ -85,6 +85,8 @@ extern char ngx_http_lua_headers_metatable_key;
      : (c) == NGX_HTTP_LUA_CONTEXT_TIMER ? "ngx.timer"                       \
      : (c) == NGX_HTTP_LUA_CONTEXT_INIT_WORKER ? "init_worker_by_lua*"       \
      : (c) == NGX_HTTP_LUA_CONTEXT_BALANCER ? "balancer_by_lua*"             \
+     : (c) == NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO ?                        \
+                                                 "ssl_client_hello_by_lua*"  \
      : (c) == NGX_HTTP_LUA_CONTEXT_SSL_CERT ? "ssl_certificate_by_lua*"      \
      : (c) == NGX_HTTP_LUA_CONTEXT_SSL_SESS_STORE ?                          \
                                                  "ssl_session_store_by_lua*" \

--- a/t/162-ssl-client-hello.t
+++ b/t/162-ssl-client-hello.t
@@ -1,0 +1,1826 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua;
+
+repeat_each(3);
+
+# All these tests need to have new openssl
+my $NginxBinary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
+my $openssl_version = eval { `$NginxBinary -V 2>&1` };
+
+if ($openssl_version =~ m/built with OpenSSL (0|1\.(0|1)\.0*)/) {
+    plan(skip_all => "too old OpenSSL, need 1.1.1, was $1");
+} else {
+    plan tests => repeat_each() * (blocks() * 6 + 6);
+}
+
+$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
+
+#log_level 'warn';
+log_level 'debug';
+
+no_long_string();
+#no_diff();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: simple logging
+--- http_config
+    ssl_client_hello_by_lua_block { print("ssl client hello by lua is running!") }
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block { ngx.status = 201 ngx.say("foo") ngx.exit(201) }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /foo HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to receive response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+sent http request: 56 bytes.
+received: HTTP/1.1 201 Created
+received: Server: nginx
+received: Content-Type: text/plain
+received: Content-Length: 4
+received: Connection: close
+received: 
+received: foo
+close: 1 nil
+
+--- error_log
+lua ssl server name: "test.com"
+
+--- no_error_log
+[error]
+[alert]
+--- grep_error_log eval: qr/ssl_client_hello_by_lua:.*?,|\bssl client hello: connection reusable: \d+|\breusable connection: \d+/
+--- grep_error_log_out eval
+qr/reusable connection: 1
+ssl client hello: connection reusable: 1
+reusable connection: 0
+ssl_client_hello_by_lua:1: ssl client hello by lua is running!,
+/
+
+
+
+=== TEST 2: sleep
+--- http_config
+    ssl_client_hello_by_lua_block {
+        local begin = ngx.now()
+        ngx.sleep(0.1)
+        print("elapsed in ssl client hello by lua: ", ngx.now() - begin)
+    }
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block {ngx.status = 201 ngx.say("foo") ngx.exit(201)}
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /foo HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to receive response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+sent http request: 56 bytes.
+received: HTTP/1.1 201 Created
+received: Server: nginx
+received: Content-Type: text/plain
+received: Content-Length: 4
+received: Connection: close
+received: 
+received: foo
+close: 1 nil
+
+--- error_log eval
+[
+'lua ssl server name: "test.com"',
+qr/elapsed in ssl client hello by lua: 0.(?:09|1[01])\d+,/,
+]
+
+--- no_error_log
+[error]
+[alert]
+
+
+
+=== TEST 3: timer
+--- http_config
+    ssl_client_hello_by_lua_block {
+        local function f()
+            print("my timer run!")
+        end
+        local ok, err = ngx.timer.at(0, f)
+        if not ok then
+            ngx.log(ngx.ERR, "failed to create timer: ", err)
+            return
+        end
+    }
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block {ngx.status = 201 ngx.say("foo") ngx.exit(201)}
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /foo HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to receive response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+sent http request: 56 bytes.
+received: HTTP/1.1 201 Created
+received: Server: nginx
+received: Content-Type: text/plain
+received: Content-Length: 4
+received: Connection: close
+received: 
+received: foo
+close: 1 nil
+
+--- error_log
+lua ssl server name: "test.com"
+my timer run!
+
+--- no_error_log
+[error]
+[alert]
+
+
+
+=== TEST 4: cosocket
+--- http_config
+    ssl_client_hello_by_lua_block {
+        local sock = ngx.socket.tcp()
+
+        sock:settimeout(2000)
+
+        local ok, err = sock:connect("127.0.0.1", $TEST_NGINX_MEMCACHED_PORT)
+        if not ok then
+            ngx.log(ngx.ERR, "failed to connect to memc: ", err)
+            return
+        end
+
+        local bytes, err = sock:send("flush_all\r\n")
+        if not bytes then
+            ngx.log(ngx.ERR, "failed to send flush_all command: ", err)
+            return
+        end
+
+        local res, err = sock:receive()
+        if not res then
+            ngx.log(ngx.ERR, "failed to receive memc reply: ", err)
+            return
+        end
+
+        print("received memc reply: ", res)
+    }
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block {ngx.status = 201 ngx.say("foo") ngx.exit(201)}
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /foo HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to receive response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+sent http request: 56 bytes.
+received: HTTP/1.1 201 Created
+received: Server: nginx
+received: Content-Type: text/plain
+received: Content-Length: 4
+received: Connection: close
+received: 
+received: foo
+close: 1 nil
+
+--- error_log
+lua ssl server name: "test.com"
+received memc reply: OK
+
+--- no_error_log
+[error]
+[alert]
+
+
+
+=== TEST 5: ngx.exit(0) - no yield
+--- http_config
+    ssl_client_hello_by_lua_block {
+        ngx.exit(0)
+        ngx.log(ngx.ERR, "should never reached here...")
+    }
+    server {
+        listen 127.0.0.2:8080 ssl;
+        server_name test.com;
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block {ngx.status = 201 ngx.say("foo") ngx.exit(201)}
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_verify_depth 3;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("127.0.0.2", 8080)
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(false, nil, true, false)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+            end  -- do
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: boolean
+
+--- error_log
+lua exit with code 0
+
+--- no_error_log
+should never reached here
+[error]
+[alert]
+[emerg]
+
+
+
+=== TEST 6: ngx.exit(ngx.ERROR) - no yield
+--- http_config
+    ssl_client_hello_by_lua_block {
+        ngx.exit(ngx.ERROR)
+        ngx.log(ngx.ERR, "should never reached here...")
+    }
+    server {
+        listen 127.0.0.2:8080 ssl;
+        server_name test.com;
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block {ngx.status = 201 ngx.say("foo") ngx.exit(201)}
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_verify_depth 3;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("127.0.0.2", 8080)
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(false, nil, true, false)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+            end  -- do
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+failed to do SSL handshake: handshake failed
+
+--- error_log eval
+[
+'lua_client_hello_by_lua: handler return value: -1, client_hello cb exit code: 0',
+qr/\[info\] .*? SSL_do_handshake\(\) failed .*?callback failed/,
+'lua exit with code -1',
+]
+
+--- no_error_log
+should never reached here
+[alert]
+[emerg]
+
+
+
+=== TEST 7: ngx.exit(0) -  yield
+--- http_config
+    ssl_client_hello_by_lua_block {
+        ngx.sleep(0.001)
+        ngx.exit(0)
+
+        ngx.log(ngx.ERR, "should never reached here...")
+    }
+    server {
+        listen 127.0.0.2:8080 ssl;
+        server_name test.com;
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block {ngx.status = 201 ngx.say("foo") ngx.exit(201)}
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_verify_depth 3;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("127.0.0.2", 8080)
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(false, nil, true, false)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+            end  -- do
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: boolean
+
+--- error_log
+lua exit with code 0
+
+--- no_error_log
+should never reached here
+[error]
+[alert]
+[emerg]
+
+
+
+=== TEST 8: ngx.exit(ngx.ERROR) - yield
+--- http_config
+    ssl_client_hello_by_lua_block {
+        ngx.sleep(0.001)
+        ngx.exit(ngx.ERROR)
+
+        ngx.log(ngx.ERR, "should never reached here...")
+    }
+    server {
+        listen 127.0.0.2:8080 ssl;
+        server_name test.com;
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block {ngx.status = 201 ngx.say("foo") ngx.exit(201)}
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_verify_depth 3;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("127.0.0.2", 8080)
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(false, nil, true, false)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+            end  -- do
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+failed to do SSL handshake: handshake failed
+
+--- error_log eval
+[
+'lua_client_hello_by_lua: client_hello cb exit code: 0',
+qr/\[info\] .*? SSL_do_handshake\(\) failed .*?callback failed/,
+'lua exit with code -1',
+]
+
+--- no_error_log
+should never reached here
+[alert]
+[emerg]
+
+
+
+=== TEST 9: lua exception - no yield
+--- http_config
+    ssl_client_hello_by_lua_block {
+        error("bad bad bad")
+        ngx.log(ngx.ERR, "should never reached here...")
+    }
+    server {
+        listen 127.0.0.2:8080 ssl;
+        server_name test.com;
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block {ngx.status = 201 ngx.say("foo") ngx.exit(201)}
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_verify_depth 3;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("127.0.0.2", 8080)
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(false, nil, true, false)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+            end  -- do
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+failed to do SSL handshake: handshake failed
+
+--- error_log eval
+[
+'runtime error: ssl_client_hello_by_lua:2: bad bad bad',
+'lua_client_hello_by_lua: handler return value: 500, client_hello cb exit code: 0',
+qr/\[info\] .*? SSL_do_handshake\(\) failed .*?callback failed/,
+qr/context: ssl_client_hello_by_lua\*, client: \d+\.\d+\.\d+\.\d+, server: \d+\.\d+\.\d+\.\d+:\d+/,
+]
+
+--- no_error_log
+should never reached here
+[alert]
+[emerg]
+
+
+
+=== TEST 10: lua exception - yield
+--- http_config
+    ssl_client_hello_by_lua_block {
+        ngx.sleep(0.001)
+        error("bad bad bad")
+        ngx.log(ngx.ERR, "should never reached here...")
+    }
+    server {
+        listen 127.0.0.2:8080 ssl;
+        server_name test.com;
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block {ngx.status = 201 ngx.say("foo") ngx.exit(201)}
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_verify_depth 3;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("127.0.0.2", 8080)
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(false, nil, true, false)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+            end  -- do
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+failed to do SSL handshake: handshake failed
+
+--- error_log eval
+[
+'runtime error: ssl_client_hello_by_lua:3: bad bad bad',
+'lua_client_hello_by_lua: client_hello cb exit code: 0',
+qr/\[info\] .*? SSL_do_handshake\(\) failed .*?callback failed/,
+]
+
+--- no_error_log
+should never reached here
+[alert]
+[emerg]
+
+
+
+=== TEST 11: get phase
+--- http_config
+    ssl_client_hello_by_lua_block {print("get_phase: ", ngx.get_phase())}
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block {ngx.status = 201 ngx.say("foo") ngx.exit(201)}
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+            end
+            collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+
+--- error_log
+lua ssl server name: "test.com"
+get_phase: ssl_client_hello
+
+--- no_error_log
+[error]
+[alert]
+
+
+
+=== TEST 12: connection aborted prematurely
+--- http_config
+    ssl_client_hello_by_lua_block {
+        ngx.sleep(0.3)
+        print("ssl-client-hello-by-lua: after sleeping")
+    }
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(150)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(false, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+
+--- response_body
+connected: 1
+failed to do SSL handshake: timeout
+
+--- error_log
+lua ssl server name: "test.com"
+ssl-client-hello-by-lua: after sleeping
+
+--- no_error_log
+[error]
+[alert]
+--- wait: 0.6
+
+
+
+=== TEST 13: subrequests disabled
+--- http_config
+    ssl_client_hello_by_lua_block {ngx.location.capture("/foo")}
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+failed to do SSL handshake: handshake failed
+
+--- error_log eval
+[
+'lua ssl server name: "test.com"',
+'ssl_client_hello_by_lua:1: API disabled in the context of ssl_client_hello_by_lua*',
+qr/\[info\] .*?callback failed/,
+]
+
+--- no_error_log
+[alert]
+
+
+
+=== TEST 14: simple logging (by_lua_file)
+--- http_config
+    ssl_client_hello_by_lua_file html/a.lua;
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block {ngx.status = 201 ngx.say("foo") ngx.exit(201)}
+            more_clear_headers Date;
+        }
+    }
+
+--- user_files
+>>> a.lua
+print("ssl client hello by lua is running!")
+
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /foo HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to receive response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+sent http request: 56 bytes.
+received: HTTP/1.1 201 Created
+received: Server: nginx
+received: Content-Type: text/plain
+received: Content-Length: 4
+received: Connection: close
+received: 
+received: foo
+close: 1 nil
+
+--- error_log
+lua ssl server name: "test.com"
+a.lua:1: ssl client hello by lua is running!
+
+--- no_error_log
+[error]
+[alert]
+
+
+
+=== TEST 15: coroutine API
+--- http_config
+    ssl_client_hello_by_lua_block {
+        local cc, cr, cy = coroutine.create, coroutine.resume, coroutine.yield
+
+        local function f()
+            local cnt = 0
+            for i = 1, 20 do
+                print("co yield: ", cnt)
+                cy()
+                cnt = cnt + 1
+            end
+        end
+
+        local c = cc(f)
+        for i = 1, 3 do
+            print("co resume, status: ", coroutine.status(c))
+            cr(c)
+        end
+    }
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block { ngx.status = 201 ngx.say("foo") ngx.exit(201) }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /foo HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to receive response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+sent http request: 56 bytes.
+received: HTTP/1.1 201 Created
+received: Server: nginx
+received: Content-Type: text/plain
+received: Content-Length: 4
+received: Connection: close
+received: 
+received: foo
+close: 1 nil
+
+--- grep_error_log eval: qr/co (?:yield: \d+|resume, status: \w+)/
+--- grep_error_log_out
+co resume, status: suspended
+co yield: 0
+co resume, status: suspended
+co yield: 1
+co resume, status: suspended
+co yield: 2
+
+--- error_log
+lua ssl server name: "test.com"
+
+--- no_error_log
+[error]
+[alert]
+
+
+
+=== TEST 16: will crash when ssl_client_hello_by_lua* is allowed in server context
+--- http_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+
+        error_log syslog:server=127.0.0.1:12345 debug;
+
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+        ssl_client_hello_by_lua_block { print("ssl client hello by lua is running!") }
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block { ngx.status = 201 ngx.say("foo") ngx.exit(201) }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /foo HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to receive response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+close: 1 nil
+
+--- no_error_log
+[error]
+--- must_die
+--- error_log eval
+qr/\[emerg\] .*? "ssl_client_hello_by_lua_block" directive is not allowed here .*?\bnginx\.conf/
+
+
+
+=== TEST 17: simple logging (syslog)
+--- http_config
+    ssl_client_hello_by_lua_block { print("ssl client hello by lua is running!") }
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+
+        error_log syslog:server=127.0.0.1:12345 debug;
+
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block { ngx.status = 201 ngx.say("foo") ngx.exit(201) }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /foo HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to receive response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+sent http request: 56 bytes.
+received: HTTP/1.1 201 Created
+received: Server: nginx
+received: Content-Type: text/plain
+received: Content-Length: 4
+received: Connection: close
+received: 
+received: foo
+close: 1 nil
+
+--- error_log eval
+[
+qr/\[error\] .*? send\(\) failed/,
+'lua ssl server name: "test.com"',
+]
+--- no_error_log
+[alert]
+ssl_client_hello_by_lua:1: ssl client hello by lua is running!
+
+
+
+=== TEST 18: check the count of running timers
+--- http_config
+    ssl_client_hello_by_lua_block { print("ssl client hello by lua is running!") }
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /timers {
+            default_type 'text/plain';
+            content_by_lua_block {
+                ngx.timer.at(0.1, function() ngx.sleep(0.3) end)
+                ngx.timer.at(0.11, function() ngx.sleep(0.3) end)
+                ngx.timer.at(0.09, function() ngx.sleep(0.3) end)
+                ngx.sleep(0.2)
+                ngx.say(ngx.timer.running_count())
+            }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /timers HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to receive response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+sent http request: 59 bytes.
+received: HTTP/1.1 200 OK
+received: Server: nginx
+received: Content-Type: text/plain
+received: Content-Length: 2
+received: Connection: close
+received: 
+received: 3
+close: 1 nil
+
+--- error_log eval
+[
+'ssl_client_hello_by_lua:1: ssl client hello by lua is running!',
+'lua ssl server name: "test.com"',
+]
+--- no_error_log
+[error]
+[alert]
+
+
+
+=== TEST 19: get raw_client_addr - IPv4
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;;";
+    ssl_client_hello_by_lua_block {
+        local ssl = require "ngx.ssl"
+        local byte = string.byte
+        local addr, addrtype, err = ssl.raw_client_addr()
+        local ip = string.format("%d.%d.%d.%d", byte(addr, 1), byte(addr, 2),
+                   byte(addr, 3), byte(addr, 4))
+        print("client ip: ", ip)
+    }
+
+    server {
+        listen 127.0.0.1:12345 ssl;
+        server_name   test.com;
+
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block { ngx.status = 201 ngx.say("foo") ngx.exit(201) }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("127.0.0.1", 12345)
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /foo HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to receive response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+sent http request: 56 bytes.
+received: HTTP/1.1 201 Created
+received: Server: nginx
+received: Content-Type: text/plain
+received: Content-Length: 4
+received: Connection: close
+received: 
+received: foo
+close: 1 nil
+
+--- error_log
+client ip: 127.0.0.1
+
+--- no_error_log
+[error]
+[alert]
+
+
+
+=== TEST 20: get raw_client_addr - unix domain socket
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;;";
+    ssl_client_hello_by_lua_block {
+        local ssl = require "ngx.ssl"
+        local addr, addrtyp, err = ssl.raw_client_addr()
+        print("client socket file: ", addr)
+    }
+
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block { ngx.status = 201 ngx.say("foo") ngx.exit(201) }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /foo HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to receive response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+sent http request: 56 bytes.
+received: HTTP/1.1 201 Created
+received: Server: nginx
+received: Content-Type: text/plain
+received: Content-Length: 4
+received: Connection: close
+received: 
+received: foo
+close: 1 nil
+
+--- error_log
+client socket file: 
+
+--- no_error_log
+[error]
+[alert]
+
+
+
+=== TEST 21: ssl_certificate_by_lua* can yield when reading early data
+--- skip_openssl: 6: < 1.1.1
+--- http_config
+    ssl_client_hello_by_lua_block {
+        local begin = ngx.now()
+        ngx.sleep(0.1)
+        print("elapsed in ssl_client_hello_by_lua*: ", ngx.now() - begin)
+    }
+
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name test.com;
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+        ssl_early_data on;
+        server_tokens off;
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_verify_depth 3;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(2000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(false, nil, true, false)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+            end  -- do
+        }
+    }
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: boolean
+--- grep_error_log eval
+qr/elapsed in ssl_client_hello_by_lua\*: 0\.(?:09|1[01])\d+,/,
+--- grep_error_log_out eval
+[
+qr/elapsed in ssl_client_hello_by_lua\*: 0\.(?:09|1[01])\d+,/,
+qr/elapsed in ssl_client_hello_by_lua\*: 0\.(?:09|1[01])\d+,/,
+qr/elapsed in ssl_client_hello_by_lua\*: 0\.(?:09|1[01])\d+,/,
+]
+--- no_error_log
+[error]
+[alert]
+[emerg]


### PR DESCRIPTION
* implemented the ssl_client_hello_by_lua_block and
  ssl_client_hello_by_lua_file directives for controlling the
  SSL handshake protocols and ciphers.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

This directive currently requires the following NGINX core patch to work correctly:
https://gist.github.com/zengjinji/83064f8535a5d15e6a3ba6d6d89e05f2
