### PR TITLE
When building from RPM auto/feature lacks LD_LIBRARY_PATH to be able to run the test.

### DIFF
--- a/config
+++ b/config
@@ -195,7 +195,7 @@ ngx_feature_test='lua_State *L = luaL_newstate();
 SAVED_CC_TEST_FLAGS="$CC_TEST_FLAGS"
 CC_TEST_FLAGS="$ngx_lua_opt_I $CC_TEST_FLAGS"
 
-. auto/feature
+LD_LIBRARY_PATH=$LUAJIT_LIB . auto/feature
 
 if [ $ngx_found = no ]; then
     cat << END


### PR DESCRIPTION
Basically, the issue is when building as part of an RPM the luajit SO is in temp location and is not rpath'ed but the the temp location is not in ld config so test doesn't run as it can't find luajit SO.

This is a hack to demo how to remediate it for RPM build, but it's obviously insufficient for all possible build paths and should probably not applied as is.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
