### PR TITLE
feature: we now ignore 'lua_regex_*' directives when NGINX is compiled without PCRE support.

### DIFF
--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -232,6 +232,30 @@ ngx_http_lua_package_path(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 }
 
 
+char *
+ngx_http_lua_regex_cache_max_entries(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf)
+{
+#if (NGX_PCRE)
+    return ngx_conf_set_num_slot(cf, cmd, conf);
+#else
+    return NGX_CONF_OK;
+#endif
+}
+
+
+char *
+ngx_http_lua_regex_match_limit(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf)
+{
+#if (NGX_PCRE)
+    return ngx_conf_set_num_slot(cf, cmd, conf);
+#else
+    return NGX_CONF_OK;
+#endif
+}
+
+
 #if defined(NDK) && NDK
 char *
 ngx_http_lua_set_by_lua_block(ngx_conf_t *cf, ngx_command_t *cmd,

--- a/src/ngx_http_lua_directive.h
+++ b/src/ngx_http_lua_directive.h
@@ -17,6 +17,10 @@ char *ngx_http_lua_package_cpath(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 char *ngx_http_lua_package_path(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
+char *ngx_http_lua_regex_cache_max_entries(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+char *ngx_http_lua_regex_match_limit(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
 char *ngx_http_lua_content_by_lua_block(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 char *ngx_http_lua_content_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -119,21 +119,27 @@ static ngx_command_t ngx_http_lua_cmds[] = {
       offsetof(ngx_http_lua_main_conf_t, set_sa_restart),
       NULL },
 
-#if (NGX_PCRE)
     { ngx_string("lua_regex_cache_max_entries"),
       NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_num_slot,
+      ngx_http_lua_regex_cache_max_entries,
       NGX_HTTP_MAIN_CONF_OFFSET,
+#if (NGX_PCRE)
       offsetof(ngx_http_lua_main_conf_t, regex_cache_max_entries),
+#else
+      0,
+#endif
       NULL },
 
     { ngx_string("lua_regex_match_limit"),
       NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_num_slot,
+      ngx_http_lua_regex_match_limit,
       NGX_HTTP_MAIN_CONF_OFFSET,
+#if (NGX_PCRE)
       offsetof(ngx_http_lua_main_conf_t, regex_match_limit),
-      NULL },
+#else
+      0,
 #endif
+      NULL },
 
     { ngx_string("lua_package_cpath"),
       NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,


### PR DESCRIPTION
Similarly as other directives and options (e.g. our patch to support `resolver ... ipv6=...` on builds without IPv6 support), `lua_regex_cache_max_entries` and `lua_regex_match_limit` are now supported when NGINX is built without PCRE support. The directives are simply ignored.

Concretely, this allows for `resty` to be used even when NGINX lacks PCRE support, since [it hard-codes the lua_regex_cache_max_entries directive](https://github.com/openresty/resty-cli/blob/master/bin/resty#L734).

When users attempt to use PCRE APIs (e.g. `ngx.re`), lua-resty-core already produces friendly errors describing the lack of support for PCRE in the current NGINX build since recently.

Sister PR:
- https://github.com/openresty/lua-resty-core/pull/270

No tests for this change at the moment, as our test matrix does not include a build without PCRE support, which is something I will work on in the future, after revisiting the CI setup.

> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.