### PR TITLE
Add suport for deriving key from tls master secret

### DIFF
--- a/config
+++ b/config
@@ -289,6 +289,7 @@ HTTP_LUA_SRCS=" \
             $ngx_addon_dir/src/ngx_http_lua_worker.c \
             $ngx_addon_dir/src/ngx_http_lua_ssl_client_helloby.c \
             $ngx_addon_dir/src/ngx_http_lua_ssl_certby.c \
+            $ngx_addon_dir/src/ngx_http_lua_ssl_export_keying_material.c \
             $ngx_addon_dir/src/ngx_http_lua_ssl_ocsp.c \
             $ngx_addon_dir/src/ngx_http_lua_lex.c \
             $ngx_addon_dir/src/ngx_http_lua_balancer.c \
@@ -354,6 +355,7 @@ HTTP_LUA_DEPS=" \
             $ngx_addon_dir/src/ngx_http_lua_ssl_certby.h \
             $ngx_addon_dir/src/ngx_http_lua_lex.h \
             $ngx_addon_dir/src/ngx_http_lua_balancer.h \
+            $ngx_addon_dir/src/ngx_http_lua_ssl_export_keying_material.h \
             $ngx_addon_dir/src/ngx_http_lua_ssl_session_storeby.h \
             $ngx_addon_dir/src/ngx_http_lua_ssl_session_fetchby.h \
             $ngx_addon_dir/src/ngx_http_lua_ssl.h \

--- a/src/ngx_http_lua_ssl_export_keying_material.c
+++ b/src/ngx_http_lua_ssl_export_keying_material.c
@@ -1,0 +1,103 @@
+
+/*
+ * Copyright (C) Yichun Zhang (agentzh)
+ */
+
+
+#ifndef DDEBUG
+#define DDEBUG 0
+#endif
+#include "ddebug.h"
+
+#if (NGX_HTTP_SSL)
+
+#include <openssl/ssl.h>
+
+#include "ngx_http_lua_cache.h"
+#include "ngx_http_lua_initworkerby.h"
+#include "ngx_http_lua_util.h"
+#include "ngx_http_ssl_module.h"
+#include "ngx_http_lua_contentby.h"
+#include "ngx_http_lua_ssl_session_fetchby.h"
+#include "ngx_http_lua_ssl.h"
+#include "ngx_http_lua_directive.h"
+
+ngx_int_t
+ngx_http_lua_ffi_ssl_export_keying_material(ngx_http_request_t *r,
+    u_char *out, size_t out_size, const char *label, size_t llen,
+    const u_char *context, size_t ctxlen, int use_ctx, char **err)
+{
+#if OPENSSL_VERSION_NUMBER < 0x10101000L
+    *err = "OpenSSL too old";
+    return NGX_ERROR;
+#else
+    ngx_connection_t    *c;
+    ngx_ssl_conn_t      *ssl_conn;
+    int                 rc;
+
+    c = r->connection;
+    if (c == NULL || c->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+    ssl_conn = c->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+    
+    rc = SSL_export_keying_material(ssl_conn,
+        out, out_size, label, llen, context, ctxlen, use_ctx);
+    if (rc == 1) {
+        return NGX_OK;
+    }
+
+    ngx_ssl_error(NGX_LOG_ALERT, c->log, 0,
+        "SSL_export_keying_material rc: %d, error: %s",
+        rc, ERR_error_string(ERR_get_error(), NULL));
+    
+    *err = "SSL_export_keying_material() failed";
+    return NGX_ERROR;
+#endif
+}
+
+ngx_int_t
+ngx_http_lua_ffi_ssl_export_keying_material_early(ngx_http_request_t *r,
+    u_char *out, size_t out_size, const char *label, size_t llen,
+    const u_char *context, size_t ctxlen, char **err)
+{
+#if OPENSSL_VERSION_NUMBER < 0x10101000L
+    *err = "OpenSSL too old";
+    return NGX_ERROR;
+#else
+    ngx_connection_t    *c;
+    ngx_ssl_conn_t      *ssl_conn;
+    int                 rc;
+
+    c = r->connection;
+    if (c == NULL || c->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+    ssl_conn = c->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+    
+    rc = SSL_export_keying_material_early(ssl_conn,
+        out, out_size, label, llen, context, ctxlen);
+    if (rc == 1) {
+        return NGX_OK;
+    }
+
+    ngx_ssl_error(NGX_LOG_ALERT, c->log, 0,
+        "SSL_export_keying_material_early rc: %d, error: %s",
+        rc, ERR_error_string(ERR_get_error(), NULL));
+    
+    *err = "SSL_export_keying_material_early() failed";
+    return NGX_ERROR;
+#endif
+}
+
+#endif /* NGX_HTTP_SSL */

--- a/src/ngx_http_lua_ssl_export_keying_material.c
+++ b/src/ngx_http_lua_ssl_export_keying_material.c
@@ -23,6 +23,7 @@
 #include "ngx_http_lua_ssl_session_fetchby.h"
 #include "ngx_http_lua_ssl.h"
 #include "ngx_http_lua_directive.h"
+#include "ngx_http_lua_ssl_export_keying_material.h"
 
 
 ngx_int_t
@@ -34,8 +35,8 @@ ngx_http_lua_ffi_ssl_export_keying_material(ngx_http_request_t *r,
     *err = "OpenSSL too old";
     return NGX_ERROR;
 #else
-    ngx_connection_t    *c;
-    ngx_ssl_conn_t      *ssl_conn;
+    ngx_connection_t   *c;
+    ngx_ssl_conn_t     *ssl_conn;
     int                 rc;
 
     c = r->connection;
@@ -46,21 +47,22 @@ ngx_http_lua_ffi_ssl_export_keying_material(ngx_http_request_t *r,
 
     ssl_conn = c->ssl->connection;
     if (ssl_conn == NULL) {
-        *err = "bad ssl conn";
+        *err = "bad ssl connection";
         return NGX_ERROR;
     }
 
-    rc = SSL_export_keying_material(ssl_conn,
-        out, out_size, label, llen, context, ctxlen, use_ctx);
+    rc = SSL_export_keying_material(ssl_conn, out, out_size, label, llen,
+                                    context, ctxlen, use_ctx);
     if (rc == 1) {
         return NGX_OK;
     }
 
-    ngx_ssl_error(NGX_LOG_ALERT, c->log, 0,
-        "SSL_export_keying_material rc: %d, error: %s",
-        rc, ERR_error_string(ERR_get_error(), NULL));
+    ngx_ssl_error(NGX_LOG_INFO, c->log, 0,
+                  "SSL_export_keying_material rc: %d, error: %s",
+                  rc, ERR_error_string(ERR_get_error(), NULL));
 
     *err = "SSL_export_keying_material() failed";
+
     return NGX_ERROR;
 #endif
 }
@@ -75,9 +77,9 @@ ngx_http_lua_ffi_ssl_export_keying_material_early(ngx_http_request_t *r,
     *err = "OpenSSL too old";
     return NGX_ERROR;
 #else
-    ngx_connection_t    *c;
+    int                  rc;
     ngx_ssl_conn_t      *ssl_conn;
-    int                 rc;
+    ngx_connection_t    *c;
 
     c = r->connection;
     if (c == NULL || c->ssl == NULL) {
@@ -87,21 +89,23 @@ ngx_http_lua_ffi_ssl_export_keying_material_early(ngx_http_request_t *r,
 
     ssl_conn = c->ssl->connection;
     if (ssl_conn == NULL) {
-        *err = "bad ssl conn";
+        *err = "bad ssl connection";
         return NGX_ERROR;
     }
 
-    rc = SSL_export_keying_material_early(ssl_conn,
-        out, out_size, label, llen, context, ctxlen);
+    rc = SSL_export_keying_material_early(ssl_conn, out, out_size,
+                                          label, llen, context, ctxlen);
+
     if (rc == 1) {
         return NGX_OK;
     }
 
-    ngx_ssl_error(NGX_LOG_ALERT, c->log, 0,
-        "SSL_export_keying_material_early rc: %d, error: %s",
-        rc, ERR_error_string(ERR_get_error(), NULL));
+    ngx_ssl_error(NGX_LOG_INFO, c->log, 0,
+                  "SSL_export_keying_material_early rc: %d, error: %s",
+                  rc, ERR_error_string(ERR_get_error(), NULL));
 
     *err = "SSL_export_keying_material_early() failed";
+
     return NGX_ERROR;
 #endif
 }

--- a/src/ngx_http_lua_ssl_export_keying_material.c
+++ b/src/ngx_http_lua_ssl_export_keying_material.c
@@ -7,6 +7,8 @@
 #ifndef DDEBUG
 #define DDEBUG 0
 #endif
+
+
 #include "ddebug.h"
 
 #if (NGX_HTTP_SSL)
@@ -21,6 +23,7 @@
 #include "ngx_http_lua_ssl_session_fetchby.h"
 #include "ngx_http_lua_ssl.h"
 #include "ngx_http_lua_directive.h"
+
 
 ngx_int_t
 ngx_http_lua_ffi_ssl_export_keying_material(ngx_http_request_t *r,
@@ -40,12 +43,13 @@ ngx_http_lua_ffi_ssl_export_keying_material(ngx_http_request_t *r,
         *err = "bad request";
         return NGX_ERROR;
     }
+
     ssl_conn = c->ssl->connection;
     if (ssl_conn == NULL) {
         *err = "bad ssl conn";
         return NGX_ERROR;
     }
-    
+
     rc = SSL_export_keying_material(ssl_conn,
         out, out_size, label, llen, context, ctxlen, use_ctx);
     if (rc == 1) {
@@ -55,11 +59,12 @@ ngx_http_lua_ffi_ssl_export_keying_material(ngx_http_request_t *r,
     ngx_ssl_error(NGX_LOG_ALERT, c->log, 0,
         "SSL_export_keying_material rc: %d, error: %s",
         rc, ERR_error_string(ERR_get_error(), NULL));
-    
+
     *err = "SSL_export_keying_material() failed";
     return NGX_ERROR;
 #endif
 }
+
 
 ngx_int_t
 ngx_http_lua_ffi_ssl_export_keying_material_early(ngx_http_request_t *r,
@@ -79,12 +84,13 @@ ngx_http_lua_ffi_ssl_export_keying_material_early(ngx_http_request_t *r,
         *err = "bad request";
         return NGX_ERROR;
     }
+
     ssl_conn = c->ssl->connection;
     if (ssl_conn == NULL) {
         *err = "bad ssl conn";
         return NGX_ERROR;
     }
-    
+
     rc = SSL_export_keying_material_early(ssl_conn,
         out, out_size, label, llen, context, ctxlen);
     if (rc == 1) {
@@ -94,7 +100,7 @@ ngx_http_lua_ffi_ssl_export_keying_material_early(ngx_http_request_t *r,
     ngx_ssl_error(NGX_LOG_ALERT, c->log, 0,
         "SSL_export_keying_material_early rc: %d, error: %s",
         rc, ERR_error_string(ERR_get_error(), NULL));
-    
+
     *err = "SSL_export_keying_material_early() failed";
     return NGX_ERROR;
 #endif

--- a/src/ngx_http_lua_ssl_export_keying_material.h
+++ b/src/ngx_http_lua_ssl_export_keying_material.h
@@ -1,0 +1,26 @@
+
+/*
+ * Copyright (C) Yichun Zhang (agentzh)
+ */
+
+
+#ifndef _NGX_HTTP_LUA_SSL_EXPORT_KEYING_MATERIAL_H_INCLUDED_
+#define _NGX_HTTP_LUA_SSL_EXPORT_KEYING_MATERIAL_H_INCLUDED_
+
+#include "ngx_http_lua_common.h"
+
+#if (NGX_HTTP_SSL)
+ngx_int_t
+ngx_http_lua_ffi_ssl_export_keying_material(ngx_http_request_t *r,
+    u_char *out, size_t out_size, const char *label, size_t llen,
+    const u_char *ctx, size_t ctxlen, int use_ctx, char **err);
+
+ngx_int_t
+ngx_http_lua_ffi_ssl_export_keying_material_early(ngx_http_request_t *r,
+    u_char *out, size_t out_size, const char *label, size_t llen,
+    const u_char *ctx, size_t ctxlen, char **err);
+#endif
+
+#endif /* _NGX_HTTP_LUA_SSL_EXPORT_KEYING_MATERIAL_H_INCLUDED_ */
+
+/* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/src/ngx_http_lua_ssl_export_keying_material.h
+++ b/src/ngx_http_lua_ssl_export_keying_material.h
@@ -10,15 +10,13 @@
 #include "ngx_http_lua_common.h"
 
 #if (NGX_HTTP_SSL)
-ngx_int_t
-ngx_http_lua_ffi_ssl_export_keying_material(ngx_http_request_t *r,
+ngx_int_t ngx_http_lua_ffi_ssl_export_keying_material(ngx_http_request_t *r,
     u_char *out, size_t out_size, const char *label, size_t llen,
     const u_char *ctx, size_t ctxlen, int use_ctx, char **err);
 
-ngx_int_t
-ngx_http_lua_ffi_ssl_export_keying_material_early(ngx_http_request_t *r,
-    u_char *out, size_t out_size, const char *label, size_t llen,
-    const u_char *ctx, size_t ctxlen, char **err);
+ngx_int_t ngx_http_lua_ffi_ssl_export_keying_material_early(
+    ngx_http_request_t *r, u_char *out, size_t out_size, const char *label,
+    size_t llen, const u_char *ctx, size_t ctxlen, char **err);
 #endif
 
 #endif /* _NGX_HTTP_LUA_SSL_EXPORT_KEYING_MATERIAL_H_INCLUDED_ */


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request to the authors of this lua-nginx-module project.

TLS has the support to derive key material from the TLS master secret that can be used on the application level. This is described in RFC8446 section 7-5. OpenSSL offers support for this [here](https://www.openssl.org/docs/man1.1.1/man3/SSL_export_keying_material.html).

We would like to use these functions from lua. This PR adds the required functions for that.