### PR TITLE
src/ngx_http_lua_ssl_certby.c: fix possible null pointer dereference found by coverity

### DIFF
--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -416,7 +416,7 @@ ngx_http_lua_log_ssl_cert_error(ngx_log_t *log, u_char *buf, size_t len)
 
     c = log->data;
 
-    if (c->addr_text.len) {
+    if (c && c->addr_text.len) {
         p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
         len -= p - buf;
         buf = p;


### PR DESCRIPTION
```
   deref_ptr: Directly dereferencing pointer c.
419    if (c->addr_text.len) {
420        p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
421        len -= p - buf;
422        buf = p;
423    }
424
   CID 149837 (#1 of 1): Dereference before null check (REVERSE_INULL)check_after_deref: Null-checking c suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
425    if (c && c->listening && c->listening->addr_text.len) {
426        p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
427        /* len -= p - buf; */
428        buf = p;
429    }
```

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
