### PR TITLE
doc: readme: the Installation part in the README.markdown is not incomplete

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -364,6 +364,10 @@ Build the source with this module:
  make install PREFIX=/opt/nginx
  cd lua-resty-lrucache
  make install PREFIX=/opt/nginx
+
+ # add necessary `lua_package_path` directive to `nginx.conf`, in the http context
+ 
+ lua_package_path "/opt/nginx/luajit/lib/lua/?.lua;;";
 ```
 
 [Back to TOC](#table-of-contents)

--- a/README.markdown
+++ b/README.markdown
@@ -323,6 +323,8 @@ Alternatively, ngx_lua can be manually compiled into Nginx:
 1. Download the latest version of the ngx_devel_kit (NDK) module [HERE](https://github.com/simplresty/ngx_devel_kit/tags)
 1. Download the latest version of ngx_lua [HERE](https://github.com/openresty/lua-nginx-module/tags)
 1. Download the latest supported version of Nginx [HERE](https://nginx.org/) (See [Nginx Compatibility](#nginx-compatibility))
+1. Download the latest version of the lua-resty-core [HERE](https://lua-resty-core)
+1. Download the latest version of the lua-resty-lrucache [HERE](https://github.com/openresty/lua-resty-lrucache)
 
 Build the source with this module:
 
@@ -354,6 +356,14 @@ Build the source with this module:
  # machine.
  make -j2
  make install
+
+# Note that this version of lug-nginx-module not allow to set `lua_load_resty_core off;` any more.
+# So, you have to install `lua-resty-core` and `lua-resty-lrucache` manually as below.
+
+ cd lua-resty-core
+ make install PREFIX=/opt/nginx
+ cd lua-resty-lrucache
+ make install PREFIX=/opt/nginx
 ```
 
 [Back to TOC](#table-of-contents)


### PR DESCRIPTION
I have tried to follow the "Installation" part in the README.markdown, and I found two import modules  are not mentioned: "lua-resty-lrucache" and "lua-resty-lrucache". You cannot do the installation without them. So , I think it's very necessary to add them to the doc. 