### PR TITLE
bugfix: fixed use of an uninitialized value in ngx_http_lua_set_by_lua_file.

### DIFF
--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -353,6 +353,7 @@ ngx_http_lua_set_by_lua_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return NGX_CONF_ERROR;
     }
 
+    filter_data->ref = LUA_REFNIL;
     filter_data->size = filter.size;
 
     ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));

--- a/t/129-ssl-socket.t
+++ b/t/129-ssl-socket.t
@@ -1,16 +1,18 @@
 # vim:set ft= ts=4 sw=4 et fdm=marker:
 
 use Test::Nginx::Socket::Lua;
+use Cwd qw(abs_path realpath);
+use File::Basename;
 
 repeat_each(2);
 
 plan tests => repeat_each() * 211;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-
 $ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
 $ENV{TEST_NGINX_RESOLVER} ||= '8.8.8.8';
 $ENV{TEST_NGINX_SERVER_SSL_PORT} ||= 12345;
+$ENV{TEST_NGINX_CERT_DIR} ||= dirname(realpath(abs_path(__FILE__)));
 
 #log_level 'warn';
 log_level 'debug';
@@ -1190,20 +1192,31 @@ SSL reused session
 
 
 === TEST 15: explicit ssl protocol configuration
+--- http_config
+    server {
+        listen              unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name         test.com;
+        ssl_certificate     $TEST_NGINX_CERT_DIR/cert/test.crt;
+        ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_protocols       TLSv1;
+
+        location / {
+            content_by_lua_block {
+                ngx.exit(200)
+            }
+        }
+    }
 --- config
     server_tokens off;
-    resolver $TEST_NGINX_RESOLVER ipv6=off;
     lua_ssl_protocols TLSv1;
-    location /t {
-        #set $port 5000;
-        set $port $TEST_NGINX_MEMCACHED_PORT;
 
+    location /t {
         content_by_lua '
             local sock = ngx.socket.tcp()
             sock:settimeout(2000)
 
             do
-                local ok, err = sock:connect("openresty.org", 443)
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -1211,7 +1224,7 @@ SSL reused session
 
                 ngx.say("connected: ", ok)
 
-                local session, err = sock:sslhandshake(nil, "openresty.org")
+                local session, err = sock:sslhandshake(nil, "test.com")
                 if not session then
                     ngx.say("failed to do SSL handshake: ", err)
                     return
@@ -1219,7 +1232,7 @@ SSL reused session
 
                 ngx.say("ssl handshake: ", type(session))
 
-                local req = "GET / HTTP/1.1\\r\\nHost: openresty.org\\r\\nConnection: close\\r\\n\\r\\n"
+                local req = "GET / HTTP/1.1\\r\\nHost: test.com\\r\\nConnection: close\\r\\n\\r\\n"
                 local bytes, err = sock:send(req)
                 if not bytes then
                     ngx.say("failed to send http request: ", err)
@@ -1242,14 +1255,13 @@ SSL reused session
             collectgarbage()
         ';
     }
-
 --- request
 GET /t
 --- response_body
 connected: 1
 ssl handshake: userdata
-sent http request: 58 bytes.
-received: HTTP/1.1 302 Moved Temporarily
+sent http request: 53 bytes.
+received: HTTP/1.1 200 OK
 close: 1 nil
 
 --- log_level: debug
@@ -1259,13 +1271,12 @@ qr/^lua ssl save session: ([0-9A-F]+)
 lua ssl free session: ([0-9A-F]+)
 $/
 --- error_log eval
-['lua ssl server name: "openresty.org"',
-qr/SSL: TLSv1, cipher: "ECDHE-RSA-AES128-SHA (SSLv3|TLSv1)/]
+['lua ssl server name: "test.com"',
+qr/SSL: TLSv1, cipher: "ECDHE-RSA-AES256-SHA (SSLv3|TLSv1)/]
 --- no_error_log
 SSL reused session
 [error]
 [alert]
---- timeout: 5
 
 
 


### PR DESCRIPTION
Caught by Valgrind:

    ==1136586== Use of uninitialised value of size 8
    ==1136586==    at 0x48B3C55: lj_tab_getinth (lj_tab.c:411)
    ==1136586==    by 0x48CBC42: lua_rawgeti (lj_api.c:823)
    ==1136586==    by 0x5823D6: ngx_http_lua_cache_load_code (ngx_http_lua_cache.c:84)
    ==1136586==    by 0x5829F3: ngx_http_lua_cache_loadfile (ngx_http_lua_cache.c:286)
    ==1136586==    by 0x576A9E: ngx_http_lua_filter_set_by_lua_file (ngx_http_lua_directive.c:457)
    ==1136586==    by 0x549361: ndk_set_var_multi_value_data_code (ndk_set_var.c:215)
    ==1136586==    by 0x4FA637: ngx_http_rewrite_handler (ngx_http_rewrite_module.c:180)
    ==1136586==    by 0x481491: ngx_http_core_rewrite_phase (ngx_http_core_module.c:922)
    ==1136586==    by 0x4812ED: ngx_http_core_run_phases (ngx_http_core_module.c:868)
    ==1136586==    by 0x48125A: ngx_http_handler (ngx_http_core_module.c:851)
    ==1136586==    by 0x4907F3: ngx_http_process_request (ngx_http_request.c:2055)
    ==1136586==    by 0x48F250: ngx_http_process_request_headers (ngx_http_request.c:1480)
    ==1136586==    by 0x48E62F: ngx_http_process_request_line (ngx_http_request.c:1151)
    ==1136586==    by 0x48CEA3: ngx_http_wait_request_handler (ngx_http_request.c:500)
    ==1136586==    by 0x46BA45: ngx_epoll_process_events (ngx_epoll_module.c:901)
    ==1136586==    by 0x459066: ngx_process_events_and_timers (ngx_event.c:257)
    ==1136586==    by 0x467988: ngx_single_process_cycle (ngx_process_cycle.c:333)
    ==1136586==    by 0x4236A9: main (nginx.c:382)
    ==1136586==
    {
       <insert_a_suppression_name_here>
       Memcheck:Value8
       fun:lj_tab_getinth
       fun:lua_rawgeti
       fun:ngx_http_lua_cache_load_code
       fun:ngx_http_lua_cache_loadfile
       fun:ngx_http_lua_filter_set_by_lua_file
       fun:ndk_set_var_multi_value_data_code
       fun:ngx_http_rewrite_handler
       fun:ngx_http_core_rewrite_phase
       fun:ngx_http_core_run_phases
       fun:ngx_http_handler
       fun:ngx_http_process_request
       fun:ngx_http_process_request_headers
       fun:ngx_http_process_request_line
       fun:ngx_http_wait_request_handler
       fun:ngx_epoll_process_events
       fun:ngx_process_events_and_timers
       fun:ngx_single_process_cycle
       fun:main
    }

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
