### PR TITLE
doc(ngx.sleep): fix grammar typo

### DIFF
--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -4662,7 +4662,7 @@ Since <code>v0.8.3</code> this function returns <code>1</code> on success, or re
 
 '''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*, ngx.timer.*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*''
 
-Sleeps for the specified seconds without blocking. One can specify time resolution up to 0.001 seconds (i.e., one milliseconds).
+Sleeps for the specified seconds without blocking. One can specify time resolution up to 0.001 seconds (i.e., one millisecond).
 
 Behind the scene, this method makes use of the Nginx timers.
 


### PR DESCRIPTION
#1642

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
