### PR TITLE
bugfix: overrided the input header only for the first time

### DIFF
--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -997,7 +997,7 @@ ngx_http_lua_ffi_req_set_header(ngx_http_request_t *r, const u_char *key,
                 v.data[len] = '\0';
                 v.len = len;
 
-                if (ngx_http_lua_set_input_header(r, k, v, override)
+                if (ngx_http_lua_set_input_header(r, k, v, override && i == 0)
                     != NGX_OK)
                 {
                     goto failed;


### PR DESCRIPTION
When multiple values are associated to the header, we should override
the header only for the first time, otherwise the following value will
override the previous one.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
