### PR TITLE
feature: add FFI interface to verify SSL client certificate

### DIFF
--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -1311,6 +1311,7 @@ int
 ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *ca_certs,
     int depth, char **err)
 {
+    ngx_http_lua_ctx_t          *ctx;
     ngx_ssl_conn_t              *ssl_conn;
     ngx_http_ssl_srv_conf_t     *sscf;
     STACK_OF(X509)              *chain = ca_certs;
@@ -1323,6 +1324,17 @@ ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *ca_certs,
 #else
     int                         i;
 #endif
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+    if (ctx == NULL) {
+        *err = "no request ctx found";
+        return NGX_ERROR;
+    }
+
+    if (!(ctx->context & NGX_HTTP_LUA_CONTEXT_SSL_CERT)) {
+        *err = "API disabled in the current context";
+        return NGX_ERROR;
+    }
 
     if (r->connection == NULL || r->connection->ssl == NULL) {
         *err = "bad request";

--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -1294,4 +1294,104 @@ failed:
 }
 
 
+static int
+ngx_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
+{
+    /*
+     * we never terminate handshake here and user can later use
+     * $ssl_client_verify to check verification result.
+     *
+     * this is consistent with Nginx behavior.
+     */
+    return 1;
+}
+
+
+int
+ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r,
+    int depth,
+    void *cdata, char **err)
+{
+    ngx_ssl_conn_t         *ssl_conn;
+    STACK_OF(X509)         *chain = cdata;
+    STACK_OF(X509_NAME)    *name_chain = NULL;
+    X509                   *x509 = NULL;
+    X509_NAME              *subject = NULL;
+    X509_STORE             *ca_store = NULL;
+#ifdef OPENSSL_IS_BORINGSSL
+    size_t                 i;
+#else
+    int                    i;
+#endif
+
+    if (r->connection == NULL || r->connection->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = r->connection->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+
+    ca_store = SSL_CTX_get_cert_store(SSL_get_SSL_CTX(ssl_conn));
+    if (ca_store == NULL) {
+        *err = "SSL_CTX_get_cert_store() failed";
+        return NGX_ERROR;
+    }
+
+    SSL_set_verify(ssl_conn, SSL_VERIFY_PEER, ngx_ssl_verify_callback);
+
+    SSL_set_verify_depth(ssl_conn, depth);
+
+    if (chain != NULL) {
+        /* construct name chain */
+
+        name_chain = sk_X509_NAME_new_null();
+        if (name_chain == NULL) {
+            *err = "sk_X509_NAME_new_null() failed";
+            return NGX_ERROR;
+        }
+
+        for (i = 0; i < sk_X509_num(chain); i++) {
+            x509 = sk_X509_value(chain, i);
+            if (x509 == NULL) {
+                *err = "sk_X509_value() failed";
+                goto failed;
+            }
+
+            /* add subject to name chain, which will be sent to client */
+            subject = X509_NAME_dup(X509_get_subject_name(x509));
+            if (subject == NULL) {
+                *err = "X509_get_subject_name() failed";
+                goto failed;
+            }
+
+            if (!sk_X509_NAME_push(name_chain, subject)) {
+                *err = "sk_X509_NAME_push() failed";
+                X509_NAME_free(subject);
+                goto failed;
+            }
+
+            /* add to trusted CA store */
+            if (X509_STORE_add_cert(ca_store, x509) == 0) {
+                *err = "X509_STORE_add_cert() failed";
+                goto failed;
+            }
+        }
+
+        SSL_set_client_CA_list(ssl_conn, name_chain);
+    }
+
+    return NGX_OK;
+
+failed:
+
+    sk_X509_NAME_free(name_chain);
+
+    return NGX_ERROR;
+}
+
+
 #endif /* NGX_HTTP_SSL */

--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -1295,7 +1295,7 @@ failed:
 
 
 static int
-ngx_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
+ngx_http_lua_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
 {
     /*
      * we never terminate handshake here and user can later use
@@ -1349,7 +1349,7 @@ ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *ca_certs,
 
     /* enable verify */
 
-    SSL_set_verify(ssl_conn, SSL_VERIFY_PEER, ngx_ssl_verify_callback);
+    SSL_set_verify(ssl_conn, SSL_VERIFY_PEER, ngx_http_lua_ssl_verify_callback);
 
     /* set depth */
 
@@ -1357,11 +1357,13 @@ ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *ca_certs,
         sscf = ngx_http_get_module_srv_conf(r, ngx_http_ssl_module);
         if (sscf != NULL) {
             depth = sscf->verify_depth;
+
         } else {
             /* same as the default value of ssl_verify_depth */
             depth = 1;
         }
     }
+
     SSL_set_verify_depth(ssl_conn, depth);
 
     /* set CA chain */
@@ -1420,9 +1422,9 @@ ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *ca_certs,
 
 failed:
 
-    X509_STORE_free(ca_store);
-
     sk_X509_NAME_free(name_chain);
+
+    X509_STORE_free(ca_store);
 
     return NGX_ERROR;
 }

--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -1308,19 +1308,20 @@ ngx_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
 
 
 int
-ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, int depth,
-    void *ca_certs, char **err)
+ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *ca_certs,
+    int depth, char **err)
 {
-    ngx_ssl_conn_t         *ssl_conn;
-    STACK_OF(X509)         *chain = ca_certs;
-    STACK_OF(X509_NAME)    *name_chain = NULL;
-    X509                   *x509 = NULL;
-    X509_NAME              *subject = NULL;
-    X509_STORE             *ca_store = NULL;
+    ngx_ssl_conn_t              *ssl_conn;
+    ngx_http_ssl_srv_conf_t     *sscf;
+    STACK_OF(X509)              *chain = ca_certs;
+    STACK_OF(X509_NAME)         *name_chain = NULL;
+    X509                        *x509 = NULL;
+    X509_NAME                   *subject = NULL;
+    X509_STORE                  *ca_store = NULL;
 #ifdef OPENSSL_IS_BORINGSSL
-    size_t                 i;
+    size_t                      i;
 #else
-    int                    i;
+    int                         i;
 #endif
 
     if (r->connection == NULL || r->connection->ssl == NULL) {
@@ -1334,17 +1335,29 @@ ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, int depth,
         return NGX_ERROR;
     }
 
-    ca_store = SSL_CTX_get_cert_store(SSL_get_SSL_CTX(ssl_conn));
-    if (ca_store == NULL) {
-        *err = "SSL_CTX_get_cert_store() failed";
-        return NGX_ERROR;
-    }
+    /* enable verify */
 
     SSL_set_verify(ssl_conn, SSL_VERIFY_PEER, ngx_ssl_verify_callback);
 
+    /* set depth */
+
+    if (depth < 0) {
+        sscf = ngx_http_get_module_srv_conf(r, ngx_http_ssl_module);
+        if (sscf != NULL) {
+            depth = sscf->verify_depth;
+        }
+    }
     SSL_set_verify_depth(ssl_conn, depth);
 
+    /* set CA chain */
+
     if (chain != NULL) {
+        ca_store = SSL_CTX_get_cert_store(SSL_get_SSL_CTX(ssl_conn));
+        if (ca_store == NULL) {
+            *err = "SSL_CTX_get_cert_store() failed";
+            return NGX_ERROR;
+        }
+
         /* construct name chain */
 
         name_chain = sk_X509_NAME_new_null();

--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -1345,6 +1345,9 @@ ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *ca_certs,
         sscf = ngx_http_get_module_srv_conf(r, ngx_http_ssl_module);
         if (sscf != NULL) {
             depth = sscf->verify_depth;
+        } else {
+            /* same as the default value of ssl_verify_depth */
+            depth = 1;
         }
     }
     SSL_set_verify_depth(ssl_conn, depth);

--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -1378,7 +1378,7 @@ ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *ca_certs,
         name_chain = sk_X509_NAME_new_null();
         if (name_chain == NULL) {
             *err = "sk_X509_NAME_new_null() failed";
-            return NGX_ERROR;
+            goto failed;
         }
 
         for (i = 0; i < sk_X509_num(chain); i++) {

--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -1369,7 +1369,7 @@ ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *ca_certs,
     if (chain != NULL) {
         ca_store = X509_STORE_new();
         if (ca_store == NULL) {
-            *err = "SSL_CTX_get_cert_store() failed";
+            *err = "X509_STORE_new() failed";
             return NGX_ERROR;
         }
 

--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -1308,12 +1308,11 @@ ngx_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
 
 
 int
-ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r,
-    int depth,
-    void *cdata, char **err)
+ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, int depth,
+    void *ca_certs, char **err)
 {
     ngx_ssl_conn_t         *ssl_conn;
-    STACK_OF(X509)         *chain = cdata;
+    STACK_OF(X509)         *chain = ca_certs;
     STACK_OF(X509_NAME)    *name_chain = NULL;
     X509                   *x509 = NULL;
     X509_NAME              *subject = NULL;

--- a/t/140-ssl-c-api.t
+++ b/t/140-ssl-c-api.t
@@ -858,8 +858,8 @@ lua ssl server name: "test.com"
             end
         }
 
-        ssl_certificate ../../cert/test.crt;
-        ssl_certificate_key ../../cert/test.key;
+        ssl_certificate ../../cert/test2.crt;
+        ssl_certificate_key ../../cert/test2.key;
 
         server_tokens off;
         location / {
@@ -873,7 +873,7 @@ lua ssl server name: "test.com"
     }
 --- config
     server_tokens off;
-    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_trusted_certificate ../../cert/test2.crt;
 
     location /t {
         proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
@@ -923,8 +923,8 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
             end
         }
 
-        ssl_certificate ../../cert/test.crt;
-        ssl_certificate_key ../../cert/test.key;
+        ssl_certificate ../../cert/test2.crt;
+        ssl_certificate_key ../../cert/test2.key;
 
         server_tokens off;
         location / {
@@ -938,7 +938,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
     }
 --- config
     server_tokens off;
-    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_trusted_certificate ../../cert/test2.crt;
 
     location /t {
         proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
@@ -988,8 +988,8 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
             end
         }
 
-        ssl_certificate ../../cert/test.crt;
-        ssl_certificate_key ../../cert/test.key;
+        ssl_certificate ../../cert/test2.crt;
+        ssl_certificate_key ../../cert/test2.key;
 
         server_tokens off;
         location / {
@@ -1003,7 +1003,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
     }
 --- config
     server_tokens off;
-    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_trusted_certificate ../../cert/test2.crt;
 
     location /t {
         proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;

--- a/t/140-ssl-c-api.t
+++ b/t/140-ssl-c-api.t
@@ -64,7 +64,8 @@ ffi.cdef[[
 
     int ngx_http_lua_ffi_ssl_clear_certs(void *r, char **err);
 
-    int ngx_http_lua_ffi_ssl_verify_client(void *r, int depth, void *cdata, char **err);
+    int ngx_http_lua_ffi_ssl_verify_client(void *r, void *cdata,
+        int depth, char **err);
 
 ]]
 _EOC_
@@ -849,7 +850,7 @@ lua ssl server name: "test.com"
                 return
             end
 
-            local rc = ffi.C.ngx_http_lua_ffi_ssl_verify_client(r, 1, cert, errmsg)
+            local rc = ffi.C.ngx_http_lua_ffi_ssl_verify_client(r, cert, 1, errmsg)
             if rc ~= 0 then
                 ngx.log(ngx.ERR, "failed to verify client: ",
                         ffi.string(errmsg[0]))
@@ -914,7 +915,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
                 return
             end
 
-            local rc = ffi.C.ngx_http_lua_ffi_ssl_verify_client(r, 1, nil, errmsg)
+            local rc = ffi.C.ngx_http_lua_ffi_ssl_verify_client(r, nil, -1, errmsg)
             if rc ~= 0 then
                 ngx.log(ngx.ERR, "failed to verify client: ",
                         ffi.string(errmsg[0]))
@@ -979,7 +980,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
                 return
             end
 
-            local rc = ffi.C.ngx_http_lua_ffi_ssl_verify_client(r, 1, nil, errmsg)
+            local rc = ffi.C.ngx_http_lua_ffi_ssl_verify_client(r, nil, -1, errmsg)
             if rc ~= 0 then
                 ngx.log(ngx.ERR, "failed to verify client: ",
                         ffi.string(errmsg[0]))

--- a/t/140-ssl-c-api.t
+++ b/t/140-ssl-c-api.t
@@ -63,6 +63,9 @@ ffi.cdef[[
     void ngx_http_lua_ffi_free_priv_key(void *cdata);
 
     int ngx_http_lua_ffi_ssl_clear_certs(void *r, char **err);
+
+    int ngx_http_lua_ffi_ssl_verify_client(void *r, int depth, void *cdata, char **err);
+
 ]]
 _EOC_
     }
@@ -808,6 +811,210 @@ close: 1 nil
 
 --- error_log
 lua ssl server name: "test.com"
+
+--- no_error_log
+[error]
+[alert]
+
+
+
+=== TEST 6: verify client with CA certificates
+--- http_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+
+        ssl_certificate_by_lua_block {
+            collectgarbage()
+
+            require "defines"
+            local ffi = require "ffi"
+
+            local errmsg = ffi.new("char *[1]")
+
+            local r = require "resty.core.base" .get_request()
+            if r == nil then
+                ngx.log(ngx.ERR, "no request found")
+                return
+            end
+
+            local f = assert(io.open("t/cert/test.crt", "rb"))
+            local cert_data = f:read("*all")
+            f:close()
+
+            local cert = ffi.C.ngx_http_lua_ffi_parse_pem_cert(cert_data, #cert_data, errmsg)
+            if not cert then
+                ngx.log(ngx.ERR, "failed to parse PEM cert: ",
+                        ffi.string(errmsg[0]))
+                return
+            end
+
+            local rc = ffi.C.ngx_http_lua_ffi_ssl_verify_client(r, 1, cert, errmsg)
+            if rc ~= 0 then
+                ngx.log(ngx.ERR, "failed to verify client: ",
+                        ffi.string(errmsg[0]))
+                return
+            end
+        }
+
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location / {
+            default_type 'text/plain';
+            content_by_lua_block {
+                print('client certificate subject: ', ngx.var.ssl_client_s_dn)
+                ngx.say(ngx.var.ssl_client_verify)
+            }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_ssl_certificate       ../../cert/test.crt;
+        proxy_ssl_certificate_key   ../../cert/test.key;
+    }
+
+--- request
+GET /t
+--- response_body
+SUCCESS
+
+--- error_log
+client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
+
+--- no_error_log
+[error]
+[alert]
+
+
+
+=== TEST 7: verify client without CA certificates
+--- http_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+
+        ssl_certificate_by_lua_block {
+            collectgarbage()
+
+            require "defines"
+            local ffi = require "ffi"
+
+            local errmsg = ffi.new("char *[1]")
+
+            local r = require "resty.core.base" .get_request()
+            if r == nil then
+                ngx.log(ngx.ERR, "no request found")
+                return
+            end
+
+            local rc = ffi.C.ngx_http_lua_ffi_ssl_verify_client(r, 1, nil, errmsg)
+            if rc ~= 0 then
+                ngx.log(ngx.ERR, "failed to verify client: ",
+                        ffi.string(errmsg[0]))
+                return
+            end
+        }
+
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location / {
+            default_type 'text/plain';
+            content_by_lua_block {
+                print('client certificate subject: ', ngx.var.ssl_client_s_dn)
+                ngx.say(ngx.var.ssl_client_verify)
+            }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_ssl_certificate       ../../cert/test.crt;
+        proxy_ssl_certificate_key   ../../cert/test.key;
+    }
+
+--- request
+GET /t
+--- response_body
+FAILED:self signed certificate
+
+--- error_log
+client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
+
+--- no_error_log
+[error]
+[alert]
+
+
+
+=== TEST 8: verify client but client provides no certificate
+--- http_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+
+        ssl_certificate_by_lua_block {
+            collectgarbage()
+
+            require "defines"
+            local ffi = require "ffi"
+
+            local errmsg = ffi.new("char *[1]")
+
+            local r = require "resty.core.base" .get_request()
+            if r == nil then
+                ngx.log(ngx.ERR, "no request found")
+                return
+            end
+
+            local rc = ffi.C.ngx_http_lua_ffi_ssl_verify_client(r, 1, nil, errmsg)
+            if rc ~= 0 then
+                ngx.log(ngx.ERR, "failed to verify client: ",
+                        ffi.string(errmsg[0]))
+                return
+            end
+        }
+
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location / {
+            default_type 'text/plain';
+            content_by_lua_block {
+                print('client certificate subject: ', ngx.var.ssl_client_s_dn)
+                ngx.say(ngx.var.ssl_client_verify)
+            }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+    }
+
+--- request
+GET /t
+--- response_body
+NONE
+
+--- error_log
+client certificate subject: nil
 
 --- no_error_log
 [error]

--- a/t/140-ssl-c-api.t
+++ b/t/140-ssl-c-api.t
@@ -856,6 +856,8 @@ lua ssl server name: "test.com"
                         ffi.string(errmsg[0]))
                 return
             end
+
+            ffi.C.ngx_http_lua_ffi_free_cert(cert)
         }
 
         ssl_certificate ../../cert/test2.crt;
@@ -875,6 +877,7 @@ lua ssl server name: "test.com"
         proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
         proxy_ssl_certificate       ../../cert/test.crt;
         proxy_ssl_certificate_key   ../../cert/test.key;
+        proxy_ssl_session_reuse     off;
     }
 
 --- request
@@ -936,6 +939,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
         proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
         proxy_ssl_certificate       ../../cert/test.crt;
         proxy_ssl_certificate_key   ../../cert/test.key;
+        proxy_ssl_session_reuse     off;
     }
 
 --- request
@@ -989,6 +993,8 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
                         ffi.string(errmsg[0]))
                 return
             end
+
+            ffi.C.ngx_http_lua_ffi_free_cert(cert)
         }
 
         ssl_certificate ../../cert/test2.crt;
@@ -1006,6 +1012,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
 --- config
     location /t {
         proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_ssl_session_reuse     off;
     }
 
 --- request


### PR DESCRIPTION
This PR adds a FFI interface that allows users to configure SSL client certificate verification dynamically. For example, Nginx can now read SNI first and then determine whether to request a client certificate during handshake. Optionally, caller can pass in a CA list used for verification.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
