### PR TITLE
doc: enhanced readability of code examples.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6301,8 +6301,8 @@ When the `replace` is a string, then it is treated as a special template for str
      return
  end
 
-     -- newstr == "hello, [12][1]34"
-     -- n == 1
+ -- newstr == "hello, [12][1]34"
+ -- n == 1
 ```
 
 where `$0` referring to the whole substring matched by the pattern and `$1` referring to the first parenthesized capturing substring.
@@ -6312,8 +6312,8 @@ Curly braces can also be used to disambiguate variable names from the background
 ```lua
 
  local newstr, n, err = ngx.re.sub("hello, 1234", "[0-9]", "${0}00")
-     -- newstr == "hello, 100234"
-     -- n == 1
+ -- newstr == "hello, 100234"
+ -- n == 1
 ```
 
 Literal dollar sign characters (`$`) in the `replace` string argument can be escaped by another dollar sign, for instance,
@@ -6321,8 +6321,8 @@ Literal dollar sign characters (`$`) in the `replace` string argument can be esc
 ```lua
 
  local newstr, n, err = ngx.re.sub("hello, 1234", "[0-9]", "$$")
-     -- newstr == "hello, $234"
-     -- n == 1
+ -- newstr == "hello, $234"
+ -- n == 1
 ```
 
 Do not use backlashes to escape dollar signs; it will not work as expected.
@@ -6334,9 +6334,10 @@ When the `replace` argument is of type "function", then it will be invoked with 
  local func = function (m)
      return "[" .. m[0] .. "][" .. m[1] .. "]"
  end
+
  local newstr, n, err = ngx.re.sub("hello, 1234", "( [0-9] ) [0-9]", func, "x")
-     -- newstr == "hello, [12][1]34"
-     -- n == 1
+ -- newstr == "hello, [12][1]34"
+ -- n == 1
 ```
 
 The dollar sign characters in the return value of the `replace` function argument are not special at all.
@@ -6366,8 +6367,8 @@ Here is some examples:
      return
  end
 
-     -- newstr == "[hello,h], [world,w]"
-     -- n == 2
+ -- newstr == "[hello,h], [world,w]"
+ -- n == 2
 ```
 
 ```lua
@@ -6376,8 +6377,8 @@ Here is some examples:
      return "[" .. m[0] .. "," .. m[1] .. "]"
  end
  local newstr, n, err = ngx.re.gsub("hello, world", "([a-z])[a-z]+", func, "i")
-     -- newstr == "[hello,h], [world,w]"
-     -- n == 2
+ -- newstr == "[hello,h], [world,w]"
+ -- n == 2
 ```
 
 This method requires the PCRE library enabled in Nginx ([Known Issue With Special Escaping Sequences](#special-escaping-sequences)).

--- a/README.markdown
+++ b/README.markdown
@@ -1513,7 +1513,7 @@ This hook is often used to create per-worker reoccurring timers (via the [ngx.ti
              end
          end
 
-         -- do something
+         -- do something in timer
      end
 
      local hdl, err = new_timer(delay, check)
@@ -1522,7 +1522,7 @@ This hook is often used to create per-worker reoccurring timers (via the [ngx.ti
          return
      end
 
-     -- do something
+     -- other job in init_worker_by_lua
  ';
 ```
 
@@ -6240,8 +6240,6 @@ Here is a small example to demonstrate its basic usage:
      ngx.log(ngx.ERR, "error: ", err)
      return
  end
-
- -- do something
 ```
 
 More often we just put it into a Lua loop:
@@ -6298,15 +6296,13 @@ When the `replace` is a string, then it is treated as a special template for str
 ```lua
 
  local newstr, n, err = ngx.re.sub("hello, 1234", "([0-9])[0-9]", "[$0][$1]")
- if newstr then
-     -- newstr == "hello, [12][1]34"
-     -- n == 1
- else
+ if not newstr then
      ngx.log(ngx.ERR, "error: ", err)
      return
  end
 
- -- do something
+     -- newstr == "hello, [12][1]34"
+     -- n == 1
 ```
 
 where `$0` referring to the whole substring matched by the pattern and `$1` referring to the first parenthesized capturing substring.
@@ -6365,15 +6361,13 @@ Here is some examples:
 ```lua
 
  local newstr, n, err = ngx.re.gsub("hello, world", "([a-z])[a-z]+", "[$0,$1]", "i")
- if newstr then
-     -- newstr == "[hello,h], [world,w]"
-     -- n == 2
- else
+ if not newstr then
      ngx.log(ngx.ERR, "error: ", err)
      return
  end
 
- -- do something
+     -- newstr == "[hello,h], [world,w]"
+     -- n == 2
 ```
 
 ```lua
@@ -7085,7 +7079,8 @@ Since the `v0.7.18` release, connecting to a datagram unix domain socket file is
      return
  end
 
- -- do something
+ -- do something after connect
+ -- such as sock:send or sock:receive
 ```
 
 assuming the datagram service is listening on the unix domain socket file `/tmp/some-datagram-service.sock` and the client socket will use the "autobind" feature on Linux.
@@ -7291,7 +7286,8 @@ Connecting to a Unix Domain Socket file is also possible:
      return
  end
 
- -- do something
+ -- do something after connect
+ -- such as sock:send or sock:receive
 ```
 
 assuming memcached (or something else) is listening on the unix domain socket file `/tmp/memcached.sock`.
@@ -8171,7 +8167,7 @@ Here is a simple example:
              return
          end
 
-         -- do something
+         -- other job in log_by_lua_block
      }
  }
 ```
@@ -8192,6 +8188,8 @@ One can also create infinite re-occurring timers, for instance, a timer getting 
          ngx.log(ngx.ERR, "failed to create the timer: ", err)
          return
      end
+
+     -- do something in timer
  end
 
  local ok, err = ngx.timer.at(delay, handler)
@@ -8200,7 +8198,7 @@ One can also create infinite re-occurring timers, for instance, a timer getting 
      return
  end
 
- -- do something
+ -- do other jobs
 ```
 
 It is recommended, however, to use the [ngx.timer.every](#ngxtimerevery) API function

--- a/README.markdown
+++ b/README.markdown
@@ -1512,6 +1512,8 @@ This hook is often used to create per-worker reoccurring timers (via the [ngx.ti
                  return
              end
          end
+
+         -- do something
      end
 
      local hdl, err = new_timer(delay, check)
@@ -1519,6 +1521,8 @@ This hook is often used to create per-worker reoccurring timers (via the [ngx.ti
          log(ERR, "failed to create timer: ", err)
          return
      end
+
+     -- do something
  ';
 ```
 
@@ -6236,6 +6240,8 @@ Here is a small example to demonstrate its basic usage:
      ngx.log(ngx.ERR, "error: ", err)
      return
  end
+
+ -- do something
 ```
 
 More often we just put it into a Lua loop:
@@ -6299,6 +6305,8 @@ When the `replace` is a string, then it is treated as a special template for str
      ngx.log(ngx.ERR, "error: ", err)
      return
  end
+
+ -- do something
 ```
 
 where `$0` referring to the whole substring matched by the pattern and `$1` referring to the first parenthesized capturing substring.
@@ -6364,6 +6372,8 @@ Here is some examples:
      ngx.log(ngx.ERR, "error: ", err)
      return
  end
+
+ -- do something
 ```
 
 ```lua
@@ -7074,6 +7084,8 @@ Since the `v0.7.18` release, connecting to a datagram unix domain socket file is
      ngx.say("failed to connect to the datagram unix domain socket: ", err)
      return
  end
+
+ -- do something
 ```
 
 assuming the datagram service is listening on the unix domain socket file `/tmp/some-datagram-service.sock` and the client socket will use the "autobind" feature on Linux.
@@ -7278,6 +7290,8 @@ Connecting to a Unix Domain Socket file is also possible:
      ngx.say("failed to connect to the memcached unix domain socket: ", err)
      return
  end
+
+ -- do something
 ```
 
 assuming memcached (or something else) is listening on the unix domain socket file `/tmp/memcached.sock`.
@@ -8156,6 +8170,8 @@ Here is a simple example:
              ngx.log(ngx.ERR, "failed to create timer: ", err)
              return
          end
+
+         -- do something
      }
  }
 ```
@@ -8183,6 +8199,8 @@ One can also create infinite re-occurring timers, for instance, a timer getting 
      ngx.log(ngx.ERR, "failed to create the timer: ", err)
      return
  end
+
+ -- do something
 ```
 
 It is recommended, however, to use the [ngx.timer.every](#ngxtimerevery) API function

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -5305,8 +5305,8 @@ When the <code>replace</code> is a string, then it is treated as a special templ
         return
     end
 
-        -- newstr == "hello, [12][1]34"
-        -- n == 1
+    -- newstr == "hello, [12][1]34"
+    -- n == 1
 </geshi>
 
 where <code>$0</code> referring to the whole substring matched by the pattern and <code>$1</code> referring to the first parenthesized capturing substring.
@@ -5315,16 +5315,16 @@ Curly braces can also be used to disambiguate variable names from the background
 
 <geshi lang="lua">
     local newstr, n, err = ngx.re.sub("hello, 1234", "[0-9]", "${0}00")
-        -- newstr == "hello, 100234"
-        -- n == 1
+    -- newstr == "hello, 100234"
+    -- n == 1
 </geshi>
 
 Literal dollar sign characters (<code>$</code>) in the <code>replace</code> string argument can be escaped by another dollar sign, for instance,
 
 <geshi lang="lua">
     local newstr, n, err = ngx.re.sub("hello, 1234", "[0-9]", "$$")
-        -- newstr == "hello, $234"
-        -- n == 1
+    -- newstr == "hello, $234"
+    -- n == 1
 </geshi>
 
 Do not use backlashes to escape dollar signs; it will not work as expected.
@@ -5335,9 +5335,10 @@ When the <code>replace</code> argument is of type "function", then it will be in
     local func = function (m)
         return "[" .. m[0] .. "][" .. m[1] .. "]"
     end
+
     local newstr, n, err = ngx.re.sub("hello, 1234", "( [0-9] ) [0-9]", func, "x")
-        -- newstr == "hello, [12][1]34"
-        -- n == 1
+    -- newstr == "hello, [12][1]34"
+    -- n == 1
 </geshi>
 
 The dollar sign characters in the return value of the <code>replace</code> function argument are not special at all.
@@ -5363,8 +5364,8 @@ Here is some examples:
         return
     end
 
-        -- newstr == "[hello,h], [world,w]"
-        -- n == 2
+    -- newstr == "[hello,h], [world,w]"
+    -- n == 2
 </geshi>
 
 <geshi lang="lua">
@@ -5372,8 +5373,8 @@ Here is some examples:
         return "[" .. m[0] .. "," .. m[1] .. "]"
     end
     local newstr, n, err = ngx.re.gsub("hello, world", "([a-z])[a-z]+", func, "i")
-        -- newstr == "[hello,h], [world,w]"
-        -- n == 2
+    -- newstr == "[hello,h], [world,w]"
+    -- n == 2
 </geshi>
 
 This method requires the PCRE library enabled in Nginx ([[#Special Escaping Sequences|Known Issue With Special Escaping Sequences]]).

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -1225,7 +1225,7 @@ This hook is often used to create per-worker reoccurring timers (via the [[#ngx.
                 end
             end
 
-            -- do something
+            -- do something in timer
         end
 
         local hdl, err = new_timer(delay, check)
@@ -1234,7 +1234,7 @@ This hook is often used to create per-worker reoccurring timers (via the [[#ngx.
             return
         end
 
-        -- do something
+        -- other job in init_worker_by_lua
     ';
 </geshi>
 
@@ -5249,8 +5249,6 @@ Here is a small example to demonstrate its basic usage:
         ngx.log(ngx.ERR, "error: ", err)
         return
     end
-
-    -- do something
 </geshi>
 
 More often we just put it into a Lua loop:
@@ -5302,15 +5300,13 @@ When the <code>replace</code> is a string, then it is treated as a special templ
 
 <geshi lang="lua">
     local newstr, n, err = ngx.re.sub("hello, 1234", "([0-9])[0-9]", "[$0][$1]")
-    if newstr then
-        -- newstr == "hello, [12][1]34"
-        -- n == 1
-    else
+    if not newstr then
         ngx.log(ngx.ERR, "error: ", err)
         return
     end
 
-    -- do something
+        -- newstr == "hello, [12][1]34"
+        -- n == 1
 </geshi>
 
 where <code>$0</code> referring to the whole substring matched by the pattern and <code>$1</code> referring to the first parenthesized capturing substring.
@@ -5362,15 +5358,13 @@ Here is some examples:
 
 <geshi lang="lua">
     local newstr, n, err = ngx.re.gsub("hello, world", "([a-z])[a-z]+", "[$0,$1]", "i")
-    if newstr then
-        -- newstr == "[hello,h], [world,w]"
-        -- n == 2
-    else
+    if not newstr then
         ngx.log(ngx.ERR, "error: ", err)
         return
     end
 
-    -- do something
+        -- newstr == "[hello,h], [world,w]"
+        -- n == 2
 </geshi>
 
 <geshi lang="lua">
@@ -5995,7 +5989,8 @@ Since the <code>v0.7.18</code> release, connecting to a datagram unix domain soc
         return
     end
 
-    -- do something
+    -- do something after connect
+    -- such as sock:send or sock:receive
 </geshi>
 
 assuming the datagram service is listening on the unix domain socket file <code>/tmp/some-datagram-service.sock</code> and the client socket will use the "autobind" feature on Linux.
@@ -6176,7 +6171,8 @@ Connecting to a Unix Domain Socket file is also possible:
         return
     end
 
-    -- do something
+    -- do something after connect
+    -- such as sock:send or sock:receive
 </geshi>
 
 assuming memcached (or something else) is listening on the unix domain socket file <code>/tmp/memcached.sock</code>.
@@ -6987,7 +6983,7 @@ Here is a simple example:
                 return
             end
 
-            -- do something
+            -- other job in log_by_lua_block
         }
     }
 </geshi>
@@ -7007,6 +7003,8 @@ One can also create infinite re-occurring timers, for instance, a timer getting 
             ngx.log(ngx.ERR, "failed to create the timer: ", err)
             return
         end
+
+        -- do something in timer
     end
 
     local ok, err = ngx.timer.at(delay, handler)
@@ -7015,7 +7013,7 @@ One can also create infinite re-occurring timers, for instance, a timer getting 
         return
     end
 
-    -- do something
+    -- do other jobs
 </geshi>
 
 It is recommended, however, to use the [[#ngx.timer.every|ngx.timer.every]] API function

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -1224,6 +1224,8 @@ This hook is often used to create per-worker reoccurring timers (via the [[#ngx.
                     return
                 end
             end
+
+            -- do something
         end
 
         local hdl, err = new_timer(delay, check)
@@ -1231,6 +1233,8 @@ This hook is often used to create per-worker reoccurring timers (via the [[#ngx.
             log(ERR, "failed to create timer: ", err)
             return
         end
+
+        -- do something
     ';
 </geshi>
 
@@ -5245,6 +5249,8 @@ Here is a small example to demonstrate its basic usage:
         ngx.log(ngx.ERR, "error: ", err)
         return
     end
+
+    -- do something
 </geshi>
 
 More often we just put it into a Lua loop:
@@ -5303,6 +5309,8 @@ When the <code>replace</code> is a string, then it is treated as a special templ
         ngx.log(ngx.ERR, "error: ", err)
         return
     end
+
+    -- do something
 </geshi>
 
 where <code>$0</code> referring to the whole substring matched by the pattern and <code>$1</code> referring to the first parenthesized capturing substring.
@@ -5361,6 +5369,8 @@ Here is some examples:
         ngx.log(ngx.ERR, "error: ", err)
         return
     end
+
+    -- do something
 </geshi>
 
 <geshi lang="lua">
@@ -5984,6 +5994,8 @@ Since the <code>v0.7.18</code> release, connecting to a datagram unix domain soc
         ngx.say("failed to connect to the datagram unix domain socket: ", err)
         return
     end
+
+    -- do something
 </geshi>
 
 assuming the datagram service is listening on the unix domain socket file <code>/tmp/some-datagram-service.sock</code> and the client socket will use the "autobind" feature on Linux.
@@ -6163,6 +6175,8 @@ Connecting to a Unix Domain Socket file is also possible:
         ngx.say("failed to connect to the memcached unix domain socket: ", err)
         return
     end
+
+    -- do something
 </geshi>
 
 assuming memcached (or something else) is listening on the unix domain socket file <code>/tmp/memcached.sock</code>.
@@ -6972,6 +6986,8 @@ Here is a simple example:
                 ngx.log(ngx.ERR, "failed to create timer: ", err)
                 return
             end
+
+            -- do something
         }
     }
 </geshi>
@@ -6998,6 +7014,8 @@ One can also create infinite re-occurring timers, for instance, a timer getting 
         ngx.log(ngx.ERR, "failed to create the timer: ", err)
         return
     end
+
+    -- do something
 </geshi>
 
 It is recommended, however, to use the [[#ngx.timer.every|ngx.timer.every]] API function


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

@thibaultcha @doujiang24 In some code example, useless `return` appears at the end of the code logic, and it is `return nil`, such as [the example of `ngx.re.gmatch`](https://github.com/openresty/lua-nginx-module#ngxregmatch). [Some reader maybe confuse about this](https://github.com/openresty/lua-nginx-module/issues/1683), and we can add comments to increase the readability of the example.