### PR TITLE
test: add test cases about http response header location 

### DIFF
--- a/src/ngx_http_lua_uri.c
+++ b/src/ngx_http_lua_uri.c
@@ -55,10 +55,6 @@ ngx_http_lua_ngx_req_set_uri(lua_State *L)
         return luaL_error(L, "attempt to use zero-length uri");
     }
 
-    if (ngx_http_lua_check_unsafe_string(r, p, len, "uri") != NGX_OK) {
-        return luaL_error(L, "attempt to set unsafe uri");
-    }
-
     if (n == 2) {
 
         luaL_checktype(L, 2, LUA_TBOOLEAN);

--- a/t/030-uri-args.t
+++ b/t/030-uri-args.t
@@ -9,7 +9,7 @@ log_level('warn');
 repeat_each(2);
 #repeat_each(1);
 
-plan tests => repeat_each() * (blocks() * 2 + 24);
+plan tests => repeat_each() * (blocks() * 2 + 22);
 
 no_root_location();
 
@@ -1568,10 +1568,9 @@ args: foo=%2C%24%40%7C%60&bar=-_.!~*'()
     }
 --- request
     GET /t
---- error_code: 500
---- error_log
-unsafe byte "0x9" in uri "/foo\x09bar"
-attempt to set unsafe uri
+--- error_code: 200
+--- response_body eval
+qr#/foo\tbar#
 
 
 
@@ -1586,10 +1585,9 @@ attempt to set unsafe uri
     }
 --- request
     GET /t
---- error_code: 500
---- error_log
-unsafe byte "0x0" in uri "\x00foo"
-attempt to set unsafe uri
+--- error_code: 200
+--- response_body eval
+qr/\0foo/
 
 
 

--- a/t/162-static-module-location.t
+++ b/t/162-static-module-location.t
@@ -93,4 +93,3 @@ GET /t/%E4%B8%AD%E6%96%87?q=name
 Location: http://localhost:1984/t/%E4%B8%AD%E6%96%87/?q=name
 --- response_body_like
 .*301 Moved Permanently.*
-

--- a/t/162-static-module-location.t
+++ b/t/162-static-module-location.t
@@ -1,0 +1,96 @@
+use Test::Nginx::Socket::Lua;
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 3);
+
+our $HtmlDir = html_dir;
+
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: decoded url contains '\0' and '\r\n'
+--- config
+    server_tokens off;
+    location = /t {
+        rewrite_by_lua_block {
+            ngx.req.read_body();
+            local args, _ = ngx.req.get_post_args();
+            ngx.req.set_uri(args["url"], true);
+        }
+    }
+--- request
+POST /t
+url=%00%0a%0dset-cookie:1234567
+--- error_code: 301
+--- response_headers
+Location: %00%0A%0Dset-cookie:1234567/
+--- response_body_like
+.*301 Moved Permanently.*
+
+
+
+=== TEST 2: uri contain chinese characters
+--- config
+    server_tokens off;
+--- user_files
+>>> t/中文/foo.txt
+Hello, world
+--- request
+GET /t/中文
+--- error_code: 301
+--- response_headers
+Location: http://localhost:1984/t/%E4%B8%AD%E6%96%87/
+--- response_body_like
+.*301 Moved Permanently.*
+
+
+
+=== TEST 3: uri contain chinese characters with args
+--- config
+    server_tokens off;
+--- user_files
+>>> t/中文/foo.txt
+Hello, world
+--- request
+GET /t/中文?q=name
+--- error_code: 301
+--- response_headers
+Location: http://localhost:1984/t/%E4%B8%AD%E6%96%87/?q=name
+--- response_body_like
+.*301 Moved Permanently.*
+
+
+
+=== TEST 4: uri already encoded
+--- config
+    server_tokens off;
+--- user_files
+>>> t/中文/foo.txt
+Hello, world
+--- request
+GET /t/%E4%B8%AD%E6%96%87
+--- error_code: 301
+--- response_headers
+Location: http://localhost:1984/t/%E4%B8%AD%E6%96%87/
+--- response_body_like
+.*301 Moved Permanently.*
+
+
+
+=== TEST 5: uri already encoded with args
+--- config
+    server_tokens off;
+--- user_files
+>>> t/中文/foo.txt
+Hello, world
+--- request
+GET /t/%E4%B8%AD%E6%96%87?q=name
+--- error_code: 301
+--- response_headers
+Location: http://localhost:1984/t/%E4%B8%AD%E6%96%87/?q=name
+--- response_body_like
+.*301 Moved Permanently.*
+


### PR DESCRIPTION
    testcast: add tow cases about http response header location in ngx_http_static_module
    
    see https://github.com/openresty/openresty/pull/611


I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
