### PR TITLE
bugfix: ngx.req.set_uri_args with string argument can contain invalid…

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4552,7 +4552,8 @@ or a Lua table holding the query arguments' key-value pairs, as in
  ngx.req.set_uri_args({ a = 3, b = "hello world" })
 ```
 
-where in the latter case, this method will escape argument keys and values according to the URI escaping rule.
+In the former case, this method will throw out a Lua exception if `args` contain '\r' or '\n' or '\0'.
+In the latter case, this method will escape argument keys and values according to the URI escaping rule.
 
 Multi-value arguments are also supported:
 

--- a/README.markdown
+++ b/README.markdown
@@ -4552,7 +4552,8 @@ or a Lua table holding the query arguments' key-value pairs, as in
  ngx.req.set_uri_args({ a = 3, b = "hello world" })
 ```
 
-In the former case, this method will throw out a Lua exception if `args` contain '\r' or '\n' or '\0'.
+In the former case, the input Lua string should be escaped. Otherwise, this
+method will escape ASCII code 0x00~0x32 and 0x7F in the Lua string.
 In the latter case, this method will escape argument keys and values according to the URI escaping rule.
 
 Multi-value arguments are also supported:

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -3791,7 +3791,8 @@ or a Lua table holding the query arguments' key-value pairs, as in
     ngx.req.set_uri_args({ a = 3, b = "hello world" })
 </geshi>
 
-In the former case, this method will throw out a Lua exception if <code>args</code> contain '\r' or '\n' or '\0'.
+In the former case, the input Lua string should be escaped. Otherwise, this
+method will escape ASCII code 0x00~0x32 and 0x7F in the Lua string.
 In the latter case, this method will escape argument keys and values according to the URI escaping rule.
 
 Multi-value arguments are also supported:

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -3791,7 +3791,8 @@ or a Lua table holding the query arguments' key-value pairs, as in
     ngx.req.set_uri_args({ a = 3, b = "hello world" })
 </geshi>
 
-where in the latter case, this method will escape argument keys and values according to the URI escaping rule.
+In the former case, this method will throw out a Lua exception if <code>args</code> contain '\r' or '\n' or '\0'.
+In the latter case, this method will escape argument keys and values according to the URI escaping rule.
 
 Multi-value arguments are also supported:
 

--- a/src/ngx_http_lua_args.c
+++ b/src/ngx_http_lua_args.c
@@ -17,20 +17,6 @@
 
 static int ngx_http_lua_ngx_req_set_uri_args(lua_State *L);
 static int ngx_http_lua_ngx_req_get_post_args(lua_State *L);
-/*
-https://tools.ietf.org/html/rfc3986*
-URI         = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
-pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
-query         = *( pchar / "/" / "?" )
-fragment      = *( pchar / "/" / "?" )
-pct-encoded   = "%" HEXDIG HEXDIG
-unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
-reserved      = gen-delims / sub-delims
-sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
-              / "*" / "+" / "," / ";" / "="
-
-gen-delims    = ":" / "/" / "?" / "#" / "[" / "]" / "@"
- */
 
 static ngx_inline ngx_int_t
 ngx_http_lua_is_escaped_query_string(ngx_http_request_t *r, u_char *str,

--- a/src/ngx_http_lua_args.c
+++ b/src/ngx_http_lua_args.c
@@ -19,13 +19,14 @@ static int ngx_http_lua_ngx_req_set_uri_args(lua_State *L);
 static int ngx_http_lua_ngx_req_get_post_args(lua_State *L);
 
 
-static ngx_inline ngx_uint_t
+static ngx_inline ngx_int_t
 ngx_http_lua_is_escaped_query_string(ngx_http_request_t *r, u_char *str,
     size_t len)
 {
     size_t           i, buf_len;
     u_char           c;
-    u_char          *buf, *src = str;
+    u_char          *buf;
+    u_char          *src;
 
     static uint32_t   map[] = {
         0x00002401, /* 0000 0000 0000 0000  0010 0100 0000 0001 */
@@ -45,6 +46,7 @@ ngx_http_lua_is_escaped_query_string(ngx_http_request_t *r, u_char *str,
         0x00000000, /* 0000 0000 0000 0000  0000 0000 0000 0000 */
     };
 
+    src = str;
     for (i = 0; i < len; i++, str++) {
         c = *str;
         if (map[c >> 5] & (1 << (c & 0x1f))) {
@@ -62,11 +64,11 @@ ngx_http_lua_is_escaped_query_string(ngx_http_request_t *r, u_char *str,
 
             ngx_pfree(r->pool, buf);
 
-            return 0;
+            return NGX_ERROR;
         }
     }
 
-    return 1;
+    return NGX_OK;
 }
 
 static int
@@ -77,7 +79,6 @@ ngx_http_lua_ngx_req_set_uri_args(lua_State *L)
     const char                  *msg;
     size_t                       len;
     u_char                      *p;
-    u_char                       c;
     int                          type;
 
     if (lua_gettop(L) != 1) {
@@ -109,7 +110,7 @@ ngx_http_lua_ngx_req_set_uri_args(lua_State *L)
 
     case LUA_TSTRING:
         p = (u_char *) lua_tolstring(L, 1, &len);
-        if (!ngx_http_lua_is_escaped_query_string(r, p, len)) {
+        if (ngx_http_lua_is_escaped_query_string(r, p, len) != NGX_OK) {
             return luaL_argerror(L, 1, "query-string contains unescaped byte");
         }
 

--- a/t/030-uri-args-with-ctrl.t
+++ b/t/030-uri-args-with-ctrl.t
@@ -1,0 +1,137 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use Test::Nginx::Socket::Lua;
+
+log_level('warn');
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 2 + 3);
+
+no_root_location();
+
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: rewrite args (string with \r)
+--- config
+    location /foo {
+        rewrite_by_lua_block {
+            ngx.req.set_uri_args("a\rb")
+        }
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/echo;
+    }
+    location /echo {
+        content_by_lua_block {
+            ngx.say(ngx.var.request_uri);
+        }
+    }
+--- request
+GET /foo?world
+--- error_code: 200
+--- response_body
+/echo?a%0Db
+
+
+
+=== TEST 2: rewrite args (string with \n)
+--- config
+    location /foo {
+        rewrite_by_lua_block {
+            ngx.req.set_uri_args("a\nb")
+        }
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/echo;
+    }
+    location /echo {
+        content_by_lua_block {
+            ngx.say(ngx.var.request_uri);
+        }
+    }
+--- request
+GET /foo?world
+--- response_body
+/echo?a%0Ab
+
+
+
+=== TEST 3: rewrite args (string with \0)
+--- config
+    location /foo {
+        rewrite_by_lua_block {
+            ngx.req.set_uri_args("a\0b")
+        }
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/echo;
+    }
+    location /echo {
+        content_by_lua_block {
+            ngx.say(ngx.var.request_uri);
+        }
+    }
+--- request
+GET /foo?world
+--- response_body
+/echo?a%00b
+
+
+
+=== TEST 4: rewrite args (string arg with 'lang=中文')
+ngx.req.set_uri_args with string argument should be carefully encoded.
+For backward compatibility, we are allowed to pass such parameters.
+--- config
+    location /foo {
+        rewrite_by_lua_block {
+            ngx.req.set_uri_args("lang=中文")
+        }
+        content_by_lua_block {
+            ngx.say(ngx.var.arg_lang)
+        }
+    }
+--- request
+GET /foo?world
+--- response_body
+中文
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: rewrite args (string arg with '语言=chinese')
+ngx.req.set_uri_args with string argument should be carefully encoded.
+For backward compatibility, we are allowed to pass such parameters.
+--- config
+    location /foo {
+        rewrite_by_lua_block {
+            ngx.req.set_uri_args("语言=chinese")
+        }
+        content_by_lua_block {
+            ngx.say(ngx.var.arg_语言)
+        }
+    }
+--- request
+GET /foo?world
+--- response_body
+chinese
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: rewrite args (string arg with '语言=中文')
+ngx.req.set_uri_args with string argument should be carefully encoded.
+For backward compatibility, we are allowed to pass such parameters.
+--- config
+    location /foo {
+        rewrite_by_lua_block {
+            ngx.req.set_uri_args("语言=中文")
+        }
+        content_by_lua_block {
+            ngx.say(ngx.var.arg_语言)
+        }
+    }
+--- request
+GET /foo?world
+--- response_body
+中文
+--- no_error_log
+[error]

--- a/t/030-uri-args.t
+++ b/t/030-uri-args.t
@@ -9,7 +9,7 @@ log_level('warn');
 repeat_each(2);
 #repeat_each(1);
 
-plan tests => repeat_each() * (blocks() * 2 + 27);
+plan tests => repeat_each() * (blocks() * 2 + 24);
 
 no_root_location();
 
@@ -1585,7 +1585,7 @@ attempt to set unsafe uri
         }
     }
 --- request
-GET /t
+    GET /t
 --- error_code: 500
 --- error_log
 unsafe byte "0x0" in uri "\x00foo"
@@ -1611,7 +1611,7 @@ attempt to set unsafe uri
         }
     }
 --- request
-GET /t
+    GET /t
 --- response_body
 request_uri: /foo%20bar
 uri: /foo bar
@@ -1634,7 +1634,7 @@ uri: /foo bar
         proxy_pass http://127.0.0.2:12345;
     }
 --- request
-GET /foo?world
+    GET /foo?world
 --- response_body_like: 500 Internal Server Error
 --- log_level: debug
 --- error_code: 500
@@ -1657,7 +1657,7 @@ bad argument #1 to 'set_uri_args' (string, number, or table expected, but got bo
         proxy_pass http://127.0.0.2:12345;
     }
 --- request
-GET /foo?world
+    GET /foo?world
 --- response_body_like: 500 Internal Server Error
 --- log_level: debug
 --- error_code: 500
@@ -1680,133 +1680,9 @@ bad argument #1 to 'set_uri_args' (string, number, or table expected, but got ni
         proxy_pass http://127.0.0.2:12345;
     }
 --- request
-GET /foo?world
+    GET /foo?world
 --- response_body_like: 500 Internal Server Error
 --- log_level: debug
 --- error_code: 500
 --- error_log
 bad argument #1 to 'set_uri_args' (string, number, or table expected, but got userdata)
-
-
-
-=== TEST 64: rewrite args (string with \r)
---- config
-    location /foo {
-        rewrite_by_lua_block {
-            ngx.req.set_uri_args("a\rb")
-        }
-        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/echo;
-    }
-    location /echo {
-        content_by_lua_block {
-            ngx.say(ngx.var.request_uri);
-        }
-    }
---- request
-GET /foo?world
---- error_code: 200
---- response_body
-/echo?a%0Db
-
-
-
-=== TEST 65: rewrite args (string with \n)
---- config
-    location /foo {
-        rewrite_by_lua_block {
-            ngx.req.set_uri_args("a\nb")
-        }
-        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/echo;
-    }
-    location /echo {
-        content_by_lua_block {
-            ngx.say(ngx.var.request_uri);
-        }
-    }
---- request
-GET /foo?world
---- response_body
-/echo?a%0Ab
-
-
-
-=== TEST 66: rewrite args (string with \0)
---- config
-    location /foo {
-        rewrite_by_lua_block {
-            ngx.req.set_uri_args("a\0b")
-        }
-        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/echo;
-    }
-    location /echo {
-        content_by_lua_block {
-            ngx.say(ngx.var.request_uri);
-        }
-    }
---- request
-GET /foo?world
---- response_body
-/echo?a%00b
-
-
-
-=== TEST 67: rewrite args (string arg with 'lang=中文')
-ngx.req.set_uri_args with string argument should be carefully encoded.
-For backward compatibility, we are allowed to pass such parameters.
---- config
-    location /foo {
-        rewrite_by_lua_block {
-            ngx.req.set_uri_args("lang=中文")
-        }
-        content_by_lua_block {
-            ngx.say(ngx.var.arg_lang)
-        }
-    }
---- request
-GET /foo?world
---- response_body
-中文
---- no_error_log
-[error]
-
-
-
-=== TEST 68: rewrite args (string arg with '语言=chinese')
-ngx.req.set_uri_args with string argument should be carefully encoded.
-For backward compatibility, we are allowed to pass such parameters.
---- config
-    location /foo {
-        rewrite_by_lua_block {
-            ngx.req.set_uri_args("语言=chinese")
-        }
-        content_by_lua_block {
-            ngx.say(ngx.var.arg_语言)
-        }
-    }
---- request
-GET /foo?world
---- response_body
-chinese
---- no_error_log
-[error]
-
-
-
-=== TEST 69: rewrite args (string arg with '语言=中文')
-ngx.req.set_uri_args with string argument should be carefully encoded.
-For backward compatibility, we are allowed to pass such parameters.
---- config
-    location /foo {
-        rewrite_by_lua_block {
-            ngx.req.set_uri_args("语言=中文")
-        }
-        content_by_lua_block {
-            ngx.say(ngx.var.arg_语言)
-        }
-    }
---- request
-GET /foo?world
---- response_body
-中文
---- no_error_log
-[error]

--- a/t/030-uri-args.t
+++ b/t/030-uri-args.t
@@ -9,7 +9,7 @@ log_level('warn');
 repeat_each(2);
 #repeat_each(1);
 
-plan tests => repeat_each() * (blocks() * 2 + 30);
+plan tests => repeat_each() * (blocks() * 2 + 27);
 
 no_root_location();
 
@@ -1704,10 +1704,7 @@ bad argument #1 to 'set_uri_args' (string, number, or table expected, but got us
 GET /foo?world
 --- error_code: 500
 --- error_log eval
-[
-qr/\[error\] .*? unsafe byte "0xd" in query string "a\\x0Db"/,
-qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(query-string contains unescaped byte\)/
-]
+qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(unescaped byte 0xd in query string "a\\x0Db"\)/
 
 
 
@@ -1726,10 +1723,7 @@ qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_u
 GET /foo?world
 --- error_code: 500
 --- error_log eval
-[
-qr/\[error\] .*? unsafe byte "0xa" in query string "a\\x0Ab"/,
-qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(query-string contains unescaped byte\)/
-]
+qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(unescaped byte 0xa in query string "a\\x0Ab"\)/
 
 
 
@@ -1748,10 +1742,7 @@ qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_u
 GET /foo?world
 --- error_code: 500
 --- error_log eval
-[
-qr/\[error\] .*? unsafe byte "0x0" in query string "a\\x00b"/,
-qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(query-string contains unescaped byte\)/
-]
+qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(unescaped byte 0x0 in query string "a\\x00b"\)/
 
 
 

--- a/t/030-uri-args.t
+++ b/t/030-uri-args.t
@@ -9,7 +9,7 @@ log_level('warn');
 repeat_each(2);
 #repeat_each(1);
 
-plan tests => repeat_each() * (blocks() * 2 + 27);
+plan tests => repeat_each() * (blocks() * 2 + 30);
 
 no_root_location();
 
@@ -1585,7 +1585,7 @@ attempt to set unsafe uri
         }
     }
 --- request
-    GET /t
+GET /t
 --- error_code: 500
 --- error_log
 unsafe byte "0x0" in uri "\x00foo"
@@ -1611,16 +1611,12 @@ attempt to set unsafe uri
         }
     }
 --- request
-    GET /t
+GET /t
 --- response_body
 request_uri: /foo%20bar
 uri: /foo bar
 --- no_error_log
 [error]
-
-
-
-<<<<<<< HEAD
 
 
 
@@ -1638,7 +1634,7 @@ uri: /foo bar
         proxy_pass http://127.0.0.2:12345;
     }
 --- request
-    GET /foo?world
+GET /foo?world
 --- response_body_like: 500 Internal Server Error
 --- log_level: debug
 --- error_code: 500
@@ -1661,7 +1657,7 @@ bad argument #1 to 'set_uri_args' (string, number, or table expected, but got bo
         proxy_pass http://127.0.0.2:12345;
     }
 --- request
-    GET /foo?world
+GET /foo?world
 --- response_body_like: 500 Internal Server Error
 --- log_level: debug
 --- error_code: 500
@@ -1684,13 +1680,12 @@ bad argument #1 to 'set_uri_args' (string, number, or table expected, but got ni
         proxy_pass http://127.0.0.2:12345;
     }
 --- request
-    GET /foo?world
+GET /foo?world
 --- response_body_like: 500 Internal Server Error
 --- log_level: debug
 --- error_code: 500
 --- error_log
 bad argument #1 to 'set_uri_args' (string, number, or table expected, but got userdata)
-=======
 
 
 
@@ -1706,7 +1701,7 @@ bad argument #1 to 'set_uri_args' (string, number, or table expected, but got us
         proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT;
     }
 --- request
-    GET /foo?world
+GET /foo?world
 --- error_code: 500
 --- error_log eval
 [
@@ -1728,7 +1723,7 @@ qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_u
         proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT;
     }
 --- request
-    GET /foo?world
+GET /foo?world
 --- error_code: 500
 --- error_log eval
 [
@@ -1750,7 +1745,7 @@ qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_u
         proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT;
     }
 --- request
-    GET /foo?world
+GET /foo?world
 --- error_code: 500
 --- error_log eval
 [
@@ -1773,7 +1768,7 @@ For backward compatibility, we are allowed to pass such parameters.
         }
     }
 --- request
-    GET /foo?world
+GET /foo?world
 --- response_body
 中文
 --- no_error_log
@@ -1794,7 +1789,7 @@ For backward compatibility, we are allowed to pass such parameters.
         }
     }
 --- request
-    GET /foo?world
+GET /foo?world
 --- response_body
 chinese
 --- no_error_log
@@ -1815,9 +1810,8 @@ For backward compatibility, we are allowed to pass such parameters.
         }
     }
 --- request
-    GET /foo?world
+GET /foo?world
 --- response_body
 中文
 --- no_error_log
 [error]
->>>>>>> e4388235... bugfix: ngx.req.set_uri_args with string argument can contain invalid chacters.

--- a/t/030-uri-args.t
+++ b/t/030-uri-args.t
@@ -1620,6 +1620,10 @@ uri: /foo bar
 
 
 
+<<<<<<< HEAD
+
+
+
 === TEST 61: set_uri_args with boolean
 --- config
     location /bar {
@@ -1686,3 +1690,125 @@ bad argument #1 to 'set_uri_args' (string, number, or table expected, but got ni
 --- error_code: 500
 --- error_log
 bad argument #1 to 'set_uri_args' (string, number, or table expected, but got userdata)
+=======
+
+
+
+=== TEST 64: rewrite args (string with \r)
+--- config
+    location /bar {
+        echo $server_protocol $query_string;
+    }
+    location /foo {
+        rewrite_by_lua_block {
+            ngx.req.set_uri_args("a\rb")
+        }
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT;
+    }
+--- request
+    GET /foo?world
+--- error_code: 500
+--- error_log eval
+qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(args need to be escaped\)/
+
+
+
+=== TEST 65: rewrite args (string with \n)
+--- config
+    location /bar {
+        echo $server_protocol $query_string;
+    }
+    location /foo {
+        rewrite_by_lua_block {
+            ngx.req.set_uri_args("a\nb")
+        }
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT;
+    }
+--- request
+    GET /foo?world
+--- error_code: 500
+--- error_log eval
+qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(args need to be escaped\)/
+
+
+
+=== TEST 66: rewrite args (string with \0)
+--- config
+    location /bar {
+        echo $server_protocol $query_string;
+    }
+    location /foo {
+        rewrite_by_lua_block {
+            ngx.req.set_uri_args("a\0b")
+        }
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT;
+    }
+--- request
+    GET /foo?world
+--- error_code: 500
+--- error_log eval
+qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(args need to be escaped\)/
+
+
+
+=== TEST 67: rewrite args (string arg with 'lang=中文')
+ngx.req.set_uri_args with string argument should be carefully encoded.
+For backward compatibility, we are allowed to pass such parameters.
+--- config
+    location /foo {
+        rewrite_by_lua_block {
+            ngx.req.set_uri_args("lang=中文")
+        }
+        content_by_lua_block {
+            ngx.say(ngx.var.arg_lang)
+        }
+    }
+--- request
+    GET /foo?world
+--- response_body
+中文
+--- no_error_log
+[error]
+
+
+
+=== TEST 68: rewrite args (string arg with '语言=chinese')
+ngx.req.set_uri_args with string argument should be carefully encoded.
+For backward compatibility, we are allowed to pass such parameters.
+--- config
+    location /foo {
+        rewrite_by_lua_block {
+            ngx.req.set_uri_args("语言=chinese")
+        }
+        content_by_lua_block {
+            ngx.say(ngx.var.arg_语言)
+        }
+    }
+--- request
+    GET /foo?world
+--- response_body
+chinese
+--- no_error_log
+[error]
+
+
+
+=== TEST 69: rewrite args (string arg with '语言=中文')
+ngx.req.set_uri_args with string argument should be carefully encoded.
+For backward compatibility, we are allowed to pass such parameters.
+--- config
+    location /foo {
+        rewrite_by_lua_block {
+            ngx.req.set_uri_args("语言=中文")
+        }
+        content_by_lua_block {
+            ngx.say(ngx.var.arg_语言)
+        }
+    }
+--- request
+    GET /foo?world
+--- response_body
+中文
+--- no_error_log
+[error]
+>>>>>>> e4388235... bugfix: ngx.req.set_uri_args with string argument can contain invalid chacters.

--- a/t/030-uri-args.t
+++ b/t/030-uri-args.t
@@ -1691,58 +1691,62 @@ bad argument #1 to 'set_uri_args' (string, number, or table expected, but got us
 
 === TEST 64: rewrite args (string with \r)
 --- config
-    location /bar {
-        echo $server_protocol $query_string;
-    }
     location /foo {
         rewrite_by_lua_block {
             ngx.req.set_uri_args("a\rb")
         }
-        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/echo;
+    }
+    location /echo {
+        content_by_lua_block {
+            ngx.say(ngx.var.request_uri);
+        }
     }
 --- request
 GET /foo?world
---- error_code: 500
---- error_log eval
-qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(unescaped byte 0xd in query string "a\\x0Db"\)/
+--- error_code: 200
+--- response_body
+/echo?a%0Db
 
 
 
 === TEST 65: rewrite args (string with \n)
 --- config
-    location /bar {
-        echo $server_protocol $query_string;
-    }
     location /foo {
         rewrite_by_lua_block {
             ngx.req.set_uri_args("a\nb")
         }
-        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/echo;
+    }
+    location /echo {
+        content_by_lua_block {
+            ngx.say(ngx.var.request_uri);
+        }
     }
 --- request
 GET /foo?world
---- error_code: 500
---- error_log eval
-qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(unescaped byte 0xa in query string "a\\x0Ab"\)/
+--- response_body
+/echo?a%0Ab
 
 
 
 === TEST 66: rewrite args (string with \0)
 --- config
-    location /bar {
-        echo $server_protocol $query_string;
-    }
     location /foo {
         rewrite_by_lua_block {
             ngx.req.set_uri_args("a\0b")
         }
-        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/echo;
+    }
+    location /echo {
+        content_by_lua_block {
+            ngx.say(ngx.var.request_uri);
+        }
     }
 --- request
 GET /foo?world
---- error_code: 500
---- error_log eval
-qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(unescaped byte 0x0 in query string "a\\x00b"\)/
+--- response_body
+/echo?a%00b
 
 
 

--- a/t/030-uri-args.t
+++ b/t/030-uri-args.t
@@ -9,7 +9,7 @@ log_level('warn');
 repeat_each(2);
 #repeat_each(1);
 
-plan tests => repeat_each() * (blocks() * 2 + 24);
+plan tests => repeat_each() * (blocks() * 2 + 27);
 
 no_root_location();
 
@@ -1709,7 +1709,10 @@ bad argument #1 to 'set_uri_args' (string, number, or table expected, but got us
     GET /foo?world
 --- error_code: 500
 --- error_log eval
-qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(args need to be escaped\)/
+[
+qr/\[error\] .*? unsafe byte "0xd" in query string "a\\x0Db"/,
+qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(query-string contains unescaped byte\)/
+]
 
 
 
@@ -1728,7 +1731,10 @@ qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_u
     GET /foo?world
 --- error_code: 500
 --- error_log eval
-qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(args need to be escaped\)/
+[
+qr/\[error\] .*? unsafe byte "0xa" in query string "a\\x0Ab"/,
+qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(query-string contains unescaped byte\)/
+]
 
 
 
@@ -1747,7 +1753,10 @@ qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_u
     GET /foo?world
 --- error_code: 500
 --- error_log eval
-qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(args need to be escaped\)/
+[
+qr/\[error\] .*? unsafe byte "0x0" in query string "a\\x00b"/,
+qr/\[error\] .*? rewrite_by_lua\(nginx.conf:\d+\):\d+: bad argument #1 to 'set_uri_args' \(query-string contains unescaped byte\)/
+]
 
 
 


### PR DESCRIPTION
bugfix: ngx.req.set_uri_args with string argument can contain invalid chacters.

throw an Lua Exception when argument contain \r or  \n or \0

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.