### PR TITLE
test: use iptable -I option to insert rule to the head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,8 +94,8 @@ before_script:
 
 script:
   - sudo iptables -I OUTPUT 1 -p udp --dport 10086 -j REJECT
-  - sudo iptables -A OUTPUT -p tcp --dst 127.0.0.2 --dport 12345 -j DROP
-  - sudo iptables -A OUTPUT -p udp --dst 127.0.0.2 --dport 12345 -j DROP
+  - sudo iptables -I OUTPUT -p tcp --dst 127.0.0.2 --dport 12345 -j DROP
+  - sudo iptables -I OUTPUT -p udp --dst 127.0.0.2 --dport 12345 -j DROP
   - cd luajit2/
   - make -j$JOBS CCDEBUG=-g Q= PREFIX=$LUAJIT_PREFIX CC=$CC XCFLAGS='-DLUA_USE_APICHECK -DLUA_USE_ASSERT -msse4.2' > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make install PREFIX=$LUAJIT_PREFIX > build.log 2>&1 || (cat build.log && exit 1)


### PR DESCRIPTION
test: use iptable -I option to insert rule to the head of the filter chain in case there are other system default rules  in front of the our own rule.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
