### PR TITLE
feature(socket.tcp): enhance the logic of parameter verification in

### DIFF
--- a/t/023-rewrite/unix-socket.t
+++ b/t/023-rewrite/unix-socket.t
@@ -79,7 +79,7 @@ qr{\[crit\] .*? connect\(\) to unix:/tmp/nosuchfile\.sock failed}
 --- request
     GET /test
 --- response_body
-failed to connect: failed to parse host name "/tmp/test-nginx.sock": invalid host
+failed to connect: missing the port number
 
 
 


### PR DESCRIPTION
In [ngx.socket.tcp:connect](https://github.com/openresty/lua-nginx-module#ngxsocketconnect), if host is a TCP socket, the third parameter could be `nil`, it is to some third part module to write their code like this:
```
function _M.connect(host, port, opt)
    sock = ngx.socket.tcp()
    sock:connect(host, port, opt)
end
```
But if the host is a unix-domain socket, the second parameter could not be a `nil`, we have to write the code like this:
```
function _M.connect(path, opt)
    sock = ngx.socket.tcp()
    if opt ~= nil then
        sock:connect("unix:" .. path, opt)
    else
       sock:connect("unix:" .. path)
   end
end
```
Just like here: https://github.com/openresty/lua-resty-redis/pull/200/files#diff-adb515948c05651051c83fd6fb3ce7ceR143-R149. I think it is a comment use way, so update the second parameter and allow it be nil.
