### PR TITLE
doc: fix unclosed <code> tag breaking markup

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5604,7 +5604,7 @@ It accepts the following values (defaults to `2`):
 ` ` (space), `#`, `%`,
 `?`, 0x00 ~ 0x1F, 0x7F ~ 0xFF will be escaped.
 * `2`: escape `str` as a URI component. All characters except
-alphabetic characters, digits, `-`, `.`, <code>_<code>,
+alphabetic characters, digits, `-`, `.`, `_`,
 `~` will be encoded as `%XX`.
 
 [Back to TOC](#nginx-api-for-lua)

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -4709,7 +4709,7 @@ It accepts the following values (defaults to `2`):
 <code> </code> (space), <code>#</code>, <code>%</code>,
 `?`, 0x00 ~ 0x1F, 0x7F ~ 0xFF will be escaped.
 * `2`: escape <code>str</code> as a URI component. All characters except
-alphabetic characters, digits, <code>-</code>, <code>.</code>, <code>_<code>,
+alphabetic characters, digits, <code>-</code>, <code>.</code>, <code>_</code>,
 <code>~</code> will be encoded as `%XX`.
 
 == ngx.unescape_uri ==


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

---

Before the fix:

  * `doc/HttpLuaModule.wiki` rendered to HTML using MediaWiki API: [link](https://tinystash.undef.im/il/4wSigPZTMqZcXxT8gGH8PeHBaza8zpNskT9UY7zWDmDTmH9Gyx8bogjyt2zei9ApFqAAkDEFJz4oaoDVQ91Ztswc.html#ngx.escape_uri)
  * `README.markdown` rendered by GitHub, screenshot: ![image](https://user-images.githubusercontent.com/2131407/86520057-7bf89480-be49-11ea-8d8c-ba540a952704.png)

