### PR TITLE
bugfix: macro contains operator should be wrapped inside a bracket.

### DIFF
--- a/src/ngx_http_lua_util.h
+++ b/src/ngx_http_lua_util.h
@@ -31,12 +31,12 @@
 
 #define NGX_HTTP_LUA_ESCAPE_HEADER_VALUE  8
 
-#define NGX_HTTP_LUA_CONTEXT_YIELDABLE  NGX_HTTP_LUA_CONTEXT_REWRITE         \
+#define NGX_HTTP_LUA_CONTEXT_YIELDABLE (NGX_HTTP_LUA_CONTEXT_REWRITE         \
                                         | NGX_HTTP_LUA_CONTEXT_ACCESS        \
                                         | NGX_HTTP_LUA_CONTEXT_CONTENT       \
                                         | NGX_HTTP_LUA_CONTEXT_TIMER         \
                                         | NGX_HTTP_LUA_CONTEXT_SSL_CERT      \
-                                        | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH
+                                        | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH)
 
 
 /* key in Lua vm registry for all the "ngx.ctx" tables */


### PR DESCRIPTION
The bracket is missing in the previous refactor.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
