### PR TITLE
feature: allow ngx.sleep to be used blockingly in non-yieldable phases

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5621,13 +5621,16 @@ ngx.sleep
 
 **syntax:** *ngx.sleep(seconds)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;*
+**context:** *init_by_lua&#42;, init_worker_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, exit_worker_by_lua&#42;*
 
-Sleeps for the specified seconds without blocking. One can specify time resolution up to 0.001 seconds (i.e., one millisecond).
+Sleeps for the specified seconds without blocking in yieldable phases or blockingly in other phases.
+One can specify time resolution up to 0.001 seconds (i.e., one millisecond).
 
 Behind the scene, this method makes use of the Nginx timers.
 
 Since the `0.7.20` release, The `0` time argument can also be specified.
+
+Since the `FIXME` release, this method can be used in non-yieldable phases blockingly.
 
 This method was introduced in the `0.5.0rc30` release.
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -4720,13 +4720,16 @@ Since <code>v0.8.3</code> this function returns <code>1</code> on success, or re
 
 '''syntax:''' ''ngx.sleep(seconds)''
 
-'''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*, ngx.timer.*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*''
+'''context:''' ''init_by_lua*, init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*, exit_worker_by_lua*''
 
-Sleeps for the specified seconds without blocking. One can specify time resolution up to 0.001 seconds (i.e., one millisecond).
+Sleeps for the specified seconds without blocking in yieldable phases or blockingly in other phases.
+One can specify time resolution up to 0.001 seconds (i.e., one millisecond).
 
 Behind the scene, this method makes use of the Nginx timers.
 
 Since the <code>0.7.20</code> release, The <code>0</code> time argument can also be specified.
+
+Since the <code>FIXME</code> release, this method can be used in non-yieldable phases blockingly.
 
 This method was introduced in the <code>0.5.0rc30</code> release.
 

--- a/t/077-sleep.t
+++ b/t/077-sleep.t
@@ -9,7 +9,7 @@ log_level('debug');
 
 repeat_each(2);
 
-plan tests => repeat_each() * 71;
+plan tests => repeat_each() * (blocks() * 4);
 
 #no_diff();
 no_long_string();
@@ -237,21 +237,20 @@ lua sleep timer expired: "/test?"
 
 
 
-=== TEST 10: ngx.sleep unavailable in log_by_lua
+=== TEST 10: ngx.sleep available in log_by_lua
 --- config
     location /t {
         echo hello;
-        log_by_lua '
-            ngx.sleep(0.1)
-        ';
+        log_by_lua_block {
+            ngx.sleep(0.001)
+        }
     }
 --- request
 GET /t
 --- response_body
 hello
---- wait: 0.1
 --- error_log
-API disabled in the context of log_by_lua*
+lua ready to sleep for 1 ms
 
 
 
@@ -500,3 +499,66 @@ f end
 worker cycle
 e?poll timer: 0
 /
+
+
+
+=== TEST 18: ngx.sleep(0) in no-yieldable phases
+--- config
+    location /t {
+        echo hello;
+        log_by_lua_block {
+            ngx.sleep(0)
+        }
+    }
+--- request
+GET /t
+--- response_body
+hello
+--- error_log
+lua ready to sleep for 0 ms
+
+
+
+=== TEST 19: ngx.sleep available in init_worker_by_lua
+--- http_config
+    init_worker_by_lua_block {
+        local start = ngx.now()
+        ngx.sleep(0.1)
+        ngx.update_time()
+        package.loaded.gap = ngx.now() - start
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say(package.loaded.gap >= 0.1)
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- response_body
+true
+
+
+
+=== TEST 20: ngx.sleep available in init_by_lua
+--- http_config
+    init_by_lua_block {
+        local start = ngx.now()
+        ngx.sleep(0.1)
+        ngx.update_time()
+        package.loaded.gap = ngx.now() - start
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say(package.loaded.gap >= 0.1)
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- response_body
+true

--- a/t/138-balancer.t
+++ b/t/138-balancer.t
@@ -9,7 +9,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 4 + 9);
+plan tests => repeat_each() * (blocks() * 4 + 8);
 
 #no_diff();
 no_long_string();
@@ -258,12 +258,12 @@ qr/\[error\] .*? failed to run balancer_by_lua\*: balancer_by_lua:2: API disable
 
 
 
-=== TEST 10: ngx.sleep is disabled
+=== TEST 10: ngx.sleep is allowed
 --- http_config
     upstream backend {
         server 0.0.0.1;
         balancer_by_lua_block {
-            ngx.sleep(0.1)
+            ngx.sleep(0.001)
         }
     }
 --- config
@@ -272,10 +272,8 @@ qr/\[error\] .*? failed to run balancer_by_lua\*: balancer_by_lua:2: API disable
     }
 --- request
     GET /t
---- response_body_like: 500 Internal Server Error
---- error_code: 500
---- error_log eval
-qr/\[error\] .*? failed to run balancer_by_lua\*: balancer_by_lua:2: API disabled in the context of balancer_by_lua\*/
+--- response_body_like: 502 Bad Gateway
+--- error_code: 502
 
 
 

--- a/t/142-ssl-session-store.t
+++ b/t/142-ssl-session-store.t
@@ -6,7 +6,7 @@ use File::Basename;
 
 repeat_each(3);
 
-plan tests => repeat_each() * (blocks() * 6 - 1);
+plan tests => repeat_each() * (blocks() * 5 + 11);
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 
@@ -95,11 +95,11 @@ ssl_session_store_by_lua_block:1: ssl session store by lua is running!,
 
 
 
-=== TEST 2: sleep is not allowed
+=== TEST 2: sleep is allowed
 --- http_config
     ssl_session_store_by_lua_block {
         local begin = ngx.now()
-        ngx.sleep(0.1)
+        ngx.sleep(0.001)
         print("elapsed in ssl store session by lua: ", ngx.now() - begin)
     }
     server {
@@ -157,7 +157,6 @@ close: 1 nil
 
 --- error_log
 lua ssl server name: "test.com"
-API disabled in the context of ssl_session_store_by_lua*
 
 --- no_error_log
 [alert]


### PR DESCRIPTION
Allow ngx.sleep everywhere simplify the application's logic.
Now we don't need to write a fallback if the same function need to be
run in non-yieldable phases.

Close #1730.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
