### PR TITLE
doc: removed the useless semicolon in the example lua code

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4205,9 +4205,9 @@ The header names are matched case-insensitively.
 ```lua
 
  -- equivalent to ngx.header["Content-Type"] = 'text/plain'
- ngx.header.content_type = 'text/plain';
+ ngx.header.content_type = 'text/plain'
 
- ngx.header["X-My-Header"] = 'blah blah';
+ ngx.header["X-My-Header"] = 'blah blah'
 ```
 
 Multi-value headers can be set this way:

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -1123,14 +1123,14 @@ You can also initialize the [[#lua_shared_dict|lua_shared_dict]] shm storage at 
     lua_shared_dict dogs 1m;
 
     init_by_lua_block {
-        local dogs = ngx.shared.dogs;
+        local dogs = ngx.shared.dogs
         dogs:set("Tom", 56)
     }
 
     server {
         location = /api {
             content_by_lua_block {
-                local dogs = ngx.shared.dogs;
+                local dogs = ngx.shared.dogs
                 ngx.say(dogs:get("Tom"))
             }
         }
@@ -1351,8 +1351,8 @@ a time. However, a workaround is possible using the [[#ngx.var.VARIABLE|ngx.var.
             local a = 32
             local b = 56
 
-            ngx.var.diff = a - b;  -- write to $diff directly
-            return a + b;          -- return the $sum value normally
+            ngx.var.diff = a - b  -- write to $diff directly
+            return a + b          -- return the $sum value normally
         ';
 
         echo "sum = $sum, diff = $diff";
@@ -1541,7 +1541,7 @@ The right way of doing this is as follows:
         rewrite_by_lua '
             ngx.var.b = tonumber(ngx.var.a) + 1
             if tonumber(ngx.var.b) == 13 then
-                return ngx.redirect("/bar");
+                return ngx.redirect("/bar")
             end
         ';
 
@@ -2824,7 +2824,7 @@ For example:
     location /foo {
         set $my_var ''; # this line is required to create $my_var at config time
         content_by_lua_block {
-            ngx.var.my_var = 123;
+            ngx.var.my_var = 123
             ...
         }
     }
@@ -3247,7 +3247,7 @@ This option is set to <code>false</code> by default
         set $dog 'hello';
         content_by_lua_block {
             res = ngx.location.capture("/other",
-                { share_all_vars = true });
+                { share_all_vars = true })
 
             ngx.print(res.body)
             ngx.say(ngx.var.uri, ": ", ngx.var.dog)
@@ -3311,7 +3311,7 @@ unescaping them in the Nginx config file.
         set $cat '';
         content_by_lua_block {
             res = ngx.location.capture("/other",
-                { vars = { dog = "hello", cat = 32 }});
+                { vars = { dog = "hello", cat = 32 }})
 
             ngx.print(res.body)
         }
@@ -3338,8 +3338,8 @@ The <code>ctx</code> option can be used to specify a custom Lua table to serve a
             local ctx = {}
             res = ngx.location.capture("/sub", { ctx = ctx })
 
-            ngx.say(ctx.foo);
-            ngx.say(ngx.ctx.foo);
+            ngx.say(ctx.foo)
+            ngx.say(ngx.ctx.foo)
         }
     }
 </geshi>
@@ -3356,13 +3356,13 @@ It is also possible to use this <code>ctx</code> option to share the same [[#ngx
 <geshi lang="nginx">
     location /sub {
         content_by_lua_block {
-            ngx.ctx.foo = "bar";
+            ngx.ctx.foo = "bar"
         }
     }
     location /lua {
         content_by_lua_block {
             res = ngx.location.capture("/sub", { ctx = ngx.ctx })
-            ngx.say(ngx.ctx.foo);
+            ngx.say(ngx.ctx.foo)
         }
     }
 </geshi>
@@ -3486,9 +3486,9 @@ The header names are matched case-insensitively.
 
 <geshi lang="lua">
     -- equivalent to ngx.header["Content-Type"] = 'text/plain'
-    ngx.header.content_type = 'text/plain';
+    ngx.header.content_type = 'text/plain'
 
-    ngx.header["X-My-Header"] = 'blah blah';
+    ngx.header["X-My-Header"] = 'blah blah'
 </geshi>
 
 Multi-value headers can be set this way:
@@ -3521,13 +3521,13 @@ is equivalent to
 Setting a slot to <code>nil</code> effectively removes it from the response headers:
 
 <geshi lang="lua">
-    ngx.header["X-My-Header"] = nil;
+    ngx.header["X-My-Header"] = nil
 </geshi>
 
 The same applies to assigning an empty table:
 
 <geshi lang="lua">
-    ngx.header["X-My-Header"] = {};
+    ngx.header["X-My-Header"] = {}
 </geshi>
 
 Setting <code>ngx.header.HEADER</code> after sending out response headers (either explicitly with [[#ngx.send_headers|ngx.send_headers]] or implicitly with [[#ngx.print|ngx.print]] and similar) will log an error message.
@@ -4403,8 +4403,8 @@ Does an internal redirect to <code>uri</code> with <code>args</code> and is simi
 
 <geshi lang="lua">
     ngx.exec('/some-location');
-    ngx.exec('/some-location', 'a=3&b=5&c=6');
-    ngx.exec('/some-location?a=3&b=5', 'c=6');
+    ngx.exec('/some-location', 'a=3&b=5&c=6')
+    ngx.exec('/some-location?a=3&b=5', 'c=6')
 </geshi>
 
 The optional second <code>args</code> can be used to specify extra URI query arguments, for example:
@@ -4430,7 +4430,7 @@ Named locations are also supported but the second <code>args</code> argument wil
 <geshi lang="nginx">
     location /foo {
         content_by_lua_block {
-            ngx.exec("@bar", "a=goodbye");
+            ngx.exec("@bar", "a=goodbye")
         }
     }
 
@@ -4509,7 +4509,7 @@ This method is similar to the [[HttpRewriteModule#rewrite|rewrite]] directive wi
 is equivalent to the following Lua code
 
 <geshi lang="lua">
-    return ngx.redirect('/foo');  -- Lua code
+    return ngx.redirect('/foo')  -- Lua code
 </geshi>
 
 while
@@ -7377,7 +7377,7 @@ For example, the following [[HttpSetMiscModule]] directives can be invoked this 
 For instance,
 
 <geshi lang="lua">
-    local res = ndk.set_var.set_escape_uri('a/b');
+    local res = ndk.set_var.set_escape_uri('a/b')
     -- now res == 'a%2fb'
 </geshi>
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

@doujiang24 @thibaultcha 
https://github.com/openresty/lua-nginx-module/pull/1757#issuecomment-668156744