### PR TITLE
bugfix: when recreating balancer buffer, remove existing buffers first

### DIFF
--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -795,7 +795,6 @@ ngx_http_lua_ffi_balancer_recreate_request(ngx_http_request_t *r,
         u->request_bufs = u->request_bufs->next;
     }
 
-
     return u->create_request(r);
 }
 

--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -788,6 +788,14 @@ ngx_http_lua_ffi_balancer_recreate_request(ngx_http_request_t *r,
 
     *err = NULL;
 
+    if (u->request_bufs != NULL && u->request_bufs != r->request_body->bufs) {
+        /* u->request_bufs already contains a valid request buffer
+         * remove it from chain first
+         */
+        u->request_bufs = u->request_bufs->next;
+    }
+
+
     return u->create_request(r);
 }
 


### PR DESCRIPTION
if they exist.

This bug was discovered first by Kong users in
https://github.com/Kong/kong/issues/6212. After investigation, it seems
that the cause is that when calling `create_request` function
multiple times, it may incorrectly consider the buffer created in the
last call request body data, causing both the old and new request buffer
to be sent to the upstream.

This PR checks the request buffer chain link before calling the
`create_request` function. If it contains a buffer generated previously,
that buffer is skipped first so the new buffer that will be generated
falls in at the correct location.

This bug only affects user calling the new `recreate_request` API during balancer retries, for users not calling it they are not impacted.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
