### PR TITLE
bugfix: unescape_uri bug with invalid quoted character

### DIFF
--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -2156,6 +2156,7 @@ ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
 
             state = sw_usual;
 
+            *d++ = '%';
             *d++ = ch;
 
             break;
@@ -2217,6 +2218,8 @@ ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
             }
 
             /* the invalid quoted character */
+
+            *d++ = '%'; *d++ = *(s - 2); *d++ = *(s - 1);
 
             break;
         }

--- a/t/030-uri-args.t
+++ b/t/030-uri-args.t
@@ -77,7 +77,7 @@ c = true
 GET /lua?foo&baz=&bar=42
 --- response_body
 bar = 42
-baz = 
+baz =
 foo = true
 
 
@@ -812,7 +812,7 @@ rc: false, err: attempt to use userdata as query arg value
 --- request
 GET /lua
 --- response_body
-args: 
+args:
 
 
 
@@ -1221,8 +1221,8 @@ b = true
 --- request
 GET /lua
 --- response_body
-a = 
-b = 
+a =
+b =
 
 
 
@@ -1767,3 +1767,31 @@ request_uri: /foo%20bar
 uri: /foo bar
 --- no_error_log
 [error]
+
+
+
+=== TEST 67: invalid quoted character
+--- config
+    location /lua {
+        content_by_lua '
+            local args, err = ngx.req.get_uri_args()
+
+            if err then
+                ngx.say("err: ", err)
+            end
+
+            local keys = {}
+            for key, val in pairs(args) do
+                table.insert(keys, key)
+            end
+
+            table.sort(keys)
+            for i, key in ipairs(keys) do
+                ngx.say(key, " = ", args[key])
+            end
+        ';
+    }
+--- request
+GET /lua?test=hello%1world
+--- response_body
+test = hello%1world


### PR DESCRIPTION
fix https://github.com/openresty/lua-nginx-module/issues/1788


```lua
local args = ngx.decode_args("a=hello%1world")
for k, v in pairs(args) do
    ngx.say("k = ", k, ", v = ", v)
end
```
output: `k = a, v = helloorld`, some charactes are missing

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
