### PR TITLE
fix negative content-length number

### DIFF
--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -492,8 +492,9 @@ ngx_http_lua_ngx_resp_get_headers(lua_State *L)
             if (p == NULL) {
                 return luaL_error(L, "no memory");
             }
+
             len = ngx_snprintf(p, NGX_OFF_T_LEN, "%O",
-                         r->headers_out.content_length_n) - p;
+                               r->headers_out.content_length_n) - p;
             lua_pushfstring(L, "%s", (char *) p, len);
         } else {
             lua_pushfstring(L, "%d", (int) r->headers_out.content_length_n);

--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -485,7 +485,17 @@ ngx_http_lua_ngx_resp_get_headers(lua_State *L)
     {
         extra++;
         lua_pushliteral(L, "content-length");
-        lua_pushfstring(L, "%d", (int) r->headers_out.content_length_n);
+        if (r->headers_out.content_length_n > NGX_MAX_INT32_VALUE) {
+            u_char *p = ngx_palloc(r->pool, NGX_OFF_T_LEN);
+            if (p == NULL) {
+                return luaL_error(L, "no memory");
+            }
+            size_t len = ngx_snprintf(p, NGX_OFF_T_LEN, "%O",
+                         r->headers_out.content_length_n) - p;
+            lua_pushfstring(L, "%s", (char *) p, len);
+        } else {
+            lua_pushfstring(L, "%d", (int) r->headers_out.content_length_n);
+        }
         lua_rawset(L, -3);
     }
 

--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -424,6 +424,8 @@ ngx_http_lua_ngx_resp_get_headers(lua_State *L)
     int                 count = 0;
     int                 truncated = 0;
     int                 extra = 0;
+    u_char             *p = NULL;
+    size_t              len = 0;
 
     n = lua_gettop(L);
 
@@ -486,11 +488,11 @@ ngx_http_lua_ngx_resp_get_headers(lua_State *L)
         extra++;
         lua_pushliteral(L, "content-length");
         if (r->headers_out.content_length_n > NGX_MAX_INT32_VALUE) {
-            u_char *p = ngx_palloc(r->pool, NGX_OFF_T_LEN);
+            p = ngx_palloc(r->pool, NGX_OFF_T_LEN);
             if (p == NULL) {
                 return luaL_error(L, "no memory");
             }
-            size_t len = ngx_snprintf(p, NGX_OFF_T_LEN, "%O",
+            len = ngx_snprintf(p, NGX_OFF_T_LEN, "%O",
                          r->headers_out.content_length_n) - p;
             lua_pushfstring(L, "%s", (char *) p, len);
         } else {


### PR DESCRIPTION
proxy mode.
download big file (> 4GB), eg [CentOS-8.2.2004-x86_64-dvd1.iso](https://mirror.xtom.com.hk/centos/8.2.2004/isos/x86_64/CentOS-8.2.2004-x86_64-dvd1.iso) size 8231321600.
ngx.resp.get_headers()['Content-Length'] return  **-35861299**

The problem is Integer Overflow. Code is here
```c
lua_pushfstring(L, "%d", (int) r->headers_out.content_length_n);
```
Can't write test case for this one..
