### PR TITLE
style: mark private ngx_http_lua_module_ctx static

### DIFF
--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -626,7 +626,7 @@ static ngx_command_t ngx_http_lua_cmds[] = {
 };
 
 
-ngx_http_module_t ngx_http_lua_module_ctx = {
+static ngx_http_module_t ngx_http_lua_module_ctx = {
     NULL,                             /*  preconfiguration */
     ngx_http_lua_init,                /*  postconfiguration */
 


### PR DESCRIPTION
`ngx_http_lua_module_ctx` is none public, and almost other modules in official release all mark `ngx_module_t.ctx` variable static. 