### PR TITLE
bugfix: entry threads would leak when exceeding the lua_max_running_t…

### DIFF
--- a/src/ngx_http_lua_timer.c
+++ b/src/ngx_http_lua_timer.c
@@ -682,6 +682,18 @@ failed:
                   "lua failed to run timer with function defined at %s:%d: %s",
                   source, ar.linedefined, errmsg);
 
+#if 1
+    if (L == NULL) {
+        if (tctx.vm_state != NULL) {
+            L = tctx.vm_state->vm;
+        }
+
+        if (L == NULL) {
+            L = lmcf->lua;
+        }
+    }
+#endif
+
     if (L != NULL) {
         ngx_http_lua_free_thread(r, L, tctx.co_ref, tctx.co, lmcf);
     }


### PR DESCRIPTION
…imers limit. this regression had appeared in commit 4de59f5da or v0.10.18rc2.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
