### PR TITLE
tests: --- shutdown_error_log should be excluded from repeat_each() when counting plans.

### DIFF
--- a/t/089-phase.t
+++ b/t/089-phase.t
@@ -8,7 +8,7 @@ log_level('warn');
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 2 + 2);
+plan tests => repeat_each() * (blocks() * 2 + 1) + 2;
 
 #no_diff();
 #no_long_string();

--- a/t/154-semaphore.t
+++ b/t/154-semaphore.t
@@ -8,7 +8,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 3) + blocks();
+plan tests => repeat_each() * (blocks() * 3) + 1;
 
 no_long_string();
 #no_diff();

--- a/t/162-exit-worker.t
+++ b/t/162-exit-worker.t
@@ -5,7 +5,7 @@ use Test::Nginx::Socket::Lua;
 master_on();
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 2 + 8);
+plan tests => repeat_each() * (blocks() * 2 + 2) + 12;
 
 #log_level("warn");
 no_long_string();

--- a/t/163-exit-worker-hup.t
+++ b/t/163-exit-worker-hup.t
@@ -16,7 +16,7 @@ use Test::Nginx::Socket::Lua $SkipReason ? (skip_all => $SkipReason) : ();
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 2 + 2);
+plan tests => repeat_each() * (blocks() * 2 + 1) + 2;
 
 no_long_string();
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.