### PR TITLE
bugfix: fixed segfault caused by an incorrect format token introduced in commit 3e24a95a.

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -2627,7 +2627,7 @@ success:
 #endif
 
         ngx_log_debug3(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                       "lua tcp socket try to recv data %uz: \"%V?%V\"",
+                       "lua tcp socket try to recv data %O: \"%V?%V\"",
                        size, &r->uri, &r->args);
 
         n = c->recv(c, b->last, size);


### PR DESCRIPTION


I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
