### PR TITLE
bugfix: accessed memory out of range when calling lua_pushfstring with none zero-terminated string introduced in commit 7367a231.

### DIFF
--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -496,7 +496,7 @@ ngx_http_lua_ngx_resp_get_headers(lua_State *L)
             len = ngx_snprintf(p, NGX_OFF_T_LEN, "%O",
                                r->headers_out.content_length_n) - p;
 
-            lua_pushfstring(L, "%s", (char *) p, len);
+            lua_pushlstring(L, (char *) p, len);
 
         } else {
             lua_pushfstring(L, "%d", (int) r->headers_out.content_length_n);


### PR DESCRIPTION
…

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
