### PR TITLE
optimize: post zombie thread: avoided the linear search.

### DIFF
--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -446,6 +446,7 @@ struct ngx_http_lua_co_ctx_s {
     ngx_http_lua_co_ctx_t   *parent_co_ctx;
 
     ngx_http_lua_posted_thread_t    *zombie_child_threads;
+    ngx_http_lua_posted_thread_t   **next_zombie_child_thread;
 
     ngx_http_cleanup_pt      cleanup;
 

--- a/src/ngx_http_lua_coroutine.c
+++ b/src/ngx_http_lua_coroutine.c
@@ -140,6 +140,7 @@ ngx_http_lua_coroutine_create_helper(lua_State *L, ngx_http_request_t *r,
 
     } else {
         ngx_memzero(coctx, sizeof(ngx_http_lua_co_ctx_t));
+        coctx->next_zombie_child_thread = &coctx->zombie_child_threads;
         coctx->co_ref = LUA_NOREF;
     }
 

--- a/src/ngx_http_lua_util.h
+++ b/src/ngx_http_lua_util.h
@@ -266,6 +266,8 @@ ngx_http_lua_init_ctx(ngx_http_request_t *r, ngx_http_lua_ctx_t *ctx)
     ngx_memzero(ctx, sizeof(ngx_http_lua_ctx_t));
     ctx->ctx_ref = LUA_NOREF;
     ctx->entry_co_ctx.co_ref = LUA_NOREF;
+    ctx->entry_co_ctx.next_zombie_child_thread =
+        &ctx->entry_co_ctx.zombie_child_threads;
     ctx->resume_handler = ngx_http_lua_wev_handler;
     ctx->request = r;
 }


### PR DESCRIPTION
This function can be very expensive when there are a lot of zombie
threads in the current context.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
