### PR TITLE
chore: fix possible null pointer dereference found by Coverity

### DIFF
--- a/src/ngx_http_lua_ssl_session_fetchby.c
+++ b/src/ngx_http_lua_ssl_session_fetchby.c
@@ -450,7 +450,8 @@ ngx_http_lua_log_ssl_sess_fetch_error(ngx_log_t *log, u_char *buf, size_t len)
         }
 
         if (c->listening && c->listening->addr_text.len) {
-            p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
+            p = ngx_snprintf(buf, len, ", server: %V", \
+                &c->listening->addr_text);
             buf = p;
         }
     }

--- a/src/ngx_http_lua_ssl_session_fetchby.c
+++ b/src/ngx_http_lua_ssl_session_fetchby.c
@@ -451,7 +451,7 @@ ngx_http_lua_log_ssl_sess_fetch_error(ngx_log_t *log, u_char *buf, size_t len)
 
         if (c->listening && c->listening->addr_text.len) {
             p = ngx_snprintf(buf, len, ", server: %V", \
-            &c->listening->addr_text);
+                             &c->listening->addr_text);
             buf = p;
         }
     }

--- a/src/ngx_http_lua_ssl_session_fetchby.c
+++ b/src/ngx_http_lua_ssl_session_fetchby.c
@@ -442,15 +442,17 @@ ngx_http_lua_log_ssl_sess_fetch_error(ngx_log_t *log, u_char *buf, size_t len)
 
     c = log->data;
 
-    if (c->addr_text.len) {
-        p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
-        len -= p - buf;
-        buf = p;
-    }
+    if (c) {
+        if (c->addr_text.len) {
+            p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
+            len -= p - buf;
+            buf = p;
+        }
 
-    if (c && c->listening && c->listening->addr_text.len) {
-        p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
-        buf = p;
+        if (c->listening && c->listening->addr_text.len) {
+            p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
+            buf = p;
+        }
     }
 
     return buf;

--- a/src/ngx_http_lua_ssl_session_fetchby.c
+++ b/src/ngx_http_lua_ssl_session_fetchby.c
@@ -442,7 +442,7 @@ ngx_http_lua_log_ssl_sess_fetch_error(ngx_log_t *log, u_char *buf, size_t len)
 
     c = log->data;
 
-    if (c) {
+    if (c != NULL) {
         if (c->addr_text.len) {
             p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
             len -= p - buf;
@@ -451,7 +451,7 @@ ngx_http_lua_log_ssl_sess_fetch_error(ngx_log_t *log, u_char *buf, size_t len)
 
         if (c->listening && c->listening->addr_text.len) {
             p = ngx_snprintf(buf, len, ", server: %V", \
-                &c->listening->addr_text);
+            &c->listening->addr_text);
             buf = p;
         }
     }


### PR DESCRIPTION
```
443    c = log->data;
444
   deref_ptr: Directly dereferencing pointer c.
445    if (c->addr_text.len) {
446        p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
447        len -= p - buf;
448        buf = p;
449    }
450
   CID 251611 (#1 of 1): Dereference before null check (REVERSE_INULL)check_after_deref: Null-checking c suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
451    if (c && c->listening && c->listening->addr_text.len) {
452        p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
453        buf = p;
454    }

```

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
