### PR TITLE
chore: fix possible null pointer dereference found by Coverity

### DIFF
--- a/src/ngx_http_lua_ssl_session_storeby.c
+++ b/src/ngx_http_lua_ssl_session_storeby.c
@@ -328,15 +328,17 @@ ngx_http_lua_log_ssl_sess_store_error(ngx_log_t *log, u_char *buf, size_t len)
 
     c = log->data;
 
-    if (c->addr_text.len) {
-        p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
-        len -= p - buf;
-        buf = p;
-    }
+    if (c) {
+        if (c->addr_text.len) {
+            p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
+            len -= p - buf;
+            buf = p;
+        }
 
-    if (c && c->listening && c->listening->addr_text.len) {
-        p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
-        buf = p;
+        if (c->listening && c->listening->addr_text.len) {
+            p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
+            buf = p;
+        }
     }
 
     return buf;

--- a/src/ngx_http_lua_ssl_session_storeby.c
+++ b/src/ngx_http_lua_ssl_session_storeby.c
@@ -336,7 +336,8 @@ ngx_http_lua_log_ssl_sess_store_error(ngx_log_t *log, u_char *buf, size_t len)
         }
 
         if (c->listening && c->listening->addr_text.len) {
-            p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
+            p = ngx_snprintf(buf, len, ", server: %V", \
+                &c->listening->addr_text);
             buf = p;
         }
     }

--- a/src/ngx_http_lua_ssl_session_storeby.c
+++ b/src/ngx_http_lua_ssl_session_storeby.c
@@ -328,7 +328,7 @@ ngx_http_lua_log_ssl_sess_store_error(ngx_log_t *log, u_char *buf, size_t len)
 
     c = log->data;
 
-    if (c) {
+    if (c != NULL) {
         if (c->addr_text.len) {
             p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
             len -= p - buf;
@@ -337,7 +337,7 @@ ngx_http_lua_log_ssl_sess_store_error(ngx_log_t *log, u_char *buf, size_t len)
 
         if (c->listening && c->listening->addr_text.len) {
             p = ngx_snprintf(buf, len, ", server: %V", \
-                &c->listening->addr_text);
+            &c->listening->addr_text);
             buf = p;
         }
     }

--- a/src/ngx_http_lua_ssl_session_storeby.c
+++ b/src/ngx_http_lua_ssl_session_storeby.c
@@ -337,7 +337,7 @@ ngx_http_lua_log_ssl_sess_store_error(ngx_log_t *log, u_char *buf, size_t len)
 
         if (c->listening && c->listening->addr_text.len) {
             p = ngx_snprintf(buf, len, ", server: %V", \
-            &c->listening->addr_text);
+                             &c->listening->addr_text);
             buf = p;
         }
     }


### PR DESCRIPTION
```
329    c = log->data;
330
   deref_ptr: Directly dereferencing pointer c.
331    if (c->addr_text.len) {
332        p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
333        len -= p - buf;
334        buf = p;
335    }
336
   CID 251578 (#1 of 1): Dereference before null check (REVERSE_INULL)check_after_deref: Null-checking c suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
337    if (c && c->listening && c->listening->addr_text.len) {
338        p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
339        buf = p;
340    }
341
```

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
