### PR TITLE
chore: fix possible null pointer dereference found by Coverity

### DIFF
--- a/src/ngx_http_lua_timer.c
+++ b/src/ngx_http_lua_timer.c
@@ -733,16 +733,19 @@ ngx_http_lua_log_timer_error(ngx_log_t *log, u_char *buf, size_t len)
     len -= p - buf;
     buf = p;
 
-    if (c->addr_text.len) {
-        p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
-        len -= p - buf;
-        buf = p;
-    }
+    if (c != NULL) {
+        if (c->addr_text.len) {
+            p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
+            len -= p - buf;
+            buf = p;
+        }
 
-    if (c && c->listening && c->listening->addr_text.len) {
-        p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
-        /* len -= p - buf; */
-        buf = p;
+        if (c->listening && c->listening->addr_text.len) {
+            p = ngx_snprintf(buf, len, ", server: %V", 
+                             &c->listening->addr_text);
+            /* len -= p - buf; */
+            buf = p;
+        }
     }
 
     return buf;


### PR DESCRIPTION
```
734    buf = p;
735
   deref_ptr: Directly dereferencing pointer c.
736    if (c->addr_text.len) {
737        p = ngx_snprintf(buf, len, ", client: %V", &c->addr_text);
738        len -= p - buf;
739        buf = p;
740    }
741
   CID 149839 (#1 of 1): Dereference before null check (REVERSE_INULL)check_after_deref: Null-checking c suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
742    if (c && c->listening && c->listening->addr_text.len) {
743        p = ngx_snprintf(buf, len, ", server: %V", &c->listening->addr_text);
744        /* len -= p - buf; */
745        buf = p;
746    }
```

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
