### PR TITLE
Add nginx worker thread api to ngx_lua

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3155,9 +3155,10 @@ The directive is supported when using OpenSSL 1.0.2 or higher and nginx 1.19.4 o
 
 Several `lua_ssl_conf_command` directives can be specified on the same level:
 
-```
-lua_ssl_conf_command Options PrioritizeChaCha;
-lua_ssl_conf_command Ciphersuites TLS_CHACHA20_POLY1305_SHA256;
+```nginx
+
+ lua_ssl_conf_command Options PrioritizeChaCha;
+ lua_ssl_conf_command Ciphersuites TLS_CHACHA20_POLY1305_SHA256;
 ```
 
 Configuration commands are applied after OpenResty own configuration for SSL, so they can be used to override anything set by OpenResty.
@@ -3165,6 +3166,8 @@ Configuration commands are applied after OpenResty own configuration for SSL, so
 Note though that configuring OpenSSL directly with `lua_ssl_conf_command` might result in a behaviour OpenResty does not expect, and should be done with care.
 
 This directive was first introduced in the `v0.10.21` release.
+
+
 
 [Back to TOC](#directives)
 
@@ -8993,7 +8996,7 @@ Note that no ngx_lua API can be used in the `function_name` function of the `mod
 
 The first argument `threadpool` specifies the Nginx thread pool name defined by [thread_pool](https://nginx.org/en/docs/ngx_core_module.html#thread_pool).
 
-The second argument `module_name` specifies the lua module name to execute in the worker thread, which would returns a lua table. The module must be inside the package path, e.g.
+The second argument `module_name` specifies the lua module name to execute in the worker thread, which would return a lua table. The module must be inside the package path, e.g.
 
 ```nginx
 
@@ -9008,15 +9011,15 @@ The type of `arg`s must be one of type below:
 * number
 * string
 * nil
-* table (the table may be recursive, and contains member of types above.)
+* table (the table may be recursive, and contains members of types above.)
 
 The `ok` is in boolean type, which indicate the C land error (failed to get thread from thread pool, pcall the module function failed, .etc). If `ok` is `false`, the `res1` is the error string.
 
 The return values (res1, ...) are returned by invocation of the module function. Normally, the `res1` should be in boolean type, so that the caller could inspect the error.
 
-This API is useful when you need to execute below types of tasks:
+This API is useful when you need to execute the below types of tasks:
 
-* CPU bound task, e.g. md5 calculation
+* CPU bound task, e.g. do md5 calculation
 * File I/O task
 * Call `os.execute()` or blocking C API via `ffi`
 * Call external Lua library not based on cosocket or nginx
@@ -9067,7 +9070,7 @@ Example1: do md5 caculation.
  return {md5=md5}
 ```
 
-Example2: write logs into log file.
+Example2: write logs into the log file.
 
 ```nginx
 

--- a/README.markdown
+++ b/README.markdown
@@ -9024,7 +9024,7 @@ This API is useful when you need to execute the below types of tasks:
 * Call `os.execute()` or blocking C API via `ffi`
 * Call external Lua library not based on cosocket or nginx
 
-Example1: do md5 caculation.
+Example1: do md5 calculation.
 
 ```nginx
 

--- a/README.markdown
+++ b/README.markdown
@@ -3334,7 +3334,12 @@ lua_worker_thread_vm_pool_size
 **context:** *http*
 
 Specifies the size limit of the Lua VM pool (default 100) that will be used in the [ngx.run_worker_thread](#ngxrun_worker_thread) API.
+
 Also, it is not allowed to create Lua VMs that exceeds the pool size limit.
+
+The lua vm in the vm pool is used to execute lua code in seperate thread.
+
+The pool is global and to avoid recreate and destroy lua vm for each request.
 
 [Back to TOC](#directives)
 
@@ -8974,7 +8979,7 @@ This API was first enabled in the `v0.6.0` release.
 ngx.run_worker_thread
 ---------------------
 
-**syntax:** *ok, res1, res2, ... = ngx.run_worker_thread(threadpool, module_name, func_name, arg, ...)*
+**syntax:** *ok, res1, res2, ... = ngx.run_worker_thread(threadpool, module_name, func_name, arg1, arg2, ...)*
 
 **context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
@@ -8982,18 +8987,11 @@ ngx.run_worker_thread
 
 **This API is available only for Linux.**
 
-Wrap the [nginx worker thread](http://nginx.org/en/docs/dev/development_guide.html#threads) to execute lua function. The caller coroutine would block until the function returns.
+Wrap the [nginx worker thread](http://nginx.org/en/docs/dev/development_guide.html#threads) to execute lua function. The caller coroutine would yield until the function returns.
 
 Note that no ngx_lua API can be used in the `function_name` function of the `module` module since it is invoked in a separate thread.
 
-The first argument `threadpool` specifies the Nginx thread pool name defined by `thread_pool`.
-
-For example:
-
-```nginx
-
- thread_pool testpool threads=100;
-```
+The first argument `threadpool` specifies the Nginx thread pool name defined by [thread_pool](https://nginx.org/en/docs/ngx_core_module.html#thread_pool).
 
 The second argument `module_name` specifies the lua module name to execute in the worker thread, which would returns a lua table. The module must be inside the package path, e.g.
 

--- a/config
+++ b/config
@@ -296,6 +296,7 @@ HTTP_LUA_SRCS=" \
             $ngx_addon_dir/src/ngx_http_lua_log_ringbuf.c \
             $ngx_addon_dir/src/ngx_http_lua_input_filters.c \
             $ngx_addon_dir/src/ngx_http_lua_pipe.c \
+            $ngx_addon_dir/src/ngx_http_lua_worker_thread.c \
             "
 
 HTTP_LUA_DEPS=" \
@@ -355,6 +356,7 @@ HTTP_LUA_DEPS=" \
             $ngx_addon_dir/src/ngx_http_lua_log_ringbuf.h \
             $ngx_addon_dir/src/ngx_http_lua_input_filters.h \
             $ngx_addon_dir/src/ngx_http_lua_pipe.h \
+            $ngx_addon_dir/src/ngx_http_lua_worker_thread.h \
             "
 
 # ----------------------------------------

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -7669,6 +7669,128 @@ This API was first usable in the context of [[#init_by_lua|init_by_lua*]] since 
 
 This API was first enabled in the <code>v0.6.0</code> release.
 
+== ngx.run_worker_thread ==
+
+'''syntax:''' ''ok, res1, res2, ... = ngx.run_worker_thread(threadpool, module, arg, ...)''
+
+'''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*''
+
+'''This feature is still experimental and the API may change in the future without notice.'''
+
+'''This API is available only for Linux.'''
+
+Wrap the [http://nginx.org/en/docs/dev/development_guide.html#threads nginx worker thread] to execute lua function. The caller coroutine would block until the function returns.
+
+Note that the <code>module</code> function can not use any ngx_lua api, because the function is invoked in separate thread.
+
+The first argument <code>threadpool</code>, specifies the nginx thread pool name.
+
+For example:
+
+<geshi lang="nginx">
+thread_pool testpool threads=100;
+</geshi>
+
+The second argument <code>module</code>, specifies the lua module name to execute in the worker thread, which would returns a lua function when loaded. The module must be inside the package path, e.g.
+
+<geshi lang="nginx">
+lua_package_path '/opt/openresty/?.lua;;';
+</geshi>
+
+The type of arg must be one of type below:
+
+* boolean
+* number
+* string
+* nil
+* table (the table may be recursive, and contains member of types above.)
+
+The <code>ok</code> is in boolean type, which indicate the C land error (failed to get thread from thread pool, pcall the module function failed, .etc). If <code>ok</code> is <code>false</code>, the <code>res1</code> is the error string.
+
+The return values (res1, ...) are returned by invocation of the module function. Normally, the <code>res1</code> should be in boolean type, so that the caller could inspect the error.
+
+This API is useful when you need to execute below types of tasks:
+
+* CPU bound task, e.g. md5 calculation
+* File I/O task
+* Call <code>os.execute()</code> or blocking C API via <code>ffi</code>
+* Call external Lua library not based on cosocket or nginx
+
+Example1: do md5 caculation.
+
+<geshi lang="nginx">
+location /calc_md5 {
+    default_type 'text/plain';
+
+    content_by_lua_block {
+        local ok, ret, md5_or_err = ngx.run_worker_thread("testpool", "calc_md5", ngx.var.arg_str)
+        if not ok then
+            ngx.say(ret)
+            return
+        end
+        if not ret then
+            ngx.say(md5_or_err)
+            return
+        end
+        ngx.say(md5_or_err)
+    }
+}
+</geshi>
+
+<code>calc_md5.lua</code>
+
+<geshi lang="lua">
+local resty_md5 = require "resty.md5"
+local resty_str = require "resty.string"
+
+return function(str)
+    local md5 = resty_md5:new()
+    if not md5 then
+        return false, "md5 new error"
+    end
+
+    local ok = md5:update(str)
+    if not ok then
+        return false, "md5 update error"
+    end
+
+    local digest = md5:final()
+    return true, resty_str.to_hex(digest)
+end
+</geshi>
+
+Example2: write logs into log file.
+
+<geshi lang="nginx">
+location /write_log_file {
+    default_type 'text/plain';
+
+    content_by_lua_block {
+        local ok, err = ngx.run_worker_thread("testpool", "write_log_file", ngx.var.arg_str)
+        if not ok then
+            ngx.say(ok, " : ", err)
+            return
+        end
+        ngx.say(ok)
+    }
+}
+</geshi>
+
+<code>write_log_file.lua</code>
+
+<geshi lang="lua">
+return function(str)
+    local file, err = io.open("/tmp/tmp.log", "a")
+    if not file then
+        return false, err
+    end
+    file:write(str)
+    file:flush()
+    file:close()
+    return true
+end
+</geshi>
+
 = Obsolete Sections =
 
 This section is just holding obsolete documentation sections that have been either renamed or removed so that existing links over the web are still valid.

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -7701,7 +7701,7 @@ Note that no ngx_lua API can be used in the `function_name` function of the `mod
 
 The first argument `threadpool` specifies the Nginx thread pool name defined by [thread_pool](https://nginx.org/en/docs/ngx_core_module.html#thread_pool).
 
-The second argument <code>module_name</code> specifies the lua module name to execute in the worker thread, which would returns a lua table. The module must be inside the package path, e.g.
+The second argument <code>module_name</code> specifies the lua module name to execute in the worker thread, which would return a lua table. The module must be inside the package path, e.g.
 
 <geshi lang="nginx">
 lua_package_path '/opt/openresty/?.lua;;';
@@ -7715,15 +7715,15 @@ The type of <code>arg</code>s must be one of type below:
 * number
 * string
 * nil
-* table (the table may be recursive, and contains member of types above.)
+* table (the table may be recursive, and contains members of types above.)
 
 The <code>ok</code> is in boolean type, which indicate the C land error (failed to get thread from thread pool, pcall the module function failed, .etc). If <code>ok</code> is <code>false</code>, the <code>res1</code> is the error string.
 
 The return values (res1, ...) are returned by invocation of the module function. Normally, the <code>res1</code> should be in boolean type, so that the caller could inspect the error.
 
-This API is useful when you need to execute below types of tasks:
+This API is useful when you need to execute the below types of tasks:
 
-* CPU bound task, e.g. md5 calculation
+* CPU bound task, e.g. do md5 calculation
 * File I/O task
 * Call <code>os.execute()</code> or blocking C API via <code>ffi</code>
 * Call external Lua library not based on cosocket or nginx
@@ -7772,7 +7772,7 @@ end
 return {md5=md5}
 </geshi>
 
-Example2: write logs into log file.
+Example2: write logs into the log file.
 
 <geshi lang="nginx">
 location /write_log_file {

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -2830,9 +2830,9 @@ This directive was first introduced in the <code>v0.10.14</code> release.
 
 '''context:''' ''http''
 
-Specifies the size limit of lua worker thread vm pool.
+Specifies the size limit of the Lua VM pool (default 100) that will be used in the [ngx.run_worker_thread](#ngxrun_worker_thread) API.
 
-Default to 100 lua vm.
+Also, it is not allowed to create Lua VMs that exceeds the pool size limit.
 
 The lua vm in the vm pool is used to execute lua code in seperate thread.
 
@@ -7687,7 +7687,7 @@ This API was first enabled in the <code>v0.6.0</code> release.
 
 == ngx.run_worker_thread ==
 
-'''syntax:''' ''ok, res1, res2, ... = ngx.run_worker_thread(threadpool, module_name, func_name, arg, ...)''
+'''syntax:''' ''ok, res1, res2, ... = ngx.run_worker_thread(threadpool, module_name, func_name, arg1, arg2, ...)''
 
 '''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*''
 
@@ -7695,17 +7695,11 @@ This API was first enabled in the <code>v0.6.0</code> release.
 
 '''This API is available only for Linux.'''
 
-Wrap the [http://nginx.org/en/docs/dev/development_guide.html#threads nginx worker thread] to execute lua function. The caller coroutine would block until the function returns.
+Wrap the [http://nginx.org/en/docs/dev/development_guide.html#threads nginx worker thread] to execute lua function. The caller coroutine would yield until the function returns.
 
-Note that the <code>module</code> function can not use any ngx_lua api, because the function is invoked in separate thread.
+Note that no ngx_lua API can be used in the `function_name` function of the `module` module since it is invoked in a separate thread.
 
-The first argument <code>threadpool</code> specifies the Nginx thread pool name defined by `thread_pool`.
-
-For example:
-
-<geshi lang="nginx">
-thread_pool testpool threads=100;
-</geshi>
+The first argument `threadpool` specifies the Nginx thread pool name defined by [thread_pool](https://nginx.org/en/docs/ngx_core_module.html#thread_pool).
 
 The second argument <code>module_name</code> specifies the lua module name to execute in the worker thread, which would returns a lua table. The module must be inside the package path, e.g.
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -2822,6 +2822,22 @@ This allows Lua I/O primitives to not be interrupted by Nginx's handling of vari
 
 This directive was first introduced in the <code>v0.10.14</code> release.
 
+== lua_worker_thread_vm_pool_size ==
+
+'''syntax:''' ''lua_worker_thread_vm_pool_size <size>''
+
+'''default:''' ''lua_worker_thread_vm_pool_size 100''
+
+'''context:''' ''http''
+
+Specifies the size limit of lua worker thread vm pool.
+
+Default to 100 lua vm.
+
+The lua vm in the vm pool is used to execute lua code in seperate thread.
+
+The pool is global and to avoid recreate and destroy lua vm for each request.
+
 = Nginx API for Lua =
 
 <!-- inline-toc -->
@@ -7671,7 +7687,7 @@ This API was first enabled in the <code>v0.6.0</code> release.
 
 == ngx.run_worker_thread ==
 
-'''syntax:''' ''ok, res1, res2, ... = ngx.run_worker_thread(threadpool, module, arg, ...)''
+'''syntax:''' ''ok, res1, res2, ... = ngx.run_worker_thread(threadpool, module_name, func_name, arg, ...)''
 
 '''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*''
 
@@ -7683,7 +7699,7 @@ Wrap the [http://nginx.org/en/docs/dev/development_guide.html#threads nginx work
 
 Note that the <code>module</code> function can not use any ngx_lua api, because the function is invoked in separate thread.
 
-The first argument <code>threadpool</code>, specifies the nginx thread pool name.
+The first argument <code>threadpool</code> specifies the Nginx thread pool name defined by `thread_pool`.
 
 For example:
 
@@ -7691,13 +7707,15 @@ For example:
 thread_pool testpool threads=100;
 </geshi>
 
-The second argument <code>module</code>, specifies the lua module name to execute in the worker thread, which would returns a lua function when loaded. The module must be inside the package path, e.g.
+The second argument <code>module_name</code> specifies the lua module name to execute in the worker thread, which would returns a lua table. The module must be inside the package path, e.g.
 
 <geshi lang="nginx">
 lua_package_path '/opt/openresty/?.lua;;';
 </geshi>
 
-The type of arg must be one of type below:
+The third argument <code>func_name</code> specifies the function field in the module table as the second argument.
+
+The type of <code>arg</code>s must be one of type below:
 
 * boolean
 * number
@@ -7723,7 +7741,7 @@ location /calc_md5 {
     default_type 'text/plain';
 
     content_by_lua_block {
-        local ok, ret, md5_or_err = ngx.run_worker_thread("testpool", "calc_md5", ngx.var.arg_str)
+        local ok, ret, md5_or_err = ngx.run_worker_thread("testpool", "calc_md5", "md5", ngx.var.arg_str)
         if not ok then
             ngx.say(ret)
             return
@@ -7743,7 +7761,7 @@ location /calc_md5 {
 local resty_md5 = require "resty.md5"
 local resty_str = require "resty.string"
 
-return function(str)
+local function md5(str)
     local md5 = resty_md5:new()
     if not md5 then
         return false, "md5 new error"
@@ -7757,6 +7775,7 @@ return function(str)
     local digest = md5:final()
     return true, resty_str.to_hex(digest)
 end
+return {md5=md5}
 </geshi>
 
 Example2: write logs into log file.
@@ -7766,7 +7785,7 @@ location /write_log_file {
     default_type 'text/plain';
 
     content_by_lua_block {
-        local ok, err = ngx.run_worker_thread("testpool", "write_log_file", ngx.var.arg_str)
+        local ok, err = ngx.run_worker_thread("testpool", "write_log_file", "log", ngx.var.arg_str)
         if not ok then
             ngx.say(ok, " : ", err)
             return
@@ -7779,7 +7798,7 @@ location /write_log_file {
 <code>write_log_file.lua</code>
 
 <geshi lang="lua">
-return function(str)
+local function log(str)
     local file, err = io.open("/tmp/tmp.log", "a")
     if not file then
         return false, err
@@ -7789,6 +7808,7 @@ return function(str)
     file:close()
     return true
 end
+return {log=log}
 </geshi>
 
 = Obsolete Sections =

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -7728,7 +7728,7 @@ This API is useful when you need to execute the below types of tasks:
 * Call <code>os.execute()</code> or blocking C API via <code>ffi</code>
 * Call external Lua library not based on cosocket or nginx
 
-Example1: do md5 caculation.
+Example1: do md5 calculation.
 
 <geshi lang="nginx">
 location /calc_md5 {

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -288,6 +288,8 @@ struct ngx_http_lua_main_conf_s {
     ngx_queue_t          free_lua_threads;  /* of ngx_http_lua_thread_ref_t */
     ngx_queue_t          cached_lua_threads;  /* of ngx_http_lua_thread_ref_t */
 
+    ngx_uint_t           worker_thread_vm_pool_size;
+
     unsigned             requires_header_filter:1;
     unsigned             requires_body_filter:1;
     unsigned             requires_capture_filter:1;

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -646,6 +646,13 @@ static ngx_command_t ngx_http_lua_cmds[] = {
       0,
       NULL },
 
+    { ngx_string("lua_worker_thread_vm_pool_size"),
+      NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_HTTP_MAIN_CONF_OFFSET,
+      offsetof(ngx_http_lua_main_conf_t, worker_thread_vm_pool_size),
+      NULL },
+
     ngx_null_command
 };
 
@@ -975,6 +982,8 @@ ngx_http_lua_create_main_conf(ngx_conf_t *cf)
         return NULL;
     }
 
+    lmcf->worker_thread_vm_pool_size = NGX_CONF_UNSET;
+
     dd("nginx Lua module main config structure initialized!");
 
     return lmcf;
@@ -1057,6 +1066,10 @@ ngx_http_lua_init_main_conf(ngx_conf_t *cf, void *conf)
         }
     }
 #endif
+
+    if (lmcf->worker_thread_vm_pool_size == NGX_CONF_UNSET_UINT) {
+        lmcf->worker_thread_vm_pool_size = 100;
+    }
 
     return NGX_CONF_OK;
 }

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -46,6 +46,9 @@
 #include "ngx_http_lua_ssl_certby.h"
 #include "ngx_http_lua_ssl.h"
 #include "ngx_http_lua_log_ringbuf.h"
+#if (NGX_THREADS)
+#include "ngx_http_lua_worker_thread.h"
+#endif
 
 
 #if 1
@@ -842,6 +845,9 @@ ngx_http_lua_inject_ngx_api(lua_State *L, ngx_http_lua_main_conf_t *lmcf,
     ngx_http_lua_inject_uthread_api(log, L);
     ngx_http_lua_inject_timer_api(L);
     ngx_http_lua_inject_config_api(L);
+#if (NGX_THREADS)
+    ngx_http_lua_inject_worker_thread_api(log, L);
+#endif
 
     lua_getglobal(L, "package"); /* ngx package */
     lua_getfield(L, -1, "loaded"); /* ngx package loaded */

--- a/src/ngx_http_lua_worker_thread.c
+++ b/src/ngx_http_lua_worker_thread.c
@@ -1,5 +1,8 @@
 /*
  * Copyright (C) Yichun Zhang (agentzh)
+ * Copyright (C) Jinhua Luo (kingluo)
+ * I hereby assign copyright in this code to the lua-nginx-module project,
+ * to be licensed under the same terms as the rest of the code.
  */
 
 

--- a/src/ngx_http_lua_worker_thread.c
+++ b/src/ngx_http_lua_worker_thread.c
@@ -25,7 +25,6 @@
 
 typedef struct ngx_http_lua_task_ctx_s {
     lua_State                        *vm;
-    ngx_thread_mutex_t                mutex;
     struct ngx_http_lua_task_ctx_s   *next;
 } ngx_http_lua_task_ctx_t;
 
@@ -33,20 +32,47 @@ typedef struct ngx_http_lua_task_ctx_s {
 typedef struct {
     ngx_http_lua_task_ctx_t *ctx;
     ngx_http_lua_co_ctx_t   *wait_co_ctx;
-    ngx_http_cleanup_pt      cleanup;
-    void                    *cleanup_data;
     int                      n_args;
     int                      rc;
     int                      is_abort;
-} ngx_http_lua_my_thread_ctx_t;
+} ngx_http_lua_worker_thread_ctx_t;
 
 
 static  ngx_http_lua_task_ctx_t   dummy_ctx;
 static  ngx_http_lua_task_ctx_t  *ctxpool = &dummy_ctx;
+static  ngx_uint_t                worker_thread_vm_count;
+
+
+/*
+ * re-implement ngx_thread_task_alloc to direct alloc instead of pool
+ * alloc because the request may exit before worker thread callback
+ */
+static ngx_thread_task_t *
+ngx_http_lua_thread_task_alloc(size_t size)
+{
+    ngx_thread_task_t  *task;
+
+    task = calloc(sizeof(ngx_thread_task_t) + size, 1);
+    if (task == NULL) {
+        return NULL;
+    }
+
+    task->ctx = task + 1;
+
+    return task;
+}
+
+
+static void
+ngx_http_lua_thread_task_free(void *ctx)
+{
+    ngx_thread_task_t *task = ctx;
+    free(task - 1);
+}
 
 
 static ngx_http_lua_task_ctx_t *
-ngx_http_lua_get_task_ctx(lua_State *L)
+ngx_http_lua_get_task_ctx(lua_State *L, ngx_http_request_t *r)
 {
     ngx_http_lua_task_ctx_t *ctx = NULL;
 
@@ -56,34 +82,41 @@ ngx_http_lua_get_task_ctx(lua_State *L)
     const char      *cpath;
     lua_State       *vm;
 
+    ngx_http_lua_main_conf_t    *lmcf;
+
+    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
+
+    if (worker_thread_vm_count >= lmcf->worker_thread_vm_pool_size) {
+        return NULL;
+    }
+
+    worker_thread_vm_count++;
+
     if (ctxpool->next == NULL) {
         ctx = calloc(sizeof(ngx_http_lua_task_ctx_t), 1);
         vm = luaL_newstate();
         ctx->vm = vm;
         luaL_openlibs(ctx->vm);
 
+        /* copy package.path and package.cpath */
         lua_getglobal(L, "package");
-        lua_getglobal(vm, "package");
-
-        /* copy package.path */
         lua_getfield(L, -1, "path");
         path = lua_tolstring(L, -1, &path_len);
+        lua_getfield(L, -2, "cpath");
+        cpath = lua_tolstring(L, -1, &cpath_len);
+
+        lua_getglobal(vm, "package");
         lua_pushlstring(vm, path, path_len);
         lua_setfield(vm, -2, "path");
-        lua_pop(L, 1);
-
-        /* copy package.cpath */
-        lua_getfield(L, -1, "cpath");
-        cpath = lua_tolstring(L, -1, &cpath_len);
         lua_pushlstring(vm, cpath, cpath_len);
         lua_setfield(vm, -2, "cpath");
-        lua_pop(L, 1);
 
-        /* remove the "package" table */
+        /* pop path and cpath from L */
+        lua_pop(L, 2);
+
+        /* pop the "package" table */
         lua_pop(L, 1);
         lua_pop(vm, 1);
-
-        ngx_thread_mutex_create(&ctx->mutex, ngx_cycle->log);
 
     } else {
         ctx = ctxpool->next;
@@ -95,23 +128,27 @@ ngx_http_lua_get_task_ctx(lua_State *L)
 
 
 static void
-ngx_http_lua_put_task_ctx(ngx_http_lua_task_ctx_t *ctx)
+ngx_http_lua_free_task_ctx(ngx_http_lua_task_ctx_t *ctx)
 {
     ctx->next = ctxpool->next;
     ctxpool->next = ctx;
     /*  clean Lua stack */
     lua_settop(ctx->vm, 0);
+
+    worker_thread_vm_count--;
 }
 
 
 static int
 ngx_http_lua_xcopy(lua_State *from, lua_State *to, int idx,
-                         const int allow_nil)
+                   const int allow_nil)
 {
     size_t           len = 0;
     const char      *str;
+    int              typ;
 
-    switch (lua_type(from, idx)) {
+    typ = lua_type(from, idx);
+    switch (typ) {
     case LUA_TBOOLEAN:
         lua_pushboolean(to, lua_toboolean(from, idx));
         return LUA_TBOOLEAN;
@@ -138,7 +175,7 @@ ngx_http_lua_xcopy(lua_State *from, lua_State *to, int idx,
 
         lua_pushnil(from);
 
-        while (lua_next(from, idx)) {
+        while (lua_next(from, idx) != 0) {
             if (ngx_http_lua_xcopy(from, to, -2, 0) != LUA_TNONE) {
                 if (ngx_http_lua_xcopy(from, to, -1, 0) != LUA_TNONE) {
                     lua_rawset(to, -3);
@@ -167,17 +204,17 @@ ngx_http_lua_xcopy(lua_State *from, lua_State *to, int idx,
      * LUA_TTHREAD
      */
     default:
-        return LUA_TNONE;
+        return luaL_error(from, "unsupported type to copy, type=%d", typ);
     }
 }
 
 
 /* executed in a separate thread */
 static void
-ngx_http_lua_my_thread_func(void *data, ngx_log_t *log)
+ngx_http_lua_worker_thread_handler(void *data, ngx_log_t *log)
 {
-    ngx_http_lua_my_thread_ctx_t     *ctx = data;
-    lua_State                        *vm = ctx->ctx->vm;
+    ngx_http_lua_worker_thread_ctx_t     *ctx = data;
+    lua_State                            *vm = ctx->ctx->vm;
 
     ctx->rc = lua_pcall(vm, ctx->n_args, LUA_MULTRET, 0);
 }
@@ -185,43 +222,35 @@ ngx_http_lua_my_thread_func(void *data, ngx_log_t *log)
 
 /* executed in nginx event loop */
 static void
-ngx_http_lua_my_thread_completion(ngx_event_t *ev)
+ngx_http_lua_worker_thread_event_handler(ngx_event_t *ev)
 {
-    ngx_http_lua_my_thread_ctx_t     *myctx;
-    int                               is_abort;
+    ngx_http_lua_worker_thread_ctx_t *worker_thread_ctx;
     lua_State                        *L;
+    ngx_http_request_t               *r;
+    ngx_connection_t                 *c;
+    int                               nresults;
+    size_t                            len;
+    const char                       *str;
+    int                               i;
+    int                               rc;
+    ngx_http_lua_ctx_t               *ctx;
+    lua_State                        *vm;
 
-    ngx_http_request_t      *r;
-    ngx_connection_t        *c;
+    worker_thread_ctx = ev->data;
 
-    int              nresults;
-    size_t           len;
-    const char      *str;
-    int              i;
-
-    int              rc;
-
-    ngx_http_lua_ctx_t *ctx;
-
-    lua_State *vm;
-
-    myctx = ev->data;
-
-    ngx_thread_mutex_lock(&myctx->ctx->mutex, ngx_cycle->log);
-    is_abort = myctx->is_abort;
-    ngx_thread_mutex_unlock(&myctx->ctx->mutex, ngx_cycle->log);
-
-    if (is_abort) {
-        ngx_http_lua_put_task_ctx(myctx->ctx);
+    if (worker_thread_ctx->is_abort) {
+        ngx_http_lua_free_task_ctx(worker_thread_ctx->ctx);
+        ngx_http_lua_thread_task_free(worker_thread_ctx);
         return;
     }
 
-    L = myctx->wait_co_ctx->co;
+    L = worker_thread_ctx->wait_co_ctx->co;
 
     r = ngx_http_lua_get_req(L);
 
     if (r == NULL) {
-        ngx_http_lua_put_task_ctx(myctx->ctx);
+        ngx_http_lua_free_task_ctx(worker_thread_ctx->ctx);
+        ngx_http_lua_thread_task_free(worker_thread_ctx);
         return;
     }
 
@@ -230,13 +259,14 @@ ngx_http_lua_my_thread_completion(ngx_event_t *ev)
     ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
 
     if (ctx == NULL) {
-        ngx_http_lua_put_task_ctx(myctx->ctx);
+        ngx_http_lua_free_task_ctx(worker_thread_ctx->ctx);
+        ngx_http_lua_thread_task_free(worker_thread_ctx);
         return;
     }
 
-    vm = myctx->ctx->vm;
+    vm = worker_thread_ctx->ctx->vm;
 
-    if (myctx->rc != 0) {
+    if (worker_thread_ctx->rc != 0) {
         str = lua_tolstring(vm, 1, &len);
         lua_pushboolean(L, 0);
         lua_pushlstring(L, str, len);
@@ -252,13 +282,12 @@ ngx_http_lua_my_thread_completion(ngx_event_t *ev)
         nresults += 1;
     }
 
-    ngx_http_lua_put_task_ctx(myctx->ctx);
+    ngx_http_lua_free_task_ctx(worker_thread_ctx->ctx);
+    ngx_http_lua_thread_task_free(worker_thread_ctx);
 
     /* resume the caller coroutine */
 
-    myctx->wait_co_ctx->cleanup = myctx->cleanup;
-    myctx->wait_co_ctx->data = myctx->cleanup_data;
-    ctx->cur_co_ctx = myctx->wait_co_ctx;
+    ctx->cur_co_ctx = worker_thread_ctx->wait_co_ctx;
     vm = ngx_http_lua_get_lua_vm(r, ctx);
 
     rc = ngx_http_lua_run_thread(vm, r, ctx, nresults);
@@ -289,42 +318,31 @@ ngx_http_lua_my_thread_completion(ngx_event_t *ev)
 static void
 ngx_http_lua_worker_thread_cleanup(void *data)
 {
-    ngx_http_lua_my_thread_ctx_t *ctx = data;
-
-    ngx_thread_mutex_lock(&ctx->ctx->mutex, ngx_cycle->log);
-    ctx->is_abort = 1;
-    ngx_thread_mutex_unlock(&ctx->ctx->mutex, ngx_cycle->log);
-
-    if (ctx->cleanup) {
-        (ctx->cleanup)(ctx->cleanup_data);
-    }
+    ngx_http_lua_co_ctx_t *ctx = data;
+    ngx_http_lua_worker_thread_ctx_t *worker_thread_ctx = ctx->data;
+    worker_thread_ctx->is_abort = 1;
 }
 
 
+/* It's not easy to use pure ffi here, using the Lua C API for now. */
 static int
 ngx_http_lua_run_worker_thread(lua_State *L)
 {
-    ngx_http_request_t      *r;
-    ngx_http_lua_ctx_t      *ctx;
-    int                      n_args;
-
-    ngx_str_t                thread_pool_name;
-    ngx_thread_pool_t       *thread_pool;
-
-    ngx_http_lua_task_ctx_t *tctx;
-    lua_State               *vm;
-
-    size_t                   len;
-    const char              *mod_name;
-    int                      rc;
-
-    size_t                   len2;
-    const char              *err;
-
-    int                      i;
-
-    ngx_thread_task_t               *task;
-    ngx_http_lua_my_thread_ctx_t    *myctx;
+    ngx_http_request_t                 *r;
+    ngx_http_lua_ctx_t                 *ctx;
+    int                                 n_args;
+    ngx_str_t                           thread_pool_name;
+    ngx_thread_pool_t                  *thread_pool;
+    ngx_http_lua_task_ctx_t            *tctx;
+    lua_State                          *vm;
+    size_t                              len;
+    const char                         *mod_name;
+    const char                         *func_name;
+    int                                 rc;
+    const char                         *err;
+    int                                 i;
+    ngx_thread_task_t                  *task;
+    ngx_http_lua_worker_thread_ctx_t   *worker_thread_ctx;
 
     r = ngx_http_lua_get_req(L);
 
@@ -338,11 +356,13 @@ ngx_http_lua_run_worker_thread(lua_State *L)
         return luaL_error(L, "no ctx found");
     }
 
+    ngx_http_lua_check_context(L, ctx, NGX_HTTP_LUA_CONTEXT_YIELDABLE);
+
     n_args = lua_gettop(L);
 
-    if (n_args < 2) {
+    if (n_args < 3) {
         lua_pushboolean(L, 0);
-        lua_pushstring(L, "expecting at least 2 arguments");
+        lua_pushstring(L, "expecting at least 3 arguments");
         return 2;
     }
 
@@ -357,65 +377,86 @@ ngx_http_lua_run_worker_thread(lua_State *L)
     }
 
     /* get vm */
-    tctx = ngx_http_lua_get_task_ctx(L);
+    tctx = ngx_http_lua_get_task_ctx(L, r);
+    if (tctx == NULL) {
+        lua_pushboolean(L, 0);
+        lua_pushstring(L, "no available Lua vm");
+        return 2;
+    }
     vm = tctx->vm;
 
     /* push function from module require */
     mod_name = lua_tolstring(L, 2, &len);
+    func_name = lua_tolstring(L, 3, NULL);
     lua_getfield(vm, LUA_GLOBALSINDEX, "require");
     lua_pushlstring(vm, mod_name, len);
     rc = lua_pcall(vm, 1, 1, 0);
 
     if (rc != 0) {
-        err = lua_tolstring(vm, 1, &len2);
+        err = lua_tolstring(vm, 1, &len);
         lua_pushboolean(L, 0);
-        lua_pushlstring(L, err, len2);
-        ngx_http_lua_put_task_ctx(tctx);
+        lua_pushlstring(L, err, len);
+        ngx_http_lua_free_task_ctx(tctx);
         return 2;
     }
 
+    if (!lua_istable(vm, -1)) {
+        lua_pushboolean(L, 0);
+        lua_pushstring(L, "invalid lua module");
+        ngx_http_lua_free_task_ctx(tctx);
+        return 2;
+    }
+
+    lua_getfield(vm, -1, func_name);
+    if (!lua_isfunction(vm, -1)) {
+        lua_pushboolean(L, 0);
+        lua_pushstring(L, "invalid function");
+        ngx_http_lua_free_task_ctx(tctx);
+        return 2;
+    }
+
+    /* remove the table returned by require */
+    lua_remove(vm, 1);
+
     /* copying passed arguments */
-    for (i = 3; i <= n_args; i++) {
+    for (i = 4; i <= n_args; i++) {
         if (ngx_http_lua_xcopy(L, vm, i, 1) == LUA_TNONE) {
             lua_pushboolean(L, 0);
             lua_pushstring(L, "unsupported argument type");
-            ngx_http_lua_put_task_ctx(tctx);
+            ngx_http_lua_free_task_ctx(tctx);
             return 2;
         }
     }
 
     /* post task */
-    task = ngx_thread_task_alloc(r->pool,
-                                 sizeof(ngx_http_lua_my_thread_ctx_t));
+    task = ngx_http_lua_thread_task_alloc(
+        sizeof(ngx_http_lua_worker_thread_ctx_t));
 
     if (task == NULL) {
-        ngx_http_lua_put_task_ctx(tctx);
+        ngx_http_lua_free_task_ctx(tctx);
         lua_pushboolean(L, 0);
         lua_pushstring(L, "ngx_thread_task_alloc failed");
         return 2;
     }
 
-    myctx = task->ctx;
+    worker_thread_ctx = task->ctx;
 
-    myctx->ctx = tctx;
-    myctx->wait_co_ctx = ctx->cur_co_ctx;
-
-    myctx->cleanup = ctx->cur_co_ctx->cleanup;
-    myctx->cleanup_data = ctx->cur_co_ctx->data;
+    worker_thread_ctx->ctx = tctx;
+    worker_thread_ctx->wait_co_ctx = ctx->cur_co_ctx;
 
     ctx->cur_co_ctx->cleanup = ngx_http_lua_worker_thread_cleanup;
-    ctx->cur_co_ctx->data = myctx;
+    ctx->cur_co_ctx->data = worker_thread_ctx;
 
-    myctx->n_args = n_args - 2;
-    myctx->rc = 0;
-    myctx->is_abort = 0;
+    worker_thread_ctx->n_args = n_args - 3;
+    worker_thread_ctx->rc = 0;
+    worker_thread_ctx->is_abort = 0;
 
-    task->handler = ngx_http_lua_my_thread_func;
-    task->event.handler = ngx_http_lua_my_thread_completion;
-    task->event.data = myctx;
+    task->handler = ngx_http_lua_worker_thread_handler;
+    task->event.handler = ngx_http_lua_worker_thread_event_handler;
+    task->event.data = worker_thread_ctx;
 
     if (ngx_thread_task_post(thread_pool, task) != NGX_OK) {
-        ngx_http_lua_put_task_ctx(tctx);
+        ngx_http_lua_free_task_ctx(tctx);
         lua_pushboolean(L, 0);
         lua_pushstring(L, "ngx_thread_task_post failed");
         return 2;

--- a/src/ngx_http_lua_worker_thread.c
+++ b/src/ngx_http_lua_worker_thread.c
@@ -1,0 +1,434 @@
+/*
+ * Copyright (C) Yichun Zhang (agentzh)
+ */
+
+
+#ifndef DDEBUG
+#define DDEBUG 0
+#endif
+#include "ddebug.h"
+
+
+#include "ngx_http_lua_worker_thread.h"
+#include "ngx_http_lua_util.h"
+
+
+#if (NGX_THREADS)
+
+
+#include <ngx_thread.h>
+#include <ngx_thread_pool.h>
+
+
+typedef struct ngx_http_lua_task_ctx_s {
+    lua_State                        *vm;
+    ngx_thread_mutex_t                mutex;
+    struct ngx_http_lua_task_ctx_s   *next;
+} ngx_http_lua_task_ctx_t;
+
+
+typedef struct {
+    ngx_http_lua_task_ctx_t *ctx;
+    ngx_http_lua_co_ctx_t   *wait_co_ctx;
+    ngx_http_cleanup_pt      cleanup;
+    void                    *cleanup_data;
+    int                      n_args;
+    int                      rc;
+    int                      is_abort;
+} ngx_http_lua_my_thread_ctx_t;
+
+
+static  ngx_http_lua_task_ctx_t   dummy_ctx;
+static  ngx_http_lua_task_ctx_t  *ctxpool = &dummy_ctx;
+
+
+static ngx_http_lua_task_ctx_t *
+ngx_http_lua_get_task_ctx(lua_State *L)
+{
+    ngx_http_lua_task_ctx_t *ctx = NULL;
+
+    size_t           path_len;
+    const char      *path;
+    size_t           cpath_len;
+    const char      *cpath;
+    lua_State       *vm;
+
+    if (ctxpool->next == NULL) {
+        ctx = calloc(sizeof(ngx_http_lua_task_ctx_t), 1);
+        vm = luaL_newstate();
+        ctx->vm = vm;
+        luaL_openlibs(ctx->vm);
+
+        lua_getglobal(L, "package");
+        lua_getglobal(vm, "package");
+
+        /* copy package.path */
+        lua_getfield(L, -1, "path");
+        path = lua_tolstring(L, -1, &path_len);
+        lua_pushlstring(vm, path, path_len);
+        lua_setfield(vm, -2, "path");
+        lua_pop(L, 1);
+
+        /* copy package.cpath */
+        lua_getfield(L, -1, "cpath");
+        cpath = lua_tolstring(L, -1, &cpath_len);
+        lua_pushlstring(vm, cpath, cpath_len);
+        lua_setfield(vm, -2, "cpath");
+        lua_pop(L, 1);
+
+        /* remove the "package" table */
+        lua_pop(L, 1);
+        lua_pop(vm, 1);
+
+        ngx_thread_mutex_create(&ctx->mutex, ngx_cycle->log);
+
+    } else {
+        ctx = ctxpool->next;
+        ctxpool->next = ctxpool->next->next;
+    }
+
+    return ctx;
+}
+
+
+static void
+ngx_http_lua_put_task_ctx(ngx_http_lua_task_ctx_t *ctx)
+{
+    ctx->next = ctxpool->next;
+    ctxpool->next = ctx;
+    /*  clean Lua stack */
+    lua_settop(ctx->vm, 0);
+}
+
+
+static int
+ngx_http_lua_xcopy(lua_State *from, lua_State *to, int idx,
+                         const int allow_nil)
+{
+    size_t           len = 0;
+    const char      *str;
+
+    switch (lua_type(from, idx)) {
+    case LUA_TBOOLEAN:
+        lua_pushboolean(to, lua_toboolean(from, idx));
+        return LUA_TBOOLEAN;
+
+    case LUA_TLIGHTUSERDATA:
+        lua_pushlightuserdata(to, lua_touserdata(from, idx));
+        return LUA_TLIGHTUSERDATA;
+
+    case LUA_TNUMBER:
+        lua_pushnumber(to, lua_tonumber(from, idx));
+        return LUA_TNUMBER;
+
+    case LUA_TSTRING:
+        str = lua_tolstring(from, idx, &len);
+        lua_pushlstring(to, str, len);
+        return LUA_TSTRING;
+
+    case LUA_TTABLE:
+        lua_newtable(to);
+        /* to positive number */
+        if (idx < 0) {
+            idx = lua_gettop(from) + idx + 1;
+        }
+
+        lua_pushnil(from);
+
+        while (lua_next(from, idx)) {
+            if (ngx_http_lua_xcopy(from, to, -2, 0) != LUA_TNONE) {
+                if (ngx_http_lua_xcopy(from, to, -1, 0) != LUA_TNONE) {
+                    lua_rawset(to, -3);
+
+                } else {
+                    lua_pop(to, 1);
+                }
+            }
+
+            lua_pop(from, 1);
+        }
+        return LUA_TTABLE;
+
+    case LUA_TNIL:
+        if (allow_nil) {
+            lua_pushnil(to);
+            return LUA_TNIL;
+        }
+        /* fall through */
+
+    /*
+     * ignore unsupported values:
+     * LUA_TNONE
+     * LUA_TFUNCTION
+     * LUA_TUSERDATA
+     * LUA_TTHREAD
+     */
+    default:
+        return LUA_TNONE;
+    }
+}
+
+
+/* executed in a separate thread */
+static void
+ngx_http_lua_my_thread_func(void *data, ngx_log_t *log)
+{
+    ngx_http_lua_my_thread_ctx_t     *ctx = data;
+    lua_State                        *vm = ctx->ctx->vm;
+
+    ctx->rc = lua_pcall(vm, ctx->n_args, LUA_MULTRET, 0);
+}
+
+
+/* executed in nginx event loop */
+static void
+ngx_http_lua_my_thread_completion(ngx_event_t *ev)
+{
+    ngx_http_lua_my_thread_ctx_t     *myctx;
+    int                               is_abort;
+    lua_State                        *L;
+
+    ngx_http_request_t      *r;
+    ngx_connection_t        *c;
+
+    int              nresults;
+    size_t           len;
+    const char      *str;
+    int              i;
+
+    int              rc;
+
+    ngx_http_lua_ctx_t *ctx;
+
+    lua_State *vm;
+
+    myctx = ev->data;
+
+    ngx_thread_mutex_lock(&myctx->ctx->mutex, ngx_cycle->log);
+    is_abort = myctx->is_abort;
+    ngx_thread_mutex_unlock(&myctx->ctx->mutex, ngx_cycle->log);
+
+    if (is_abort) {
+        ngx_http_lua_put_task_ctx(myctx->ctx);
+        return;
+    }
+
+    L = myctx->wait_co_ctx->co;
+
+    r = ngx_http_lua_get_req(L);
+
+    if (r == NULL) {
+        ngx_http_lua_put_task_ctx(myctx->ctx);
+        return;
+    }
+
+    c = r->connection;
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+
+    if (ctx == NULL) {
+        ngx_http_lua_put_task_ctx(myctx->ctx);
+        return;
+    }
+
+    vm = myctx->ctx->vm;
+
+    if (myctx->rc != 0) {
+        str = lua_tolstring(vm, 1, &len);
+        lua_pushboolean(L, 0);
+        lua_pushlstring(L, str, len);
+        nresults = 2;
+
+    } else {
+        /* copying return values */
+        lua_pushboolean(L, 1);
+        nresults = lua_gettop(vm);
+        for (i = 1; i <= nresults; i++) {
+            ngx_http_lua_xcopy(vm, L, i, 1);
+        }
+        nresults += 1;
+    }
+
+    ngx_http_lua_put_task_ctx(myctx->ctx);
+
+    /* resume the caller coroutine */
+
+    myctx->wait_co_ctx->cleanup = myctx->cleanup;
+    myctx->wait_co_ctx->data = myctx->cleanup_data;
+    ctx->cur_co_ctx = myctx->wait_co_ctx;
+    vm = ngx_http_lua_get_lua_vm(r, ctx);
+
+    rc = ngx_http_lua_run_thread(vm, r, ctx, nresults);
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "lua run thread returned %d", rc);
+
+    if (rc == NGX_AGAIN) {
+        ngx_http_lua_run_posted_threads(c, vm, r, ctx, c->requests);
+        return;
+    }
+
+    if (rc == NGX_DONE) {
+        ngx_http_lua_finalize_request(r, NGX_DONE);
+        ngx_http_lua_run_posted_threads(c, vm, r, ctx, c->requests);
+        return;
+    }
+
+    /* rc == NGX_ERROR || rc >= NGX_OK */
+
+    if (ctx->entered_content_phase) {
+        ngx_http_lua_finalize_request(r, rc);
+        return;
+    }
+}
+
+
+static void
+ngx_http_lua_worker_thread_cleanup(void *data)
+{
+    ngx_http_lua_my_thread_ctx_t *ctx = data;
+
+    ngx_thread_mutex_lock(&ctx->ctx->mutex, ngx_cycle->log);
+    ctx->is_abort = 1;
+    ngx_thread_mutex_unlock(&ctx->ctx->mutex, ngx_cycle->log);
+
+    if (ctx->cleanup) {
+        (ctx->cleanup)(ctx->cleanup_data);
+    }
+}
+
+
+static int
+ngx_http_lua_run_worker_thread(lua_State *L)
+{
+    ngx_http_request_t      *r;
+    ngx_http_lua_ctx_t      *ctx;
+    int                      n_args;
+
+    ngx_str_t                thread_pool_name;
+    ngx_thread_pool_t       *thread_pool;
+
+    ngx_http_lua_task_ctx_t *tctx;
+    lua_State               *vm;
+
+    size_t                   len;
+    const char              *mod_name;
+    int                      rc;
+
+    size_t                   len2;
+    const char              *err;
+
+    int                      i;
+
+    ngx_thread_task_t               *task;
+    ngx_http_lua_my_thread_ctx_t    *myctx;
+
+    r = ngx_http_lua_get_req(L);
+
+    if (r == NULL) {
+        return luaL_error(L, "no request found");
+    }
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+
+    if (ctx == NULL) {
+        return luaL_error(L, "no ctx found");
+    }
+
+    n_args = lua_gettop(L);
+
+    if (n_args < 2) {
+        lua_pushboolean(L, 0);
+        lua_pushstring(L, "expecting at least 2 arguments");
+        return 2;
+    }
+
+    thread_pool_name.data = (u_char*) lua_tolstring(L, 1,
+                                                    &thread_pool_name.len);
+    thread_pool = ngx_thread_pool_get((ngx_cycle_t *) ngx_cycle,
+                                      &thread_pool_name);
+    if (thread_pool == NULL) {
+        lua_pushboolean(L, 0);
+        lua_pushstring(L, "thread_pool not found");
+        return 2;
+    }
+
+    /* get vm */
+    tctx = ngx_http_lua_get_task_ctx(L);
+    vm = tctx->vm;
+
+    /* push function from module require */
+    mod_name = lua_tolstring(L, 2, &len);
+    lua_getfield(vm, LUA_GLOBALSINDEX, "require");
+    lua_pushlstring(vm, mod_name, len);
+    rc = lua_pcall(vm, 1, 1, 0);
+
+    if (rc != 0) {
+        err = lua_tolstring(vm, 1, &len2);
+        lua_pushboolean(L, 0);
+        lua_pushlstring(L, err, len2);
+        ngx_http_lua_put_task_ctx(tctx);
+        return 2;
+    }
+
+    /* copying passed arguments */
+    for (i = 3; i <= n_args; i++) {
+        if (ngx_http_lua_xcopy(L, vm, i, 1) == LUA_TNONE) {
+            lua_pushboolean(L, 0);
+            lua_pushstring(L, "unsupported argument type");
+            ngx_http_lua_put_task_ctx(tctx);
+            return 2;
+        }
+    }
+
+    /* post task */
+    task = ngx_thread_task_alloc(r->pool,
+                                 sizeof(ngx_http_lua_my_thread_ctx_t));
+
+    if (task == NULL) {
+        ngx_http_lua_put_task_ctx(tctx);
+        lua_pushboolean(L, 0);
+        lua_pushstring(L, "ngx_thread_task_alloc failed");
+        return 2;
+    }
+
+    myctx = task->ctx;
+
+    myctx->ctx = tctx;
+    myctx->wait_co_ctx = ctx->cur_co_ctx;
+
+    myctx->cleanup = ctx->cur_co_ctx->cleanup;
+    myctx->cleanup_data = ctx->cur_co_ctx->data;
+
+    ctx->cur_co_ctx->cleanup = ngx_http_lua_worker_thread_cleanup;
+    ctx->cur_co_ctx->data = myctx;
+
+    myctx->n_args = n_args - 2;
+    myctx->rc = 0;
+    myctx->is_abort = 0;
+
+    task->handler = ngx_http_lua_my_thread_func;
+    task->event.handler = ngx_http_lua_my_thread_completion;
+    task->event.data = myctx;
+
+    if (ngx_thread_task_post(thread_pool, task) != NGX_OK) {
+        ngx_http_lua_put_task_ctx(tctx);
+        lua_pushboolean(L, 0);
+        lua_pushstring(L, "ngx_thread_task_post failed");
+        return 2;
+    }
+
+    return lua_yield(L, 0);
+}
+
+
+void
+ngx_http_lua_inject_worker_thread_api(ngx_log_t *log, lua_State *L)
+{
+    lua_pushcfunction(L, ngx_http_lua_run_worker_thread);
+    lua_setfield(L, -2, "run_worker_thread");
+}
+
+#endif
+
+/* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/src/ngx_http_lua_worker_thread.h
+++ b/src/ngx_http_lua_worker_thread.h
@@ -1,5 +1,8 @@
 /*
  * Copyright (C) Yichun Zhang (agentzh)
+ * Copyright (C) Jinhua Luo (kingluo)
+ * I hereby assign copyright in this code to the lua-nginx-module project,
+ * to be licensed under the same terms as the rest of the code.
  */
 
 #ifndef _NGX_HTTP_LUA_WORKER_THREAD_H_INCLUDED_

--- a/src/ngx_http_lua_worker_thread.h
+++ b/src/ngx_http_lua_worker_thread.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) Yichun Zhang (agentzh)
+ */
+
+#ifndef _NGX_HTTP_LUA_WORKER_THREAD_H_INCLUDED_
+#define _NGX_HTTP_LUA_WORKER_THREAD_H_INCLUDED_
+
+
+#include "ngx_http_lua_common.h"
+
+
+void ngx_http_lua_inject_worker_thread_api(ngx_log_t *log, lua_State *L);
+
+
+#endif /* _NGX_HTTP_LUA_WORKER_THREAD_H_INCLUDED_ */
+
+/* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/t/062-count.t
+++ b/t/062-count.t
@@ -34,7 +34,7 @@ __DATA__
 --- request
 GET /test
 --- response_body
-ngx: 113
+ngx: 114
 --- no_error_log
 [error]
 
@@ -55,7 +55,7 @@ ngx: 113
 --- request
 GET /test
 --- response_body
-113
+114
 --- no_error_log
 [error]
 
@@ -83,7 +83,7 @@ GET /test
 --- request
 GET /test
 --- response_body
-n = 113
+n = 114
 --- no_error_log
 [error]
 
@@ -305,7 +305,7 @@ GET /t
 --- response_body_like: 404 Not Found
 --- error_code: 404
 --- error_log
-ngx. entry count: 113
+ngx. entry count: 114
 
 
 

--- a/t/166-worker-thread.t
+++ b/t/166-worker-thread.t
@@ -1,0 +1,288 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua;
+
+#worker_connections(1014);
+#master_on();
+#workers(2);
+#log_level('warn');
+
+repeat_each(1);
+
+plan tests => repeat_each() * (blocks() * 2);
+
+our $HtmlDir = html_dir;
+
+#no_diff();
+#no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: hello from worker thread
+--- main_config
+    thread_pool testpool threads=100;
+--- http_config eval
+    "lua_package_path '$::HtmlDir/?.lua;./?.lua;;';"
+--- config
+location /hello {
+    default_type 'text/plain';
+
+    content_by_lua_block {
+        local ok, hello_or_err = ngx.run_worker_thread("testpool", "hello")
+        ngx.say(ok, " : ", hello_or_err)
+    }
+}
+--- user_files
+>>> hello.lua
+return function()
+    return "hello"
+end
+--- request
+GET /hello
+--- response_body
+true : hello
+
+
+
+=== TEST 2: thread_pool not found
+--- http_config eval
+    "lua_package_path '$::HtmlDir/?.lua;./?.lua;;';"
+--- config
+location /hello {
+    default_type 'text/plain';
+
+    content_by_lua_block {
+        local ok, hello_or_err = ngx.run_worker_thread("testpool", "hello")
+        ngx.say(ok, " : ", hello_or_err)
+    }
+}
+--- user_files
+>>> hello.lua
+return function()
+    return "hello"
+end
+--- request
+GET /hello
+--- response_body
+false : thread_pool not found
+
+
+
+=== TEST 3: pass table
+--- main_config
+    thread_pool testpool threads=100;
+--- http_config eval
+    "lua_package_path '$::HtmlDir/?.lua;./?.lua;;';"
+--- config
+location /hello {
+    default_type 'text/plain';
+
+    content_by_lua_block {
+        local ok, ok_or_err = ngx.run_worker_thread("testpool", "hello", {["hello"]="world", [1]={["embed"]=1}})
+        ngx.say(ok, " , ", ok_or_err)
+    }
+}
+--- user_files
+>>> hello.lua
+return function(arg1)
+    if arg1.hello == "world" and arg1[1].embed == 1 then
+        return true
+    end
+    return false
+end
+--- request
+GET /hello
+--- response_body
+true , true
+
+
+
+=== TEST 4: expecting at least 2 arguments
+--- main_config
+    thread_pool testpool threads=100;
+--- http_config eval
+    "lua_package_path '$::HtmlDir/?.lua;./?.lua;;';"
+--- config
+location /hello {
+    default_type 'text/plain';
+
+    content_by_lua_block {
+        local ok, err = ngx.run_worker_thread("testpool")
+        ngx.say(ok, " : ", err)
+    }
+}
+--- request
+GET /hello
+--- response_body
+false : expecting at least 2 arguments
+
+
+
+=== TEST 5: base64
+--- main_config
+    thread_pool testpool threads=100;
+--- http_config eval
+    "lua_package_path '$::HtmlDir/?.lua;./?.lua;;';"
+--- config
+location /hello {
+    default_type 'text/plain';
+
+    content_by_lua_block {
+        local ok, base64 = ngx.run_worker_thread("testpool", "hello", "hello")
+        ngx.say(ok, " , ", base64 == "aGVsbG8=")
+    }
+}
+--- user_files
+>>> hello.lua
+local b='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+
+local function enc(data)
+    return ((data:gsub('.', function(x)
+        local r,b='',x:byte()
+        for i=8,1,-1 do r=r..(b%2^i-b%2^(i-1)>0 and '1' or '0') end
+        return r;
+    end)..'0000'):gsub('%d%d%d?%d?%d?%d?', function(x)
+        if (#x < 6) then return '' end
+        local c=0
+        for i=1,6 do c=c+(x:sub(i,i)=='1' and 2^(6-i) or 0) end
+        return b:sub(c+1,c+1)
+    end)..({ '', '==', '=' })[#data%3+1])
+end
+
+return function(arg1)
+    return enc(arg1)
+end
+--- request
+GET /hello
+--- response_body
+true , true
+
+
+
+=== TEST 6: return table
+--- main_config
+    thread_pool testpool threads=100;
+--- http_config eval
+    "lua_package_path '$::HtmlDir/?.lua;./?.lua;;';"
+--- config
+location /hello {
+    default_type 'text/plain';
+
+    content_by_lua_block {
+        local ok, ret = ngx.run_worker_thread("testpool", "hello")
+        if ret.hello == "world" and ret[1].embed == 1 then
+            ngx.say(ok, " , ", true)
+        end
+    }
+}
+--- user_files
+>>> hello.lua
+return function()
+    return {["hello"]="world", [1]={["embed"]=1}}
+end
+--- request
+GET /hello
+--- response_body
+true , true
+
+
+
+=== TEST 7: unsupported argument type
+--- main_config
+    thread_pool testpool threads=100;
+--- http_config eval
+    "lua_package_path '$::HtmlDir/?.lua;./?.lua;;';"
+--- config
+location /hello {
+    default_type 'text/plain';
+
+    content_by_lua_block {
+        local function dummy() end
+        local ok, err = ngx.run_worker_thread("testpool", "hello", dummy)
+        ngx.say(ok, " : ", err)
+    }
+}
+--- user_files
+>>> hello.lua
+return function()
+    return "hello"
+end
+--- request
+GET /hello
+--- response_body
+false : unsupported argument type
+
+
+
+=== TEST 8: multiple return values
+--- main_config
+    thread_pool testpool threads=100;
+--- http_config eval
+    "lua_package_path '$::HtmlDir/?.lua;./?.lua;;';"
+--- config
+location /hello {
+    default_type 'text/plain';
+
+    content_by_lua_block {
+        local ok, res1, res2 = ngx.run_worker_thread("testpool", "hello")
+        ngx.say(ok, " : ", res1, " , ", res2)
+    }
+}
+--- user_files
+>>> hello.lua
+return function()
+    return "hello", 200
+end
+--- request
+GET /hello
+--- response_body
+true : hello , 200
+
+
+
+=== TEST 9: access ngx.* api
+--- main_config
+    thread_pool testpool threads=100;
+--- http_config eval
+    "lua_package_path '$::HtmlDir/?.lua;./?.lua;;';"
+--- config
+location /hello {
+    default_type 'text/plain';
+
+    content_by_lua_block {
+        local ok, err = ngx.run_worker_thread("testpool", "hello")
+        ngx.say(ok, " : ", err)
+    }
+}
+--- user_files
+>>> hello.lua
+return function()
+    ngx.sleep(1)
+    return "ok"
+end
+--- request
+GET /hello
+--- response_body_like
+false : .*attempt to index global 'ngx' \(a nil value\)
+
+
+
+=== TEST 10: module not found
+--- main_config
+    thread_pool testpool threads=100;
+--- http_config eval
+    "lua_package_path '$::HtmlDir/?.lua;./?.lua;;';"
+--- config
+location /hello {
+    default_type 'text/plain';
+
+    content_by_lua_block {
+        local ok, err = ngx.run_worker_thread("testpool", "hello")
+        ngx.say(ok, " : ", err)
+    }
+}
+--- request
+GET /hello
+--- response_body_like
+false : module 'hello' not found.*

--- a/t/166-worker-thread.t
+++ b/t/166-worker-thread.t
@@ -448,7 +448,7 @@ return {foobar=foobar}
 GET /t
 --- response_body eval
 "killed\ntrue : hello\n"
---- timeout: 20
+--- timeout: 10
 
 
 
@@ -480,7 +480,7 @@ return {hello=hello}
 --- request
 GET /hello
 --- response_body
---- timeout: 20
+--- timeout: 10
 
 
 

--- a/t/166-worker-thread.t
+++ b/t/166-worker-thread.t
@@ -72,7 +72,7 @@ return {hello=hello}
 --- request
 GET /hello
 --- response_body
-false : thread_pool not found
+false : thread pool testpool not found
 
 
 

--- a/util/build.sh
+++ b/util/build.sh
@@ -25,6 +25,7 @@ force=$2
 add_fake_shm_module="--add-module=$root/t/data/fake-shm-module"
 
 time ngx-build $force $version \
+            --with-threads \
             --with-pcre-jit \
             --with-ipv6 \
             --with-cc-opt="-I$PCRE_INC -I$OPENSSL_INC" \


### PR DESCRIPTION
This API is useful when you need to execute below types of tasks:
* CPU bound task, e.g. md5 calculation
* File I/O task
* Call `os.execute()` or blocking C API via `ffi`
* Call external Lua library not based on cosocket or nginx

It would not block the main thread when executed, but would block the caller request (coroutine) instead.