### PR TITLE
bugfix: correct the way to handle invalid quote in ngx.escape_uri/ngx.req.get_{uri,post}_args

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5741,6 +5741,7 @@ Unescape `str` as an escaped URI component.
 For example,
 
 ```lua
+
  ngx.say(ngx.unescape_uri("b%20r56+7"))
 ```
 
@@ -5754,6 +5755,7 @@ Invalid escaping sequences are handled in a conventional way: `%`s are left unch
 For example, 
 
 ```lua
+
  ngx.say(ngx.unescape_uri("%search%%20%again%"))
 ```
 

--- a/README.markdown
+++ b/README.markdown
@@ -5748,7 +5748,7 @@ For example,
 gives the output
 
 
-    `b r56 7`
+    b r56 7
 
 Invalid escaping sequences are handled in a conventional way: `%`s are left unchanged. Also, character that should not appear in escaped string are simply left unchanged.
 
@@ -5756,13 +5756,13 @@ For example,
 
 ```lua
 
- ngx.say(ngx.unescape_uri(" %search%%20%again%"))
+ ngx.say(ngx.unescape_uri("try %search%%20%again%"))
 ```
 
 gives the output
 
 
-    ` %search% %again%`
+    try %search% %again%
 
 (Note that `%20` following `%` got unescape to space, even it can be considered a part of invalid sequence.)
 

--- a/README.markdown
+++ b/README.markdown
@@ -5741,15 +5741,28 @@ Unescape `str` as an escaped URI component.
 For example,
 
 ```lua
-
  ngx.say(ngx.unescape_uri("b%20r56+7"))
 ```
 
 gives the output
 
 
-    b r56 7
+    `b r56 7`
 
+Invalid escaping sequences are handled in a conventional way: `%`s are left unchanged.
+
+For example, 
+
+```lua
+ ngx.say(ngx.unescape_uri("%search%%20%again%"))
+```
+
+gives the output
+
+
+    `%search% %again%`
+
+(Note that `%20` following `%` got unescape to space, even it can be considered a part of invalid sequence.)
 
 [Back to TOC](#nginx-api-for-lua)
 

--- a/README.markdown
+++ b/README.markdown
@@ -5750,19 +5750,19 @@ gives the output
 
     `b r56 7`
 
-Invalid escaping sequences are handled in a conventional way: `%`s are left unchanged.
+Invalid escaping sequences are handled in a conventional way: `%`s are left unchanged. Also, character that should not appear in escaped string are simply left unchanged.
 
 For example, 
 
 ```lua
 
- ngx.say(ngx.unescape_uri("%search%%20%again%"))
+ ngx.say(ngx.unescape_uri(" %search%%20%again%"))
 ```
 
 gives the output
 
 
-    `%search% %again%`
+    ` %search% %again%`
 
 (Note that `%20` following `%` got unescape to space, even it can be considered a part of invalid sequence.)
 

--- a/README.markdown
+++ b/README.markdown
@@ -5750,7 +5750,7 @@ gives the output
 
     b r56 7
 
-Invalid escaping sequences are handled in a conventional way: `%`s are left unchanged. Also, character that should not appear in escaped string are simply left unchanged.
+Invalid escaping sequences are handled in a conventional way: `%`s are left unchanged. Also, characters that should not appear in escaped string are simply left unchanged.
 
 For example, 
 
@@ -5764,7 +5764,7 @@ gives the output
 
     try %search% %again%
 
-(Note that `%20` following `%` got unescape to space, even it can be considered a part of invalid sequence.)
+(Note that `%20` following `%` got unescaped, even it can be considered a part of invalid sequence.)
 
 [Back to TOC](#nginx-api-for-lua)
 

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -2228,9 +2228,9 @@ ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
                 *d++ = '%';
                 continue;
             }
-			// we can be sure here they must be hex digits
+            // we can be sure here they must be hex digits
             ch = ngx_http_lua_util_hex2int(s[0]) * 16 +
-    			ngx_http_lua_util_hex2int(s[1]);
+                ngx_http_lua_util_hex2int(s[1]);
             if (type & NGX_UNESCAPE_REDIRECT) {
                 if (ch > '%' && ch < 0x7f) {
                     *d++ = '%';

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -2235,7 +2235,7 @@ ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
                 if (ch == '?') {
                     *d++ = ch;
                     break;
-                } else if (ch > '%' && ch < 0x7f) {
+                } else if (ch <= '%' || ch >= 0x7f) {
                     *d++ = '%';
                     continue;
                 } 

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -2232,7 +2232,7 @@ ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
             }
             /* we can be sure here they must be hex digits */
             ch = ngx_http_lua_util_hex2int(s[0]) * 16 +
-                ngx_http_lua_util_hex2int(s[1]);
+                 ngx_http_lua_util_hex2int(s[1]);
                 
             if ((isuri || isredirect) && ch == '?') {
                 *d++ = ch;

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -2236,7 +2236,7 @@ ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
             if ((isuri || isredirect) && ch == '?') {
                 *d++ = ch;
                 break;
-            }else if (isredirect && (ch <= '%' || ch >= 0x7f)) {
+            } else if (isredirect && (ch <= '%' || ch >= 0x7f)) {
                 *d++ = '%';
                 continue;
             }

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -2213,7 +2213,8 @@ ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
     ngx_uint_t type)
 {
     u_char *d = *dst, *s = *src, *de = (*dst+size);
-    int isuri = type & NGX_UNESCAPE_URI, isredirect = type & NGX_UNESCAPE_REDIRECT;
+    int isuri = type & NGX_UNESCAPE_URI;
+    int isredirect = type & NGX_UNESCAPE_REDIRECT;
 
     while (size--) {
         u_char curr = *s++;

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -2232,13 +2232,13 @@ ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
             ch = ngx_http_lua_util_hex2int(s[0]) * 16 +
                 ngx_http_lua_util_hex2int(s[1]);
             if (type & NGX_UNESCAPE_REDIRECT) {
-                if (ch > '%' && ch < 0x7f) {
-                    *d++ = '%';
-                    continue;
-                } else if (ch == '?') {
+                if (ch == '?') {
                     *d++ = ch;
                     break;
-                }
+                } else if (ch > '%' && ch < 0x7f) {
+                    *d++ = '%';
+                    continue;
+                } 
             }
             *d++ = ch;
             s += 2;

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -2198,7 +2198,7 @@ void
 ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
     ngx_uint_t type)
 {
-    u_char  *d, *s, ch, c, decoded;
+    u_char  *d, *s, ch, c, decoded, saved;
     enum {
         sw_usual = 0,
         sw_quoted,
@@ -2256,6 +2256,7 @@ ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
 
             state = sw_usual;
 
+			*d++ = '%';
             *d++ = ch;
 
             break;
@@ -2317,6 +2318,10 @@ ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
             }
 
             /* the invalid quoted character */
+            d[0]='%';
+            d[1]=saved;
+            d[2]=ch;
+            d=d+3;
 
             break;
         }

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -2197,14 +2197,14 @@ ngx_http_lua_util_hex2int(char xdigit)
 {
     if (isdigit(xdigit)) {
         return xdigit - '0';
-    } else {
-        xdigit = tolower(xdigit);
-        if (xdigit <= 'f' && xdigit >= 'a') {
-            return xdigit - 'a' + 10;
-        } else {
-            return -1;
-        }
     }
+
+    xdigit = tolower(xdigit);
+    if (xdigit <= 'f' && xdigit >= 'a') {
+        return xdigit - 'a' + 10;
+    }
+    
+    return -1;
 }
 
 /* XXX we also decode '+' to ' ' */
@@ -2224,6 +2224,7 @@ ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
         {
             *d++ = '?';
             break;
+
         } else if (curr == '%') {
             u_char ch;
             if (size < 2 || !(isxdigit(s[0]) && isxdigit(s[1]))) {
@@ -2244,9 +2245,11 @@ ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
             *d++ = ch;
             s += 2;
             size -= 2;
+
         } else if (curr == '+') {
             *d++ = ' ';
             continue;
+
         } else {
             *d++ = curr;
         }

--- a/t/006-escape.t
+++ b/t/006-escape.t
@@ -301,7 +301,7 @@ qr/\[error\] \d+#\d+: \*\d+ lua entry thread aborted: runtime error: "type" is n
 --- config
     location /lua {
         content_by_lua_block {
-            ngx.say(ngx.escape_uri("%ua%%20%au"))
+            ngx.say(ngx.unescape_uri("%ua%%20%au"))
         }
     }
 --- request

--- a/t/006-escape.t
+++ b/t/006-escape.t
@@ -308,3 +308,21 @@ qr/\[error\] \d+#\d+: \*\d+ lua entry thread aborted: runtime error: "type" is n
 GET /lua
 --- response_body
 %ua% %au
+
+
+
+=== TEST 21: invalid unescape sequences where remain length less than 2
+--- config
+    location /lua {
+        content_by_lua_block {
+            ngx.say(ngx.unescape_uri("%u"))
+            ngx.say(ngx.unescape_uri("%"))
+            ngx.say(ngx.unescape_uri("good%20job%"))
+        }
+    }
+--- request
+GET /lua
+--- response_body
+%u
+%
+good jod%

--- a/t/006-escape.t
+++ b/t/006-escape.t
@@ -294,3 +294,17 @@ GET /lua
 --- error_code: 500
 --- error_log eval
 qr/\[error\] \d+#\d+: \*\d+ lua entry thread aborted: runtime error: "type" is not a number/
+
+
+
+=== TEST 14: invalid unescape sequences
+--- config
+    location /lua {
+        content_by_lua_block {
+            ngx.say(ngx.escape_uri("%ua%%20%au"))
+        }
+    }
+--- request
+GET /lua
+--- response_body
+[%ua% %au]

--- a/t/006-escape.t
+++ b/t/006-escape.t
@@ -307,4 +307,4 @@ qr/\[error\] \d+#\d+: \*\d+ lua entry thread aborted: runtime error: "type" is n
 --- request
 GET /lua
 --- response_body
-[%ua% %au]
+%ua% %au

--- a/t/006-escape.t
+++ b/t/006-escape.t
@@ -297,7 +297,7 @@ qr/\[error\] \d+#\d+: \*\d+ lua entry thread aborted: runtime error: "type" is n
 
 
 
-=== TEST 14: invalid unescape sequences
+=== TEST 20: invalid unescape sequences
 --- config
     location /lua {
         content_by_lua_block {

--- a/t/006-escape.t
+++ b/t/006-escape.t
@@ -327,4 +327,4 @@ GET /lua
 %a
 %u
 %
-good jod%
+good job%

--- a/t/006-escape.t
+++ b/t/006-escape.t
@@ -315,7 +315,8 @@ GET /lua
 --- config
     location /lua {
         content_by_lua_block {
-            ngx.say(ngx.unescape_uri("%u"))
+            ngx.say(ngx.unescape_uri("%a")) -- first charactor is good
+            ngx.say(ngx.unescape_uri("%u")) -- first charactor is bad
             ngx.say(ngx.unescape_uri("%"))
             ngx.say(ngx.unescape_uri("good%20job%"))
         }
@@ -323,6 +324,7 @@ GET /lua
 --- request
 GET /lua
 --- response_body
+%a
 %u
 %
 good jod%


### PR DESCRIPTION
test case like: "%20%1a%a1%au%ua"

Original implementation fails to handle invalid quote sequence correctly:
1. '%'s are discarded, which are preserved by most implementation;
2. when the problem happens at last charactor(and string is not null-terminated), an extra charactor will be copied

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
