### PR TITLE
tests: fixed typo in 162-exit-worker.t.

### DIFF
--- a/t/162-exit-worker.t
+++ b/t/162-exit-worker.t
@@ -83,7 +83,7 @@ hello, world
 --- http_config
     exit_worker_by_lua_block {
         local function bar()
-            ngx.log(ngx.ERR, "run the timer!"
+            ngx.log(ngx.ERR, "run the timer!")
         end
 
         local ok, err = ngx.timer.at(0, bar)


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.