### PR TITLE
doc: sync doc from README to ensure wiki2markdown.pl is work

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5750,9 +5750,10 @@ gives the output
 
     b r56 7
 
+
 Invalid escaping sequences are handled in a conventional way: `%`s are left unchanged. Also, characters that should not appear in escaped string are simply left unchanged.
 
-For example, 
+For example,
 
 ```lua
 
@@ -5763,6 +5764,7 @@ gives the output
 
 
     try %search% %again%
+
 
 (Note that `%20` following `%` got unescaped, even it can be considered a part of invalid sequence.)
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -4835,6 +4835,22 @@ gives the output
     b r56 7
 </geshi>
 
+Invalid escaping sequences are handled in a conventional way: `%`s are left unchanged. Also, characters that should not appear in escaped string are simply left unchanged.
+
+For example,
+
+<geshi lang="lua">
+    ngx.say(ngx.unescape_uri("try %search%%20%again%"))
+</geshi>
+
+gives the output
+
+<geshi lang="text">
+    try %search% %again%
+</geshi>
+
+(Note that `%20` following `%` got unescaped, even it can be considered a part of invalid sequence.)
+
 == ngx.encode_args ==
 
 '''syntax:''' ''str = ngx.encode_args(table)''


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

We have broken doc/HttpLuaModule.wiki since https://github.com/openresty/lua-nginx-module/commit/eb944dedd28231a99d8a2a71cbc392ce2dad36c1