### PR TITLE
change: changed from graceful shutdown to abort when lua_resume return LUA_ERRMEM.

### DIFF
--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -1471,7 +1471,7 @@ user_co_done:
                 break;
 
             case LUA_ERRMEM:
-                err = "memory allocation error when running lua coroutine";
+                err = "[lua] memory allocation error";
                 ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0, err);
                 abort();
                 break;

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -1471,8 +1471,9 @@ user_co_done:
                 break;
 
             case LUA_ERRMEM:
-                err = "memory allocation error";
-                ngx_quit = 1;
+                err = "memory allocation error when running lua coroutine";
+                ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0, err);
+                abort();
                 break;
 
             case LUA_ERRERR:
@@ -2203,7 +2204,7 @@ ngx_http_lua_util_hex2int(char xdigit)
     if (xdigit <= 'f' && xdigit >= 'a') {
         return xdigit - 'a' + 10;
     }
-    
+
     return -1;
 }
 
@@ -2234,7 +2235,7 @@ ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
             /* we can be sure here they must be hex digits */
             ch = ngx_http_lua_util_hex2int(s[0]) * 16 +
                  ngx_http_lua_util_hex2int(s[1]);
-                
+
             if ((isuri || isredirect) && ch == '?') {
                 *d++ = ch;
                 break;
@@ -2254,7 +2255,7 @@ ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
             *d++ = curr;
         }
     }
-    
+
     /* a safe guard if dst need to be null-terminated */
     if (d != de) {
         *d = '\0';

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -2204,7 +2204,7 @@ ngx_http_lua_util_hex2int(char xdigit)
     if (xdigit <= 'f' && xdigit >= 'a') {
         return xdigit - 'a' + 10;
     }
-
+    
     return -1;
 }
 
@@ -2235,7 +2235,7 @@ ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
             /* we can be sure here they must be hex digits */
             ch = ngx_http_lua_util_hex2int(s[0]) * 16 +
                  ngx_http_lua_util_hex2int(s[1]);
-
+                
             if ((isuri || isredirect) && ch == '?') {
                 *d++ = ch;
                 break;
@@ -2255,7 +2255,7 @@ ngx_http_lua_unescape_uri(u_char **dst, u_char **src, size_t size,
             *d++ = curr;
         }
     }
-
+    
     /* a safe guard if dst need to be null-terminated */
     if (d != de) {
         *d = '\0';


### PR DESCRIPTION
If the worker voluntary enter into graceful shutdown state, the master will not respawn worker with the same worker id until the worker process exit.
when reuseport is on, the new connections assigned to the voluntary graceful shutdown worker will not be accepted.
when reuseport is off, the new connections will be accepted by other processes which are still working. But if all workers are in voluntary shutdown state, the new connections will not be accepted.

So the worker should not enter into the voluntary graceful shutdown state when LUA_ERRMEM occurs.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
