### PR TITLE
feature: add lua_ssl_ciphersuites directive for specifying the enabled TLSv1.3 ciphersuites

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3082,7 +3082,19 @@ lua_ssl_ciphersuites
 
 **context:** *http, server, location*
 
-Specifies the enabled TLSV1.3 ciphersuites for requests to a SSL/TLS server in the [tcpsock:sslhandshake](#tcpsocksslhandshake) method. The ciphersuites are specified in the format understood by the OpenSSL library.
+Specifies the enabled TLSV1.3 ciphersuites for requests to a SSL/TLS server in the [tcpsock:sslhandshake](#tcpsocksslhandshake) method. The ciphersuite list is separated by colon(:) in order of preference. Valid TLSv1.3 ciphersuite names are:
+
+TLS_AES_128_GCM_SHA256
+
+TLS_AES_256_GCM_SHA384
+
+TLS_CHACHA20_POLY1305_SHA256
+
+TLS_AES_128_CCM_SHA256
+
+TLS_AES_128_CCM_8_SHA256
+
+An empty list is permissible.
 
 The full list can be viewed using the “openssl ciphers” command.
 

--- a/README.markdown
+++ b/README.markdown
@@ -1149,6 +1149,7 @@ Directives
 * [lua_socket_keepalive_timeout](#lua_socket_keepalive_timeout)
 * [lua_socket_log_errors](#lua_socket_log_errors)
 * [lua_ssl_ciphers](#lua_ssl_ciphers)
+* [lua_ssl_ciphersuites](#lua_ssl_ciphersuites)
 * [lua_ssl_crl](#lua_ssl_crl)
 * [lua_ssl_protocols](#lua_ssl_protocols)
 * [lua_ssl_trusted_certificate](#lua_ssl_trusted_certificate)
@@ -3069,6 +3070,23 @@ Specifies the enabled ciphers for requests to a SSL/TLS server in the [tcpsock:s
 The full list can be viewed using the “openssl ciphers” command.
 
 This directive was first introduced in the `v0.9.11` release.
+
+[Back to TOC](#directives)
+
+lua_ssl_ciphersuites
+---------------
+
+**syntax:** *lua_ssl_ciphersuites &lt;ciphersuites&gt;*
+
+**default:** *lua_ssl_ciphers TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256*
+
+**context:** *http, server, location*
+
+Specifies the enabled TLSV1.3 ciphersuites for requests to a SSL/TLS server in the [tcpsock:sslhandshake](#tcpsocksslhandshake) method. The ciphersuites are specified in the format understood by the OpenSSL library.
+
+The full list can be viewed using the “openssl ciphers” command.
+
+This directive was first introduced in the `v0.10.20` release.
 
 [Back to TOC](#directives)
 

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -333,6 +333,7 @@ typedef struct {
     ngx_ssl_t              *ssl;  /* shared by SSL cosockets */
     ngx_uint_t              ssl_protocols;
     ngx_str_t               ssl_ciphers;
+    ngx_str_t               ssl_ciphersuites;
     ngx_uint_t              ssl_verify_depth;
     ngx_str_t               ssl_trusted_certificate;
     ngx_str_t               ssl_crl;

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -333,7 +333,9 @@ typedef struct {
     ngx_ssl_t              *ssl;  /* shared by SSL cosockets */
     ngx_uint_t              ssl_protocols;
     ngx_str_t               ssl_ciphers;
+#ifdef NGX_SSL_TLSv1_3
     ngx_str_t               ssl_ciphersuites;
+#endif
     ngx_uint_t              ssl_verify_depth;
     ngx_str_t               ssl_trusted_certificate;
     ngx_str_t               ssl_crl;

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -1438,7 +1438,7 @@ ngx_http_lua_set_ssl(ngx_conf_t *cf, ngx_http_lua_loc_conf_t *llcf)
 
     ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
                   "OpenSSL too old to support lua_ssl_ciphersuites");
-    return NGX_CONF_ERROR;
+    return NGX_ERROR;
 
 #   endif
 #endif

--- a/t/129-ssl-socket.t
+++ b/t/129-ssl-socket.t
@@ -2565,6 +2565,7 @@ qr/\[error\] .* ngx.socket sslhandshake: expecting 1 ~ 5 arguments \(including t
 
 
 === TEST 32: default cipher -TLSv1.3
+--- skip_openssl: 8: < 1.1.1
 --- http_config
     server {
         listen              unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -2655,6 +2656,7 @@ SSL reused session
 
 
 === TEST 33: explicit cipher configuration - TLSv1.3
+--- skip_openssl: 8: < 1.1.1
 --- http_config
     server {
         listen              unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -2746,6 +2748,7 @@ SSL reused session
 
 
 === TEST 34: explicit cipher configuration not in the default list - TLSv1.3
+--- skip_openssl: 8: < 1.1.1
 --- http_config
     server {
         listen              unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;

--- a/t/129-ssl-socket.t
+++ b/t/129-ssl-socket.t
@@ -6,7 +6,7 @@ use File::Basename;
 
 repeat_each(2);
 
-plan tests => repeat_each() * 211;
+plan tests => repeat_each() * 235;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 $ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
@@ -2560,4 +2560,272 @@ GET /t
 qr/\[error\] .* ngx.socket sslhandshake: expecting 1 ~ 5 arguments \(including the object\), but seen 0/
 --- no_error_log
 [alert]
+--- timeout: 10
+
+
+
+=== TEST 32: default cipher -TLSv1.3
+--- http_config
+    server {
+        listen              unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name         test.com;
+        ssl_certificate     $TEST_NGINX_CERT_DIR/cert/test.crt;
+        ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_protocols       TLSv1.3;
+
+        location / {
+            content_by_lua_block {
+                ngx.exit(200)
+            }
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_protocols TLSv1.3;
+
+    location /t {
+        content_by_lua '
+            local sock = ngx.socket.tcp()
+            sock:settimeout(2000)
+
+            do
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local session, err = sock:sslhandshake(nil, "test.com")
+                if not session then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(session))
+
+                local req = "GET / HTTP/1.1\\r\\nHost: test.com\\r\\nConnection: close\\r\\n\\r\\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                local line, err = sock:receive()
+                if not line then
+                    ngx.say("failed to receive response status line: ", err)
+                    return
+                end
+
+                ngx.say("received: ", line)
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            collectgarbage()
+        ';
+    }
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+sent http request: 53 bytes.
+received: HTTP/1.1 200 OK
+close: 1 nil
+
+--- log_level: debug
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
+--- grep_error_log_out eval
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
+$/
+--- error_log eval
+['lua ssl server name: "test.com"',
+qr/SSL: TLSv1.3, cipher: "TLS_AES_256_GCM_SHA384 TLSv1.3/]
+--- no_error_log
+SSL reused session
+[error]
+[alert]
+--- timeout: 10
+
+
+
+=== TEST 33: explicit cipher configuration - TLSv1.3
+--- http_config
+    server {
+        listen              unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name         test.com;
+        ssl_certificate     $TEST_NGINX_CERT_DIR/cert/test.crt;
+        ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_protocols       TLSv1.3;
+
+        location / {
+            content_by_lua_block {
+                ngx.exit(200)
+            }
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_protocols TLSv1.3;
+    lua_ssl_ciphersuites TLS_AES_128_GCM_SHA256;
+
+    location /t {
+        content_by_lua '
+            local sock = ngx.socket.tcp()
+            sock:settimeout(2000)
+
+            do
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local session, err = sock:sslhandshake(nil, "test.com")
+                if not session then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(session))
+
+                local req = "GET / HTTP/1.1\\r\\nHost: test.com\\r\\nConnection: close\\r\\n\\r\\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                local line, err = sock:receive()
+                if not line then
+                    ngx.say("failed to receive response status line: ", err)
+                    return
+                end
+
+                ngx.say("received: ", line)
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            collectgarbage()
+        ';
+    }
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: userdata
+sent http request: 53 bytes.
+received: HTTP/1.1 200 OK
+close: 1 nil
+
+--- log_level: debug
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
+--- grep_error_log_out eval
+qr/^lua ssl save session: ([0-9A-F]+)
+lua ssl free session: ([0-9A-F]+)
+$/
+--- error_log eval
+['lua ssl server name: "test.com"',
+qr/SSL: TLSv1.3, cipher: "TLS_AES_128_GCM_SHA256 TLSv1.3/]
+--- no_error_log
+SSL reused session
+[error]
+[alert]
+--- timeout: 10
+
+
+
+=== TEST 34: explicit cipher configuration not in the default list - TLSv1.3
+--- http_config
+    server {
+        listen              unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name         test.com;
+        ssl_certificate     $TEST_NGINX_CERT_DIR/cert/test.crt;
+        ssl_certificate_key $TEST_NGINX_CERT_DIR/cert/test.key;
+        ssl_protocols       TLSv1.3;
+
+        location / {
+            content_by_lua_block {
+                ngx.exit(200)
+            }
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_protocols TLSv1.3;
+    lua_ssl_ciphersuites TLS_AES_128_CCM_SHA256;
+
+    location /t {
+        content_by_lua '
+            local sock = ngx.socket.tcp()
+            sock:settimeout(2000)
+
+            do
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local session, err = sock:sslhandshake(nil, "test.com")
+                if not session then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(session))
+
+                local req = "GET / HTTP/1.1\\r\\nHost: test.com\\r\\nConnection: close\\r\\n\\r\\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                local line, err = sock:receive()
+                if not line then
+                    ngx.say("failed to receive response status line: ", err)
+                    return
+                end
+
+                ngx.say("received: ", line)
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            collectgarbage()
+        ';
+    }
+--- request
+GET /t
+--- response_body
+connected: 1
+failed to do SSL handshake: handshake failed
+
+--- log_level: debug
+--- grep_error_log eval: qr/lua ssl (?:set|save|free) session: [0-9A-F]+/
+--- grep_error_log_out
+--- error_log eval
+[
+qr/\[info\] .*?SSL_do_handshake\(\) failed .*?no shared cipher/,
+'lua ssl server name: "test.com"',
+]
+--- no_error_log
+SSL reused session
+[alert]
+[emerg]
 --- timeout: 10


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

sister PR: [stream-lua-nginx-module #251](https://github.com/openresty/stream-lua-nginx-module/pull/251)