### PR TITLE
bugfix: we didn't exclude the ssl_verify_callback when compiling with LibreSSL

### DIFF
--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -1333,6 +1333,7 @@ failed:
 }
 
 
+#ifndef LIBRESSL_VERSION_NUMBER
 static int
 ngx_http_lua_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
 {
@@ -1344,6 +1345,7 @@ ngx_http_lua_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
      */
     return 1;
 }
+#endif
 
 
 int


### PR DESCRIPTION
It leads to 'error: ‘ngx_http_lua_ssl_verify_callback’ defined but not used [-Werror=unused-function]'
error.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
