### PR TITLE
travis-ci: remove clang compiler mode from travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ language: c
 
 compiler:
   - gcc
-  - clang
 
 addons:
   apt:


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
