### PR TITLE
chore: check context in ngx.timer.* for exit process

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1672,6 +1672,8 @@ For example,
  }
 ```
 
+It's not allowed to create a timer (even a 0-delay timer) here since it runs after all timers have been processed.
+
 This directive was first introduced in the `v0.10.18` release.
 
 [Back to TOC](#directives)
@@ -3154,9 +3156,10 @@ The directive is supported when using OpenSSL 1.0.2 or higher and nginx 1.19.4 o
 
 Several `lua_ssl_conf_command` directives can be specified on the same level:
 
-```
-lua_ssl_conf_command Options PrioritizeChaCha;
-lua_ssl_conf_command Ciphersuites TLS_CHACHA20_POLY1305_SHA256;
+```nginx
+
+ lua_ssl_conf_command Options PrioritizeChaCha;
+ lua_ssl_conf_command Ciphersuites TLS_CHACHA20_POLY1305_SHA256;
 ```
 
 Configuration commands are applied after OpenResty own configuration for SSL, so they can be used to override anything set by OpenResty.
@@ -3164,6 +3167,8 @@ Configuration commands are applied after OpenResty own configuration for SSL, so
 Note though that configuring OpenSSL directly with `lua_ssl_conf_command` might result in a behaviour OpenResty does not expect, and should be done with care.
 
 This directive was first introduced in the `v0.10.21` release.
+
+
 
 [Back to TOC](#directives)
 
@@ -8405,7 +8410,7 @@ ngx.timer.at
 
 **syntax:** *hdl, err = ngx.timer.at(delay, callback, user_arg1, user_arg2, ...)*
 
-**context:** *init_worker_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, exit_worker_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;*
 
 Creates an Nginx timer with a user callback function as well as optional user arguments.
 
@@ -8548,7 +8553,7 @@ ngx.timer.every
 
 **syntax:** *hdl, err = ngx.timer.every(delay, callback, user_arg1, user_arg2, ...)*
 
-**context:** *init_worker_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, exit_worker_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;*
 
 Similar to the [ngx.timer.at](#ngxtimerat) API function, but
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -1362,6 +1362,8 @@ For example,
     }
 </geshi>
 
+It's not allowed to create a timer (even a 0-delay timer) here since it runs after all timers have been processed.
+
 This directive was first introduced in the <code>v0.10.18</code> release.
 
 == exit_worker_by_lua_file ==
@@ -7196,7 +7198,7 @@ See also [[#lua_check_client_abort|lua_check_client_abort]].
 
 '''syntax:''' ''hdl, err = ngx.timer.at(delay, callback, user_arg1, user_arg2, ...)''
 
-'''context:''' ''init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*, exit_worker_by_lua*''
+'''context:''' ''init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
 
 Creates an Nginx timer with a user callback function as well as optional user arguments.
 
@@ -7334,7 +7336,7 @@ This API was first introduced in the <code>v0.8.0</code> release.
 
 '''syntax:''' ''hdl, err = ngx.timer.every(delay, callback, user_arg1, user_arg2, ...)''
 
-'''context:''' ''init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*, exit_worker_by_lua*''
+'''context:''' ''init_worker_by_lua*, set_by_lua*, rewrite_by_lua*, access_by_lua*, content_by_lua*, header_filter_by_lua*, body_filter_by_lua*, log_by_lua*, ngx.timer.*, balancer_by_lua*, ssl_certificate_by_lua*, ssl_session_fetch_by_lua*, ssl_session_store_by_lua*''
 
 Similar to the [[#ngx.timer.at|ngx.timer.at]] API function, but
 

--- a/src/ngx_http_lua_timer.c
+++ b/src/ngx_http_lua_timer.c
@@ -174,6 +174,15 @@ ngx_http_lua_ngx_timer_helper(lua_State *L, int every)
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
 
+    /*
+     * Since nginx has been confirmed that all timers have been cleaned up when
+     * exit worker is executed, all timers will no longer be executed in exit
+     * worker phase.
+     * Reference https://github.com/nginx/nginx/blob/f02e2a734ef472f0dcf83ab2
+     * e8ce96d1acead8a5/src/os/unix/ngx_process_cycle.c#L715
+     */
+    ngx_http_lua_check_context(L, ctx, ~NGX_HTTP_LUA_CONTEXT_EXIT_WORKER);
+
     if (ngx_exiting && delay > 0) {
         lua_pushnil(L);
         lua_pushliteral(L, "process exiting");

--- a/t/162-exit-worker.t
+++ b/t/162-exit-worker.t
@@ -5,7 +5,7 @@ use Test::Nginx::Socket::Lua;
 master_on();
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 2 + 2) + 12;
+plan tests => repeat_each() * (blocks() * 2 + 2) + 11;
 
 #log_level("warn");
 no_long_string();
@@ -79,7 +79,7 @@ hello, world
 
 
 
-=== TEST 4: exit_worker_by_lua single process ngx.timer not work
+=== TEST 4: ngx.timer is not allow
 --- http_config
     exit_worker_by_lua_block {
         local function bar()
@@ -101,8 +101,8 @@ hello, world
 GET /t
 --- response_body
 ok
---- no_error_log
-[error]
+--- shutdown_error_log
+API disabled in the context of exit_worker_by_lua*
 
 
 


### PR DESCRIPTION
Since nginx has been confirmed that all timers have been cleaned up when exit worker is executed, all timers will no longer be executed in exit worker phase. 
Reference https://github.com/nginx/nginx/blob/f02e2a734ef472f0dcf83ab2e8ce96d1acead8a5/src/os/unix/ngx_process_cycle.c#L715