### PR TITLE
change: do not need to create the Lua request ctx data table from C

### DIFF
--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -781,10 +781,13 @@ ngx_http_lua_init_registry(lua_State *L, ngx_log_t *log)
     lua_rawset(L, LUA_REGISTRYINDEX);
     /* }}} */
 
-    /* create the registry entry for the Lua request ctx data table */
-    lua_pushliteral(L, ngx_http_lua_ctx_tables_key);
-    lua_createtable(L, 0, 32 /* nrec */);
-    lua_rawset(L, LUA_REGISTRYINDEX);
+    /*
+     * the the Lua request ctx data table will create in resty.core.ctx,
+     * just equivalent to the following code:
+     *    lua_pushliteral(L, ngx_http_lua_ctx_tables_key);
+     *    lua_createtable(L, 0, 0);
+     *    lua_rawset(L, LUA_REGISTRYINDEX);
+     */
 
     /* create the registry entry for the Lua socket connection pool table */
     lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(


### PR DESCRIPTION
since we already changed to create the table from Lua in resty.core.ctx.

related change:
https://github.com/openresty/lua-resty-core/commit/2d667ec81497a7a2ec10bd6b7d1f27509637c928

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
