### PR TITLE
bugfix:fix expired(not cleared)share dict list len incorrect problem

### DIFF
--- a/src/ngx_http_lua_shdict.c
+++ b/src/ngx_http_lua_shdict.c
@@ -815,7 +815,7 @@ ngx_http_lua_shdict_push_helper(lua_State *L, int flags)
                        "type matched, reusing it");
 
         sd->expires = 0;
-
+        sd->value_len = 0;
         /* free list nodes */
 
         queue = ngx_http_lua_shdict_get_list_head(sd, key.len);

--- a/t/145-shdict-list.t
+++ b/t/145-shdict-list.t
@@ -751,30 +751,30 @@ done
     location = /test {
         content_by_lua_block {
             local dogs = ngx.shared.dogs
-	    local len, err = dogs:lpush("cc", "1") --add another list to avoid key"aa" be cleaned (run ‘ngx_http_lua_shdict_expire(ctx, 1)’ may clean key ,ensure key'aa' not clean ,just expired))
+            local len, err = dogs:lpush("cc", "1") --add another list to avoid key"aa" be cleaned (run ‘ngx_http_lua_shdict_expire(ctx, 1)’ may clean key ,ensure key'aa' not clean ,just expired))
             if not len then
                 ngx.say("push cc  err: ", err)
             end
-	    local len, err = dogs:lpush("aa", "1")
+            local len, err = dogs:lpush("aa", "1")
             if not len then
                 ngx.say("push1 err: ", err)
             end
-	    local succ, err = dogs:expire("aa", 0.2)
-	    if not succ then
-	        ngx.say("expire err: ",err)
-	    end
-	    ngx.sleep(0.3) -- list aa expired
-	    local len, err = dogs:lpush("aa", "2") --push to an expired list may set as a new list
+            local succ, err = dogs:expire("aa", 0.2)
+            if not succ then
+                ngx.say("expire err: ",err)
+            end
+            ngx.sleep(0.3) -- list aa expired
+            local len, err = dogs:lpush("aa", "2") --push to an expired list may set as a new list
             if not len then
                 ngx.say("push2 err: ", err)
             end
-	    local len, err = dogs:llen("aa") -- new list len is 1
+            local len, err = dogs:llen("aa") -- new list len is 1
             if not len then
                 ngx.say("llen err: ", err)
-	    else
-	        ngx.say("aa:len :", dogs:llen("aa"))
+            else
+            ngx.say("aa:len :", dogs:llen("aa"))
             end
-	}
+        }
     }
 
 --- request
@@ -793,32 +793,32 @@ aa:len :1
     location = /test {
         content_by_lua_block {
             local dogs = ngx.shared.dogs
-	    local len, err = dogs:lpush("cc", "1") --add another list to avoid key"aa" be cleaned (run ‘ngx_http_lua_shdict_expire(ctx, 1)’ may clean key ,ensure key'aa' not clean ,just expired))
+            local len, err = dogs:lpush("cc", "1") --add another list to avoid key"aa" be cleaned (run ‘ngx_http_lua_shdict_expire(ctx, 1)’ may clean key ,ensure key'aa' not clean ,just expired))
             if not len then
                 ngx.say("push cc  err: ", err)
             end
-	    local len, err = dogs:lpush("aa", "1")
+            local len, err = dogs:lpush("aa", "1")
             if not len then
                 ngx.say("push1 err: ", err)
             end
-	    local succ, err = dogs:expire("aa", 0.2)
-	    if not succ then
-	        ngx.say("expire err: ",err)
-	    end
-	    ngx.sleep(0.3) -- list aa expired
-	    local len, err = dogs:lpush("aa", "2") --push to an expired list may set as a new list
+            local succ, err = dogs:expire("aa", 0.2)
+            if not succ then
+            ngx.say("expire err: ",err)
+            end
+            ngx.sleep(0.3) -- list aa expired
+            local len, err = dogs:lpush("aa", "2") --push to an expired list may set as a new list
             if not len then
                 ngx.say("push2 err: ", err)
             end
-	    local val, err = dogs:lpop("aa") 
+            local val, err = dogs:lpop("aa") 
             if not val then
                 ngx.say("llen err: ", err)
             end
-	    local val, err = dogs:lpop("aa")  -- val == nil
+            local val, err = dogs:lpop("aa")  -- val == nil
             ngx.say("aa list value: ", val)
            
 
-	}
+        }
     }
 
 --- request

--- a/t/145-shdict-list.t
+++ b/t/145-shdict-list.t
@@ -787,9 +787,6 @@ aa:len :1
 [error]
 
 
- 
-
-
 
 === TEST 21: push to an expired list then pop many time (more then list len )
 --- http_config
@@ -821,8 +818,6 @@ aa:len :1
             end
             local val, err = dogs:lpop("aa")  -- val == nil
             ngx.say("aa list value: ", val)
-           
-
         }
     }
 

--- a/t/145-shdict-list.t
+++ b/t/145-shdict-list.t
@@ -743,3 +743,89 @@ GET /test
 done
 --- no_error_log
 [error]
+
+=== TEST 20: push to an expired list
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+	    local len, err = dogs:lpush("cc", "1") --add another list to avoid key"aa" be cleaned (run ‘ngx_http_lua_shdict_expire(ctx, 1)’ may clean key ,ensure key'aa' not clean ,just expired))
+            if not len then
+                ngx.say("push cc  err: ", err)
+            end
+	    local len, err = dogs:lpush("aa", "1")
+            if not len then
+                ngx.say("push1 err: ", err)
+            end
+	    local succ, err = dogs:expire("aa", 0.2)
+	    if not succ then
+	        ngx.say("expire err: ",err)
+	    end
+	    ngx.sleep(0.3) -- list aa expired
+	    local len, err = dogs:lpush("aa", "2") --push to an expired list may set as a new list
+            if not len then
+                ngx.say("push2 err: ", err)
+            end
+	    local len, err = dogs:llen("aa") -- new list len is 1
+            if not len then
+                ngx.say("llen err: ", err)
+	    else
+	        ngx.say("aa:len :", dogs:llen("aa"))
+            end
+	}
+    }
+
+--- request
+GET /test
+--- response_body
+aa:len :1
+--- no_error_log
+[error]
+
+
+ 
+=== TEST 21: push to an expired list then pop many time (more then list len )
+--- http_config
+    lua_shared_dict dogs 1m;
+--- config
+    location = /test {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+	    local len, err = dogs:lpush("cc", "1") --add another list to avoid key"aa" be cleaned (run ‘ngx_http_lua_shdict_expire(ctx, 1)’ may clean key ,ensure key'aa' not clean ,just expired))
+            if not len then
+                ngx.say("push cc  err: ", err)
+            end
+	    local len, err = dogs:lpush("aa", "1")
+            if not len then
+                ngx.say("push1 err: ", err)
+            end
+	    local succ, err = dogs:expire("aa", 0.2)
+	    if not succ then
+	        ngx.say("expire err: ",err)
+	    end
+	    ngx.sleep(0.3) -- list aa expired
+	    local len, err = dogs:lpush("aa", "2") --push to an expired list may set as a new list
+            if not len then
+                ngx.say("push2 err: ", err)
+            end
+	    local val, err = dogs:lpop("aa") 
+            if not val then
+                ngx.say("llen err: ", err)
+            end
+	    local val, err = dogs:lpop("aa")  -- val == nil
+            ngx.say("aa list value: ", val)
+           
+
+	}
+    }
+
+--- request
+GET /test
+--- response_body
+aa list value: nil
+--- no_error_log
+[error]
+
+

--- a/t/145-shdict-list.t
+++ b/t/145-shdict-list.t
@@ -744,6 +744,8 @@ done
 --- no_error_log
 [error]
 
+
+
 === TEST 20: push to an expired list
 --- http_config
     lua_shared_dict dogs 1m;
@@ -786,6 +788,9 @@ aa:len :1
 
 
  
+
+
+
 === TEST 21: push to an expired list then pop many time (more then list len )
 --- http_config
     lua_shared_dict dogs 1m;
@@ -827,5 +832,3 @@ GET /test
 aa list value: nil
 --- no_error_log
 [error]
-
-


### PR DESCRIPTION
修复一个share dict list过期处理的问题：
当向一个过期的list push时，
如果过期的list没有被清除，重新复用时，list长度没有重新置为0，导致新队列pop时，返回500
例子：
local dogs = ngx.shared.dogs
dogs:lpush("cc", "1")
dogs:lpush("aa", "1")
dogs:expire("aa", 0.2)
ngx.sleep(0.3)
dogs:lpush("aa", "2")
dogs:lpop("aa")
dogs:lpop("aa")     --此时触发500，而不是期望的返回nil
