### PR TITLE
bugfix: fixed potential leak on memory allocation errors of ngx_http_lua_set_ssl.

### DIFF
--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -1485,6 +1485,7 @@ ngx_http_lua_set_ssl(ngx_conf_t *cf, ngx_http_lua_loc_conf_t *llcf)
 
     cln = ngx_pool_cleanup_add(cf->pool, 0);
     if (cln == NULL) {
+        ngx_ssl_cleanup_ctx(llcf->ssl);
         return NGX_ERROR;
     }
 


### PR DESCRIPTION
similar to https://hg.nginx.org/nginx/rev/8981dbb12254
If ngx_pool_cleanup_add() fails, we have to clean just created SSL context
manually, thus appropriate call added.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
