### PR TITLE
chore: fix possible null pointer dereference found by Coverity.

### DIFF
--- a/src/ngx_http_lua_timer.c
+++ b/src/ngx_http_lua_timer.c
@@ -173,6 +173,7 @@ ngx_http_lua_ngx_timer_helper(lua_State *L, int every)
     }
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+    ngx_http_lua_assert(ctx != NULL);
 
     /*
      * Since nginx has been confirmed that all timers have been cleaned up when
@@ -323,7 +324,7 @@ ngx_http_lua_ngx_timer_helper(lua_State *L, int every)
         tctx->client_addr_text.data = NULL;
     }
 
-    if (ctx && ctx->vm_state) {
+    if (ctx->vm_state) {
         tctx->vm_state = ctx->vm_state;
         tctx->vm_state->count++;
 


### PR DESCRIPTION
fix #1941.

```
** CID 339181:  Null pointer dereferences  (REVERSE_INULL)
/src/ngx_http_lua_timer.c: 326 in ngx_http_lua_ngx_timer_helper()
________________________________________________________________________________________________________
*** CID 339181:  Null pointer dereferences  (REVERSE_INULL)
/src/ngx_http_lua_timer.c: 326 in ngx_http_lua_ngx_timer_helper()
320
321         } else {
322             tctx->client_addr_text.len = 0;
323             tctx->client_addr_text.data = NULL;
324         }
325
>>>     CID 339181:  Null pointer dereferences  (REVERSE_INULL)
>>>     Null-checking "ctx" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
326         if (ctx && ctx->vm_state) {
327             tctx->vm_state = ctx->vm_state;
328             tctx->vm_state->count++;
329
330         } else {
331             tctx->vm_state = NULL;
```

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
