### PR TITLE
tests: wrong pid path when running jobs greater than 1.

### DIFF
--- a/t/157-socket-keepalive-hup.t
+++ b/t/157-socket-keepalive-hup.t
@@ -32,7 +32,8 @@ __DATA__
         set $port $TEST_NGINX_SERVER_PORT;
 
         content_by_lua_block {
-            local f, err = io.open("$TEST_NGINX_SERVER_ROOT/logs/nginx.pid", "r")
+            local pidfile = ngx.config.prefix() .. "/logs/nginx.pid"
+            local f, err = io.open(pidfile, "r")
             if not f then
                 ngx.say("failed to open nginx.pid: ", err)
                 return


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
