### PR TITLE
tests: skip test cases for unsupported event types.

### DIFF
--- a/t/082-body-filter-2.t
+++ b/t/082-body-filter-2.t
@@ -1,12 +1,19 @@
 # vim:set ft= ts=4 sw=4 et fdm=marker:
 
+our $SkipReason;
+
 BEGIN {
-    $ENV{TEST_NGINX_POSTPONE_OUTPUT} = 1;
-    $ENV{TEST_NGINX_EVENT_TYPE} = 'poll';
-    $ENV{MOCKEAGAIN}='w'
+    if ($ENV{TEST_NGINX_EVENT_TYPE} && $ENV{TEST_NGINX_EVENT_TYPE} ne 'poll') {
+        $SkipReason = "unavailable for the event type '$ENV{TEST_NGINX_EVENT_TYPE}'";
+
+    } else {
+        $ENV{TEST_NGINX_POSTPONE_OUTPUT} = 1;
+        $ENV{TEST_NGINX_EVENT_TYPE} = 'poll';
+        $ENV{MOCKEAGAIN}='w'
+    }
 }
 
-use Test::Nginx::Socket::Lua;
+use Test::Nginx::Socket::Lua $SkipReason ? (skip_all => $SkipReason) : ();
 
 #worker_connections(1014);
 #master_process_enabled(1);

--- a/t/166-worker-thread.t
+++ b/t/166-worker-thread.t
@@ -1,6 +1,16 @@
 # vim:set ft= ts=4 sw=4 et fdm=marker:
 
-use Test::Nginx::Socket::Lua;
+our $SkipReason;
+
+BEGIN {
+    if ($ENV{TEST_NGINX_EVENT_TYPE}
+        && $ENV{TEST_NGINX_EVENT_TYPE} !~ /^kqueue|epoll|eventport$/)
+    {
+        $SkipReason = "unavailable for the event type '$ENV{TEST_NGINX_EVENT_TYPE}'";
+    }
+}
+
+use Test::Nginx::Socket::Lua $SkipReason ? (skip_all => $SkipReason) : ();
 
 #worker_connections(1014);
 #master_on();


### PR DESCRIPTION
* skip test cases for t/082-body-filter-2.t when the event type is not
'poll'.
* skip test cases for t/166-worker-thread.t when the event do not support
worker thread.



I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.