### PR TITLE
bugfix: forgot to clean cached thread contexts when worker process exit.

### DIFF
--- a/src/ngx_http_lua_exitworkerby.c
+++ b/src/ngx_http_lua_exitworkerby.c
@@ -13,6 +13,10 @@
 #include "ngx_http_lua_exitworkerby.h"
 #include "ngx_http_lua_util.h"
 
+#if (NGX_THREADS)
+#include "ngx_http_lua_worker_thread.h"
+#endif
+
 
 void
 ngx_http_lua_exit_worker(ngx_cycle_t *cycle)
@@ -22,6 +26,10 @@ ngx_http_lua_exit_worker(ngx_cycle_t *cycle)
     ngx_http_request_t          *r = NULL;
     ngx_http_lua_ctx_t          *ctx;
     ngx_http_conf_ctx_t         *conf_ctx;
+
+#if (NGX_THREADS)
+    ngx_http_lua_thread_exit_process();
+#endif
 
     lmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_lua_module);
     if (lmcf == NULL

--- a/src/ngx_http_lua_worker_thread.c
+++ b/src/ngx_http_lua_worker_thread.c
@@ -48,14 +48,14 @@ static  ngx_uint_t                worker_thread_vm_count;
 void
 ngx_http_lua_thread_exit_process(void)
 {
-   ngx_http_lua_task_ctx_t  *ctx;
+    ngx_http_lua_task_ctx_t  *ctx;
 
-   while (ctxpool->next != NULL) {
-       ctx = ctxpool->next;
-       ctxpool->next = ctx->next;
-       lua_close(ctx->vm);
-       ngx_free(ctx);
-   }
+    while (ctxpool->next != NULL) {
+        ctx = ctxpool->next;
+        ctxpool->next = ctx->next;
+        lua_close(ctx->vm);
+        ngx_free(ctx);
+    }
 }
 
 

--- a/src/ngx_http_lua_worker_thread.c
+++ b/src/ngx_http_lua_worker_thread.c
@@ -45,6 +45,20 @@ static  ngx_http_lua_task_ctx_t  *ctxpool = &dummy_ctx;
 static  ngx_uint_t                worker_thread_vm_count;
 
 
+void
+ngx_http_lua_thread_exit_process(void)
+{
+   ngx_http_lua_task_ctx_t  *ctx;
+
+   while (ctxpool->next != NULL) {
+       ctx = ctxpool->next;
+       ctxpool->next = ctx->next;
+       lua_close(ctx->vm);
+       ngx_free(ctx);
+   }
+}
+
+
 /*
  * Re-implement ngx_thread_task_alloc to avoid alloc from request pool
  * since the request may exit before worker thread finish.

--- a/src/ngx_http_lua_worker_thread.h
+++ b/src/ngx_http_lua_worker_thread.h
@@ -13,6 +13,7 @@
 
 
 void ngx_http_lua_inject_worker_thread_api(ngx_log_t *log, lua_State *L);
+void ngx_http_lua_thread_exit_process(void);
 
 
 #endif /* _NGX_HTTP_LUA_WORKER_THREAD_H_INCLUDED_ */


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
