### PR TITLE
tests: 132-lua-blocks.t and 158-global-var.t: use RegExp instead of strict character match.

### DIFF
--- a/t/132-lua-blocks.t
+++ b/t/132-lua-blocks.t
@@ -312,7 +312,7 @@ hello, world
 [error]
 --- must_die
 --- error_log eval
-qr/\[emerg\] .*? Lua code block missing the closing long bracket "]]", the inlined Lua code may be too long in .*?\bnginx\.conf:41/
+qr/\[emerg\] .*? Lua code block missing the closing long bracket "]]", the inlined Lua code may be too long in .*?\bnginx\.conf:\d+/
 
 
 
@@ -331,7 +331,7 @@ hello, world
 [error]
 --- must_die
 --- error_log eval
-qr/\[emerg\] .*? Lua code block missing the closing long bracket "]==]", the inlined Lua code may be too long in .*?\bnginx.conf:41/
+qr/\[emerg\] .*? Lua code block missing the closing long bracket "]==]", the inlined Lua code may be too long in .*?\bnginx.conf:\d+/
 
 
 
@@ -350,7 +350,7 @@ hello, world
 [error]
 --- must_die
 --- error_log eval
-qr/\[emerg\] .*? Lua code block missing the closing long bracket "]]", the inlined Lua code may be too long in .*?\bnginx\.conf:41/
+qr/\[emerg\] .*? Lua code block missing the closing long bracket "]]", the inlined Lua code may be too long in .*?\bnginx\.conf:\d+/
 
 
 
@@ -369,7 +369,7 @@ hello, world
 [error]
 --- must_die
 --- error_log eval
-qr/\[emerg\] .*? Lua code block missing the closing long bracket "]=]", the inlined Lua code may be too long in .*?\bnginx\.conf:41/
+qr/\[emerg\] .*? Lua code block missing the closing long bracket "]=]", the inlined Lua code may be too long in .*?\bnginx\.conf:\d+/
 
 
 
@@ -640,4 +640,4 @@ hello, world
 [error]
 --- must_die
 --- error_log eval
-qr/\[emerg\] .*? Lua code block missing the closing long bracket "]]", the inlined Lua code may be too long in .*?\bnginx\.conf:41/
+qr/\[emerg\] .*? Lua code block missing the closing long bracket "]]", the inlined Lua code may be too long in .*?\bnginx\.conf:\d+/

--- a/t/158-global-var.t
+++ b/t/158-global-var.t
@@ -86,7 +86,7 @@ set_by_lua:3: in main chunk, \n\z/, "old foo: 1\n"]
 qr/(old foo: \d+|\[\w+\].*?writing a global Lua variable \('[^'\s]+'\)|\w+_by_lua\(.*?\):\d+: in main chunk, )/
 --- grep_error_log_out eval
 [qr/\A\[warn\] .*?writing a global Lua variable \('foo'\)
-rewrite_by_lua\(nginx\.conf:48\):3: in main chunk, \n\z/, "old foo: 1\n"]
+rewrite_by_lua\(nginx\.conf:\d+\):\d+: in main chunk, \n\z/, "old foo: 1\n"]
 
 
 
@@ -109,7 +109,7 @@ rewrite_by_lua\(nginx\.conf:48\):3: in main chunk, \n\z/, "old foo: 1\n"]
 qr/(old foo: \d+|\[\w+\].*?writing a global Lua variable \('[^'\s]+'\)|\w+_by_lua\(.*?\):\d+: in main chunk, )/
 --- grep_error_log_out eval
 [qr/\A\[warn\] .*?writing a global Lua variable \('foo'\)
-access_by_lua\(nginx\.conf:48\):3: in main chunk, \n\z/, "old foo: 1\n"]
+access_by_lua\(nginx\.conf:\d+\):\d+: in main chunk, \n\z/, "old foo: 1\n"]
 
 
 
@@ -132,7 +132,7 @@ access_by_lua\(nginx\.conf:48\):3: in main chunk, \n\z/, "old foo: 1\n"]
 qr/(old foo: \d+|\[\w+\].*?writing a global Lua variable \('[^'\s]+'\)|\w+_by_lua\(.*?\):\d+: in main chunk, )/
 --- grep_error_log_out eval
 [qr/\A\[warn\] .*?writing a global Lua variable \('foo'\)
-content_by_lua\(nginx\.conf:48\):3: in main chunk, \n\z/, "old foo: 1\n"]
+content_by_lua\(nginx\.conf:\d+\):\d+: in main chunk, \n\z/, "old foo: 1\n"]
 
 
 
@@ -179,10 +179,10 @@ header_filter_by_lua:3: in main chunk, \n\z/, "old foo: 1\n"]
 --- response_body_like chomp
 \A(?:nil|2)\n\z
 --- grep_error_log eval
-qr/(old foo: \d+|\[\w+\].*?writing a global Lua variable \('[^'\s]+'\)|\w+_by_lua:\d+: in main chunk, )/
+qr/(old foo: \d+|\[\w+\].*?writing a global Lua variable \('[^'\s]+'\)|\w+_by_lua:\d+: in main chunk,)/
 --- grep_error_log_out eval
 [qr/\[warn\] .*?writing a global Lua variable \('foo'\)
-body_filter_by_lua:3: in main chunk, 
+body_filter_by_lua:3: in main chunk,
 old foo: 1\n\z/, "old foo: 2\nold foo: 3\n"]
 
 
@@ -208,7 +208,7 @@ old foo: 1\n\z/, "old foo: 2\nold foo: 3\n"]
 qr/(old foo: \d+|\[\w+\].*?writing a global Lua variable \('[^'\s]+'\)|\w+_by_lua\(.*?\):\d+: in main chunk)/
 --- grep_error_log_out eval
 [qr/\A\[warn\] .*?writing a global Lua variable \('foo'\)
-log_by_lua\(nginx\.conf:50\):3: in main chunk\n\z/, "old foo: 1\n"]
+log_by_lua\(nginx\.conf:\d+\):\d+: in main chunk\n\z/, "old foo: 1\n"]
 
 
 
@@ -331,7 +331,7 @@ ssl_certificate_by_lua:3: in main chunk\n\z/, "old foo: 1\n"]
 qr/(old foo: \d+|\[\w+\].*?writing a global Lua variable \('[^'\s]+'\)|\w+_by_lua\(.*?\):\d+: in\b)/
 --- grep_error_log_out eval
 [qr/\A\[warn\] .*?writing a global Lua variable \('foo'\)
-content_by_lua\(nginx\.conf:56\):4: in\n\z/, "old foo: 1\n"]
+content_by_lua\(nginx\.conf:\d+\):\d+: in\n\z/, "old foo: 1\n"]
 
 
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.