### PR TITLE
tests: NGINX_TEST_CHECK_LEAK detects memoryleak because nginx can not…

### DIFF
--- a/t/127-uthread-kill.t
+++ b/t/127-uthread-kill.t
@@ -139,6 +139,7 @@ lua clean up the timer for pending ngx.sleep
 === TEST 3: kill pending resolver
 --- config
     resolver 127.0.0.2:12345;
+    resolver_timeout 5ms;
     location /lua {
         content_by_lua '
             local function f()


### PR DESCRIPTION
… free resolver ctx quickly.

This was introduce in commit acd53645754ce which is use to resovle double free of resolver ctx.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
