### PR TITLE
feature: expose the 'Last-Modified' response header as ngx.header["Last-Modified"].

### DIFF
--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -1137,7 +1137,6 @@ ngx_http_lua_ffi_get_resp_header(ngx_http_request_t *r,
 
     case 13:
         if (ngx_strncasecmp(key_buf, (u_char *) "Last-Modified", 13) == 0) {
-
             last_modified = r->headers_out.last_modified_time;
             if (last_modified >= 0) {
                 p = ngx_palloc(r->pool,

--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -1068,6 +1068,7 @@ ngx_http_lua_ffi_get_resp_header(ngx_http_request_t *r,
 {
     int                  found;
     u_char               c, *p;
+    time_t               last_modified;
     ngx_uint_t           i;
     ngx_table_elt_t     *h;
     ngx_list_part_t     *part;
@@ -1132,6 +1133,21 @@ ngx_http_lua_ffi_get_resp_header(ngx_http_request_t *r,
             return 1;
         }
 
+        break;
+
+    case 13:
+        last_modified = r->headers_out.last_modified_time;
+        if (last_modified >= 0) {
+            p = ngx_palloc(r->pool, sizeof("Mon, 28 Sep 1970 06:00:00 GMT"));
+            if (p == NULL) {
+                *errmsg = "no memory";
+                return NGX_ERROR;
+            }
+
+            values[0].data = p;
+            values[0].len = ngx_http_time(p, last_modified) - p;
+            return 1;
+        }
         break;
 
     default:

--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -1148,6 +1148,7 @@ ngx_http_lua_ffi_get_resp_header(ngx_http_request_t *r,
             values[0].len = ngx_http_time(p, last_modified) - p;
             return 1;
         }
+
         break;
 
     default:

--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -1136,17 +1136,24 @@ ngx_http_lua_ffi_get_resp_header(ngx_http_request_t *r,
         break;
 
     case 13:
-        last_modified = r->headers_out.last_modified_time;
-        if (last_modified >= 0) {
-            p = ngx_palloc(r->pool, sizeof("Mon, 28 Sep 1970 06:00:00 GMT"));
-            if (p == NULL) {
-                *errmsg = "no memory";
-                return NGX_ERROR;
+        if (ngx_strncasecmp(key_buf, (u_char *) "Last-Modified", 13) == 0) {
+
+            last_modified = r->headers_out.last_modified_time;
+            if (last_modified >= 0) {
+                p = ngx_palloc(r->pool,
+                               sizeof("Mon, 28 Sep 1970 06:00:00 GMT"));
+                if (p == NULL) {
+                    *errmsg = "no memory";
+                    return NGX_ERROR;
+                }
+
+                values[0].data = p;
+                values[0].len = ngx_http_time(p, last_modified) - p;
+
+                return 1;
             }
 
-            values[0].data = p;
-            values[0].len = ngx_http_time(p, last_modified) - p;
-            return 1;
+            return 0;
         }
 
         break;

--- a/t/016-resp-header.t
+++ b/t/016-resp-header.t
@@ -2148,7 +2148,15 @@ upstream prematurely closed connection while sending to client
 --- config
     location /a.txt {
         header_filter_by_lua_block {
-            local last_mod = ngx.parse_http_time(ngx.header["Last-Modified"])
+            local last_modified = ngx.header["Last-Modified"]
+            if last_modified == nil then
+                ngx.log(ngx.ERR, "can not get lasted modified")
+                ngx.exit(500)
+                return
+            end
+
+
+            local last_mod = ngx.parse_http_time(last_modified)
             local age = ngx.time() - last_mod
             ngx.header["Age"] = age
         }
@@ -2158,6 +2166,37 @@ upstream prematurely closed connection while sending to client
 Foo
 --- request
 GET /a.txt
+--- raw_response_headers_like chomp
+Age: \d\r\n
+--- no_error_log
+[error]
+
+
+
+=== TEST 96: Expose the 'Last-Modified' response header as ngx.header["Last-Modified"]
+--- config
+    location /test/ {
+        proxy_pass http://127.0.0.1:$server_port/;
+
+        header_filter_by_lua_block {
+            local last_modified = ngx.header["Last-Modified"]
+            if last_modified == nil then
+                ngx.log(ngx.ERR, "can not get lasted modified")
+                ngx.exit(500)
+                return
+            end
+
+            local last_mod = ngx.parse_http_time(last_modified)
+            local age = ngx.time() - last_mod
+            ngx.header["Age"] = age
+        }
+    }
+
+--- user_files
+>>> a.txt
+Foo
+--- request
+GET /test/a.txt
 --- raw_response_headers_like chomp
 Age: \d\r\n
 --- no_error_log

--- a/t/016-resp-header.t
+++ b/t/016-resp-header.t
@@ -2141,3 +2141,24 @@ hi
 --- error_log
 my Content-Length: 8589934591
 upstream prematurely closed connection while sending to client
+
+
+
+=== TEST 95: Expose the 'Last-Modified' response header as ngx.header["Last-Modified"]
+--- config
+    location /a.txt {
+        header_filter_by_lua_block {
+            local last_mod = ngx.parse_http_time(ngx.header["Last-Modified"])
+            local age = ngx.time() - last_mod
+            ngx.header["Age"] = age
+        }
+    }
+--- user_files
+>>> a.txt
+Foo
+--- request
+GET /a.txt
+--- raw_response_headers_like chomp
+Age: \d\r\n
+--- no_error_log
+[error]


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.


the original PR is https://github.com/openresty/lua-nginx-module/pull/1384.
the ngx.header was rewrite via ffi. So need to rewrite this feature.