### PR TITLE
tests: fixed ngx-releng missing ack dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ compiler:
 addons:
   apt:
     packages:
+      - ack
       - axel
       - cpanminus
       - libtest-base-perl


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
