### PR TITLE
bugfix: forgot to close pipe after dup2.

### DIFF
--- a/src/ngx_http_lua_pipe.c
+++ b/src/ngx_http_lua_pipe.c
@@ -773,6 +773,12 @@ ngx_http_lua_ffi_pipe_spawn(ngx_http_lua_ffi_pipe_proc_t *proc,
             }
         }
 
+        close(in[0]);
+        close(out[1]);
+        if (!merge_stderr) {
+            close(err[1]);
+        }
+
         if (environ != NULL) {
 #if (NGX_HTTP_LUA_HAVE_EXECVPE)
             if (execvpe(file, (char * const *) argv, (char * const *) environ)


### PR DESCRIPTION
when ngx.pipe starts a daemon process, the pipes will
be inherited by the daemon process.And ngx.pipe will
wait for reading until timeout.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
