### PR TITLE
Fix segfault for malformed requests

### DIFF
--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -171,7 +171,7 @@ ngx_http_lua_ngx_req_raw_header(lua_State *L)
         && mr->request_line.data[mr->request_line.len] == CR)
     {
         line_break_len = 2;
-        
+
     } else {
         line_break_len = 1;
     }

--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -169,7 +169,7 @@ ngx_http_lua_ngx_req_raw_header(lua_State *L)
 
     if ( mr->request_line.len <= 0 ) {
         line_break_len = 0;
-        
+
     } else if ( mr->request_line.data[mr->request_line.len] == CR) {
         line_break_len = 2;
 

--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -167,12 +167,10 @@ ngx_http_lua_ngx_req_raw_header(lua_State *L)
     size = 0;
     b = c->buffer;
 
-    if ( mr->request_line.len <= 0 ) {
-        line_break_len = 0;
-
-    } else if ( mr->request_line.data[mr->request_line.len] == CR) {
+    if (mr->request_line.len > 0
+        && mr->request_line.data[mr->request_line.len] == CR)
+    {
         line_break_len = 2;
-
     } else {
         line_break_len = 1;
     }

--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -167,9 +167,13 @@ ngx_http_lua_ngx_req_raw_header(lua_State *L)
     size = 0;
     b = c->buffer;
 
-    if (mr->request_line.len > 0
-        && mr->request_line.data[mr->request_line.len] == CR)
-    {
+    if (mr->request_line.len == 0) {
+        /* return empty string on invalid request */
+        lua_pushlstring(L, "", 0);
+        return 1;
+    }
+
+    if (mr->request_line.data[mr->request_line.len] == CR) {
         line_break_len = 2;
 
     } else {

--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -171,6 +171,7 @@ ngx_http_lua_ngx_req_raw_header(lua_State *L)
         && mr->request_line.data[mr->request_line.len] == CR)
     {
         line_break_len = 2;
+        
     } else {
         line_break_len = 1;
     }

--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -167,7 +167,7 @@ ngx_http_lua_ngx_req_raw_header(lua_State *L)
     size = 0;
     b = c->buffer;
 
-    if (mr->request_line.data[mr->request_line.len] == CR) {
+    if (mr->request_line.len>0 && mr->request_line.data[mr->request_line.len] == CR) {
         line_break_len = 2;
 
     } else {

--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -167,8 +167,10 @@ ngx_http_lua_ngx_req_raw_header(lua_State *L)
     size = 0;
     b = c->buffer;
 
-    if (mr->request_line.len>0 &&
-        mr->request_line.data[mr->request_line.len] == CR) {
+    if ( mr->request_line.len <= 0 ) {
+        line_break_len = 0;
+        
+    } else if ( mr->request_line.data[mr->request_line.len] == CR) {
         line_break_len = 2;
 
     } else {

--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -167,7 +167,8 @@ ngx_http_lua_ngx_req_raw_header(lua_State *L)
     size = 0;
     b = c->buffer;
 
-    if (mr->request_line.len>0 && mr->request_line.data[mr->request_line.len] == CR) {
+    if (mr->request_line.len>0 &&
+        mr->request_line.data[mr->request_line.len] == CR) {
         line_break_len = 2;
 
     } else {

--- a/t/104-req-raw-header.t
+++ b/t/104-req-raw-header.t
@@ -1017,3 +1017,36 @@ client sent invalid header line: "\x20..." while reading client request headers
 [error]
 --- skip_nginx
 3: < 1.21.1
+
+
+
+=== TEST 35: bugfix: invalid http request
+--- log_level: error
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;;";
+--- config
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            local ok, err = sock:connect("127.0.0.1", $TEST_NGINX_SERVER_PORT)
+            if not ok then
+                ngx.log(ngx.ERR, "failed to connect to memc: ", err)
+                return
+            end
+            sock:send("\n")
+            sock:close()
+
+            ngx.say("OK")
+        }
+    }
+
+    log_by_lua_block {
+        local h = ngx.req.raw_header()
+    }
+
+--- request
+GET /t
+--- response_body
+OK
+--- no_error_log
+[error]


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

This PR fixes issue #2001 

Unit test results:
```
# cd /home/openresty-*/bundle/ngx_lua-*
# prove t/104-req-raw-header.t
t/104-req-raw-header.t .. ok       
All tests successful.
Files=1, Tests=234,  6 wallclock secs ( 0.06 usr  0.01 sys +  0.67 cusr  0.30 csys =  1.04 CPU)
Result: PASS
```