### PR TITLE
bugfix: the error message should use the first line rather than the last line of the code block when load lua code block failed.

### DIFF
--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -276,6 +276,8 @@ struct ngx_http_lua_main_conf_s {
                                                 of requests */
     ngx_uint_t           malloc_trim_req_count;
 
+    ngx_uint_t           directive_line;
+
 #if (nginx_version >= 1011011)
     /* the following 2 fields are only used by ngx.req.raw_headers() for now */
     ngx_buf_t          **busy_buf_ptrs;

--- a/src/ngx_http_lua_directive.c
+++ b/src/ngx_http_lua_directive.c
@@ -1332,7 +1332,8 @@ ngx_http_lua_gen_chunk_name(ngx_conf_t *cf, const char *tag, size_t tag_len,
 found:
 
     lmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_lua_module);
-    start_line = lmcf->directive_line ? : cf->conf_file->line;
+    start_line = lmcf->directive_line > 0
+        ? lmcf->directive_line : cf->conf_file->line;
 
     p = ngx_snprintf(out, len, "=%*s(%*s:%d)%Z",
                      tag_len, tag, cf->conf_file->file.name.data

--- a/t/002-content.t
+++ b/t/002-content.t
@@ -10,7 +10,7 @@ use Test::Nginx::Socket::Lua;
 repeat_each(2);
 #repeat_each(1);
 
-plan tests => repeat_each() * (blocks() * 2 + 24);
+plan tests => repeat_each() * (blocks() * 2 + 27);
 
 #no_diff();
 #no_long_string();

--- a/t/002-content.t
+++ b/t/002-content.t
@@ -849,4 +849,71 @@ GET /lua
 --- response_body_like: 500 Internal Server Error
 --- error_code: 500
 --- error_log eval
-qr/failed to load inlined Lua code: /
+qr/failed to load inlined Lua code: content_by_lua\(nginx.conf:40\)/
+
+
+
+=== TEST 43: syntax error in content_by_lua_block
+--- config
+    location /lua {
+
+        content_by_lua_block {
+            'for end';
+        }
+    }
+--- request
+GET /lua
+--- response_body_like: 500 Internal Server Error
+--- error_code: 500
+--- error_log eval
+qr/failed to load inlined Lua code: content_by_lua\(nginx.conf:41\)/
+
+
+
+=== TEST 44: syntax error in second content_by_lua_block
+--- config
+    location /foo {
+        content_by_lua_block {
+            'for end';
+        }
+    }
+
+    location /lua {
+        content_by_lua_block {
+            'for end';
+        }
+    }
+--- request
+GET /lua
+--- response_body_like: 500 Internal Server Error
+--- error_code: 500
+--- error_log eval
+qr/failed to load inlined Lua code: content_by_lua\(nginx.conf:46\)/
+
+
+
+=== TEST 45: syntax error in thrid content_by_lua_block
+--- config
+    location /foo {
+        content_by_lua_block {
+            'for end';
+        }
+    }
+
+    location /bar {
+        content_by_lua_block {
+            'for end';
+        }
+    }
+
+    location /lua {
+        content_by_lua_block {
+            'for end';
+        }
+    }
+--- request
+GET /lua
+--- response_body_like: 500 Internal Server Error
+--- error_code: 500
+--- error_log eval
+qr/failed to load inlined Lua code: content_by_lua\(nginx.conf:52\)/


### PR DESCRIPTION

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
