### PR TITLE
feat: cosocket use mem pool

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -6113,12 +6113,12 @@ ngx_http_lua_tcp_resolve_cleanup(void *data)
         ngx_http_lua_socket_tcp_resume_conn_op(u->socket_pool);
     }
 
-    rctx = u->resolved->ctx;
     if (u->pool) {
         ngx_destroy_pool(u->pool);
         u->pool = NULL;
     }
 
+    rctx = u->resolved->ctx;
     if (rctx == NULL) {
         return;
     }

--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -6113,12 +6113,12 @@ ngx_http_lua_tcp_resolve_cleanup(void *data)
         ngx_http_lua_socket_tcp_resume_conn_op(u->socket_pool);
     }
 
+    rctx = u->resolved->ctx;
     if (u->pool) {
         ngx_destroy_pool(u->pool);
         u->pool = NULL;
     }
 
-    rctx = u->resolved->ctx;
     if (rctx == NULL) {
         return;
     }

--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -4175,9 +4175,13 @@ ngx_http_lua_socket_tcp_finalize(ngx_http_request_t *r,
         return;
     }
 
-    if (u->resolved && u->resolved->ctx) {
-        ngx_resolve_name_done(u->resolved->ctx);
-        u->resolved->ctx = NULL;
+    if (u->resolved) {
+        if (u->resolved->ctx) {
+            ngx_resolve_name_done(u->resolved->ctx);
+            u->resolved->ctx = NULL;
+        }
+
+        u->resolved = NULL;
     }
 
     if (u->peer.free) {

--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -6114,6 +6114,11 @@ ngx_http_lua_tcp_resolve_cleanup(void *data)
     }
 
     rctx = u->resolved->ctx;
+    if (u->pool) {
+        ngx_destroy_pool(u->pool);
+        u->pool = NULL;
+    }
+
     if (rctx == NULL) {
         return;
     }

--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -645,6 +645,10 @@ ngx_http_lua_socket_tcp_connect_helper(lua_State *L,
 
     } /* end spool != NULL */
 
+    if (!u->pool) {
+        u->pool = ngx_create_pool(128, r->connection->log);
+    }
+
     host.data = ngx_palloc(u->pool, host_len + 1);
     if (host.data == NULL) {
         return luaL_error(L, "no memory");
@@ -1117,10 +1121,6 @@ ngx_http_lua_socket_tcp_connect(lua_State *L)
         ngx_http_lua_socket_tcp_create_socket_pool(L, r, key, pool_size,
                                                    backlog, &spool);
         u->socket_pool = spool;
-    }
-
-    if (!u->pool) {
-        u->pool = ngx_create_pool(128, r->connection->log);
     }
 
     return ngx_http_lua_socket_tcp_connect_helper(L, u, r, ctx, p,

--- a/src/ngx_http_lua_socket_tcp.h
+++ b/src/ngx_http_lua_socket_tcp.h
@@ -91,6 +91,7 @@ struct ngx_http_lua_socket_tcp_upstream_s {
     ngx_http_cleanup_pt             *cleanup;
     ngx_http_request_t              *request;
     ngx_peer_connection_t            peer;
+    ngx_pool_t                      *pool;
 
     ngx_msec_t                       read_timeout;
     ngx_msec_t                       send_timeout;


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

**# Why do we need this PR?**
When we use Cosocket in a long connection, the memory used to establish a new connection at the back end is not immediately freed, causing memory to continue to grow until the long connection is disconnected.
Fix this problem by using the pool of new links to free up memory when new links break


The demo will not leak memory
```
location = /{
                content_by_lua_block {
                for i = 0, 0xffffffff do
                    local sock = ngx.socket.tcp()
                    local ok, err = sock:connect("127.0.0.1", 12345)
                    if not ok then
                        ngx.log(ngx.INFO, "failed to connect to peer: ", err)
                    end
                    local ok = sock:receive("*l")
                    assert(ok == "OK")
                    sock:close()
                end
            }
        }
```