### PR TITLE
fix potential null pointer dereference found by Coverity

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -1730,7 +1730,7 @@ ngx_http_lua_ffi_socket_tcp_sslhandshake(ngx_http_request_t *r,
 #endif
     }
 
-    if (server_name != NULL && server_name->len == 0) {
+    if (server_name == NULL || server_name->len == 0) {
         u->ssl_name.len = 0;
 
     } else {

--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -1730,7 +1730,7 @@ ngx_http_lua_ffi_socket_tcp_sslhandshake(ngx_http_request_t *r,
 #endif
     }
 
-    if (server_name->len == 0) {
+    if (server_name != NULL && server_name->len == 0) {
         u->ssl_name.len = 0;
 
     } else {


### PR DESCRIPTION

```
*** CID 352757:  Null pointer dereferences  (FORWARD_NULL)
/src/ngx_http_lua_socket_tcp.c: 1733 in
ngx_http_lua_ffi_socket_tcp_sslhandshake()
1727     #else
1728             *errmsg = "no OCSP support";
1729             return NGX_ERROR;
1730     #endif
1731         }
1732
>>>     CID 352757:  Null pointer dereferences  (FORWARD_NULL)
>>>     Dereferencing null pointer "server_name".
1733         if (server_name->len == 0) {
1734             u->ssl_name.len = 0;
1735
1736         } else {
1737             if (u->ssl_name.data) {
1738                 /* buffer already allocated */
```

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
