### PR TITLE
bugfix: wrong memory size for the pernding timers array.

### DIFF
--- a/src/ngx_http_lua_timer.c
+++ b/src/ngx_http_lua_timer.c
@@ -821,7 +821,7 @@ ngx_http_lua_abort_pending_timers(ngx_event_t *ev)
     prev = NULL;
 
     events = ngx_pcalloc(ngx_cycle->pool,
-                         lmcf->pending_timers * sizeof(ngx_event_t));
+                         lmcf->pending_timers * sizeof(ngx_event_t *));
     if (events == NULL) {
         return;
     }


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
