### PR TITLE
fix potential null pointer dereference found by coverity

### DIFF
--- a/src/ngx_http_lua_pipe.c
+++ b/src/ngx_http_lua_pipe.c
@@ -1141,7 +1141,7 @@ ngx_http_lua_pipe_get_lua_ctx(ngx_http_request_t *r,
     int                                 rc;
 
     *ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
-    if (ctx == NULL) {
+    if (*ctx == NULL) {
         return NGX_HTTP_LUA_FFI_NO_REQ_CTX;
     }
 


### PR DESCRIPTION
```
    deref_ptr: Directly dereferencing pointer ctx.
1143    *ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
    CID 258020 (#1 of 1): Dereference before null check (REVERSE_INULL)check_after_deref: Null-checking ctx suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
1144    if (ctx == NULL) {
1145        return NGX_HTTP_LUA_FFI_NO_REQ_CTX;
1146    }

```
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
