### PR TITLE
doc: add more explanation for premature in ngx.timer.at.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8749,7 +8749,7 @@ be any Lua function, which will be invoked later in a background
 called automatically by the Nginx core with the arguments `premature`,
 `user_arg1`, `user_arg2`, and etc, where the `premature`
 argument takes a boolean value indicating whether it is a premature timer
-expiration or not, and `user_arg1`, `user_arg2`, and etc, are
+expiration or not, but it will never be `true` for a `0` delay timer, and `user_arg1`, `user_arg2`, and etc, are
 those (extra) user arguments specified when calling `ngx.timer.at`
 as the remaining arguments.
 

--- a/README.markdown
+++ b/README.markdown
@@ -8749,7 +8749,7 @@ be any Lua function, which will be invoked later in a background
 called automatically by the Nginx core with the arguments `premature`,
 `user_arg1`, `user_arg2`, and etc, where the `premature`
 argument takes a boolean value indicating whether it is a premature timer
-expiration or not, but it will never be `true` for a `0` delay timer, and `user_arg1`, `user_arg2`, and etc, are
+expiration or not, but it will always be `false` for a `0` delay timer, and `user_arg1`, `user_arg2`, and etc, are
 those (extra) user arguments specified when calling `ngx.timer.at`
 as the remaining arguments.
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
