### PR TITLE
doc: add detail on explanation of a running timer

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3529,7 +3529,7 @@ lua_max_running_timers
 
 Controls the maximum number of "running timers" allowed.
 
-Running timers are those timers whose user callback functions are still running.
+Running timers are those timers whose user callback functions are still running or `lightthreads` spawned in callback functions are still running.
 
 When exceeding this limit, Nginx will stop running the callbacks of newly expired timers and log an error message "N lua_max_running_timers are not enough" where "N" is the current value of this directive.
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

Consider the following example:
```lua
local function print_tm()
    print("Running: ", ngx.timer.running_count(), " Pending: ", ngx.timer.pending_count())
end

print("init")
print_tm()

local function spawn()
    local t1 = ngx.thread.spawn(function()
        ngx.sleep(5)
        print("t1 done")
        return "t1"
    end)

    local t2 = ngx.thread.spawn(function()
        ngx.sleep(1)
        print("t2 done")
        return "t2"
    end)


    local wait = function()
        local w = ngx.thread.wait(t1, t2)
        print("wait returned: ", w)
    end
    print("before spawn")
    print_tm()

    return wait
end

ngx.timer.at(0, function()
     spawn()()
     print("exit")
end)

print("after timer.at")
print_tm()

while true do
    print_tm()
    ngx.sleep(1)
end
```

The timer's callback functions looks like "exited", but the timer is still running until threads are terminated.