### PR TITLE
bugfix: add a timed recycling child process as a last resort.

### DIFF
--- a/src/ngx_http_lua_pipe.c
+++ b/src/ngx_http_lua_pipe.c
@@ -78,12 +78,15 @@ static void ngx_http_lua_pipe_proc_read_stdout_cleanup(void *data);
 static void ngx_http_lua_pipe_proc_read_stderr_cleanup(void *data);
 static void ngx_http_lua_pipe_proc_write_cleanup(void *data);
 static void ngx_http_lua_pipe_proc_wait_cleanup(void *data);
+static void ngx_http_lua_pipe_reap_pids(ngx_event_t *ev);
+static void ngx_http_lua_pipe_reap_timer_handler(ngx_event_t *ev);
 void ngx_http_lua_ffi_pipe_proc_destroy(
     ngx_http_lua_ffi_pipe_proc_t *proc);
 
 
 static ngx_rbtree_t       ngx_http_lua_pipe_rbtree;
 static ngx_rbtree_node_t  ngx_http_lua_pipe_proc_sentinel;
+static ngx_event_t        ngx_reap_pid_event;
 
 
 #if (NGX_HTTP_LUA_HAVE_SIGNALFD)
@@ -161,6 +164,16 @@ ngx_http_lua_pipe_add_signal_handler(ngx_cycle_t *cycle)
     int                  rc;
     struct sigaction     sa;
 #endif
+
+    ngx_reap_pid_event.handler = ngx_http_lua_pipe_reap_timer_handler;
+    ngx_reap_pid_event.log = cycle->log;
+    ngx_reap_pid_event.data = cycle;
+    ngx_reap_pid_event.cancelable = 1;
+
+    if (!ngx_reap_pid_event.timer_set) {
+        ngx_add_timer(&ngx_reap_pid_event, 1000);
+        ngx_reap_pid_event.timer_set = 1;
+    }
 
 #if (NGX_HTTP_LUA_HAVE_SIGNALFD)
     if (sigemptyset(&set) != 0) {
@@ -353,11 +366,7 @@ static void
 ngx_http_lua_pipe_sigchld_event_handler(ngx_event_t *ev)
 {
     int                              n;
-    int                              status;
-    ngx_pid_t                        pid;
     ngx_connection_t                *c = ev->data;
-    ngx_rbtree_node_t               *node;
-    ngx_http_lua_pipe_node_t        *pipe_node;
 
     ngx_log_debug0(NGX_LOG_DEBUG_EVENT, ngx_cycle->log, 0,
                    "lua pipe reaping children");
@@ -379,71 +388,96 @@ ngx_http_lua_pipe_sigchld_event_handler(ngx_event_t *ev)
             break;
         }
 
-        for ( ;; ) {
-            pid = waitpid(-1, &status, WNOHANG);
+        ngx_http_lua_pipe_reap_pids(ev);
+    }
+}
 
-            if (pid == 0) {
-                break;
+
+static void
+ngx_http_lua_pipe_reap_pids(ngx_event_t *ev)
+{
+    int                              status;
+    ngx_pid_t                        pid;
+    ngx_rbtree_node_t               *node;
+    ngx_http_lua_pipe_node_t        *pipe_node;
+
+    for ( ;; ) {
+        pid = waitpid(-1, &status, WNOHANG);
+
+        if (pid == 0) {
+            break;
+        }
+
+        if (pid < 0) {
+            if (ngx_errno != NGX_ECHILD) {
+                ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, ngx_errno,
+                              "lua pipe waitpid failed");
             }
 
-            if (pid < 0) {
-                if (ngx_errno != NGX_ECHILD) {
-                    ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, ngx_errno,
-                                  "lua pipe waitpid failed");
-                }
+            break;
+        }
 
-                break;
-            }
+        /* This log is ported from Nginx's signal handler since we override
+         * or block it in this implementation. */
+        ngx_log_error(NGX_LOG_NOTICE, ngx_cycle->log, 0,
+                      "signal %d (SIGCHLD) received from %P",
+                      SIGCHLD, pid);
 
-            /* This log is ported from Nginx's signal handler since we override
-             * or block it in this implementation. */
-            ngx_log_error(NGX_LOG_NOTICE, ngx_cycle->log, 0,
-                          "signal %d (SIGCHLD) received from %P",
-                          SIGCHLD, pid);
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                       "lua pipe SIGCHLD fd read pid:%P status:%d", pid,
+                       status);
 
-            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
-                           "lua pipe SIGCHLD fd read pid:%P status:%d", pid,
-                           status);
+        node = ngx_http_lua_pipe_lookup_pid(pid);
+        if (node != NULL) {
+            pipe_node = (ngx_http_lua_pipe_node_t *) &node->color;
+            if (pipe_node->wait_co_ctx != NULL) {
+                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                               "lua pipe resume process:%p waiting for %P",
+                               pipe_node->proc, pid);
 
-            node = ngx_http_lua_pipe_lookup_pid(pid);
-            if (node != NULL) {
-                pipe_node = (ngx_http_lua_pipe_node_t *) &node->color;
-                if (pipe_node->wait_co_ctx != NULL) {
-                    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
-                                   "lua pipe resume process:%p waiting for %P",
-                                   pipe_node->proc, pid);
-
-                    /*
-                     * We need the extra parentheses around the first argument
-                     * of ngx_post_event() just to work around macro issues in
-                     * nginx cores older than 1.7.12 (exclusive).
-                     */
-                    ngx_post_event((&pipe_node->wait_co_ctx->sleep),
-                                   &ngx_posted_events);
-                }
-
-                /* TODO: we should proactively close and free up the pipe after
-                 * the user consume all the data in the pipe.
+                /*
+                 * We need the extra parentheses around the first argument
+                 * of ngx_post_event() just to work around macro issues in
+                 * nginx cores older than 1.7.12 (exclusive).
                  */
-                pipe_node->proc->pipe->dead = 1;
+                ngx_post_event((&pipe_node->wait_co_ctx->sleep),
+                               &ngx_posted_events);
+            }
 
-                if (WIFSIGNALED(status)) {
-                    pipe_node->status = WTERMSIG(status);
-                    pipe_node->reason_code = REASON_SIGNAL_CODE;
+            /* TODO: we should proactively close and free up the pipe after
+             * the user consume all the data in the pipe.
+             */
+            pipe_node->proc->pipe->dead = 1;
 
-                } else if (WIFEXITED(status)) {
-                    pipe_node->status = WEXITSTATUS(status);
-                    pipe_node->reason_code = REASON_EXIT_CODE;
+            if (WIFSIGNALED(status)) {
+                pipe_node->status = WTERMSIG(status);
+                pipe_node->reason_code = REASON_SIGNAL_CODE;
 
-                } else {
-                    ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
-                                  "lua pipe unknown exit status %d from "
-                                  "process %P", status, pid);
-                    pipe_node->status = status;
-                    pipe_node->reason_code = REASON_UNKNOWN_CODE;
-                }
+            } else if (WIFEXITED(status)) {
+                pipe_node->status = WEXITSTATUS(status);
+                pipe_node->reason_code = REASON_EXIT_CODE;
+
+            } else {
+                ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
+                              "lua pipe unknown exit status %d from "
+                              "process %P", status, pid);
+                pipe_node->status = status;
+                pipe_node->reason_code = REASON_UNKNOWN_CODE;
             }
         }
+    }
+}
+
+
+static void
+ngx_http_lua_pipe_reap_timer_handler(ngx_event_t *ev)
+{
+    ngx_http_lua_pipe_reap_pids(ev);
+
+    if (!ngx_exiting) {
+        ngx_add_timer(&ngx_reap_pid_event, 1000);
+        ngx_reap_pid_event.timer_set = 1;
+        ngx_reap_pid_event.timedout = 0;
     }
 }
 

--- a/src/ngx_http_lua_pipe.c
+++ b/src/ngx_http_lua_pipe.c
@@ -172,7 +172,6 @@ ngx_http_lua_pipe_add_signal_handler(ngx_cycle_t *cycle)
 
     if (!ngx_reap_pid_event.timer_set) {
         ngx_add_timer(&ngx_reap_pid_event, 1000);
-        ngx_reap_pid_event.timer_set = 1;
     }
 
 #if (NGX_HTTP_LUA_HAVE_SIGNALFD)
@@ -476,7 +475,6 @@ ngx_http_lua_pipe_reap_timer_handler(ngx_event_t *ev)
 
     if (!ngx_exiting) {
         ngx_add_timer(&ngx_reap_pid_event, 1000);
-        ngx_reap_pid_event.timer_set = 1;
         ngx_reap_pid_event.timedout = 0;
     }
 }


### PR DESCRIPTION
We found that after running for a while, signalfd does not receive notifications.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
