### PR TITLE
bugfix: mixed recv api call causes unexpected result.

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -75,6 +75,8 @@ static void ngx_http_lua_socket_dummy_handler(ngx_http_request_t *r,
     ngx_http_lua_socket_tcp_upstream_t *u);
 static int ngx_http_lua_socket_tcp_receive_helper(ngx_http_request_t *r,
     ngx_http_lua_socket_tcp_upstream_t *u, lua_State *L);
+static void ngx_http_lua_socket_tcp_read_prepare(ngx_http_request_t *r,
+    ngx_http_lua_socket_tcp_upstream_t *u, void *data, lua_State *L);
 static ngx_int_t ngx_http_lua_socket_tcp_read(ngx_http_request_t *r,
     ngx_http_lua_socket_tcp_upstream_t *u);
 static int ngx_http_lua_socket_tcp_receive_retval_handler(ngx_http_request_t *r,
@@ -2163,8 +2165,6 @@ ngx_http_lua_socket_tcp_receive_helper(ngx_http_request_t *r,
     ngx_http_lua_ctx_t                  *ctx;
     ngx_http_lua_co_ctx_t               *coctx;
 
-    u->input_filter_ctx = u;
-
     ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
 
     if (u->bufs_in == NULL) {
@@ -2192,6 +2192,8 @@ ngx_http_lua_socket_tcp_receive_helper(ngx_http_request_t *r,
 
     u->read_waiting = 0;
     u->read_co_ctx = NULL;
+
+    ngx_http_lua_socket_tcp_read_prepare(r, u, u, L);
 
     rc = ngx_http_lua_socket_tcp_read(r, u);
 
@@ -2511,6 +2513,87 @@ ngx_http_lua_socket_read_any(void *data, ssize_t bytes)
     }
 
     return rc;
+}
+
+
+static void
+ngx_http_lua_socket_tcp_read_prepare(ngx_http_request_t *r,
+    ngx_http_lua_socket_tcp_upstream_t *u, void *data, lua_State *L)
+{
+    ngx_http_lua_ctx_t                  *ctx;
+    ngx_chain_t                         *new_cl;
+    ngx_buf_t                           *b;
+    off_t                                size;
+
+    ngx_http_lua_socket_compiled_pattern_t     *cp;
+
+    /* input_filter_ctx doesn't change, no need recovering */
+    if (u->input_filter_ctx == data) {
+        return;
+    }
+
+    /* last input_filter_ctx is null or upstream, no data pending */
+    if (u->input_filter_ctx == NULL || u->input_filter_ctx == u) {
+        u->input_filter_ctx = data;
+        return;
+    }
+
+    /* compiled pattern may be with data pending */
+
+    cp = u->input_filter_ctx;
+    u->input_filter_ctx = data;
+
+    cp->upstream = NULL;
+
+    /* no data pending */
+    if (cp->state <= 0) {
+        return;
+    }
+
+    b = &u->buffer;
+
+    if (b->pos - b->start >= cp->state) {
+        dd("pending data in one buffer");
+
+        b->pos -= cp->state;
+
+        u->buf_in->buf->pos = b->pos;
+        u->buf_in->buf->last = b->pos;
+
+        /* reset dfa state for future matching */
+        cp->state = 0;
+        return;
+    }
+
+    dd("pending data in multiple buffers");
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+
+    size = ngx_buf_size(b);
+
+    new_cl =
+        ngx_http_lua_chain_get_free_buf(r->connection->log, r->pool,
+                                        &ctx->free_recv_bufs,
+                                        cp->state + size);
+
+    if (new_cl == NULL) {
+        luaL_error(L, "no memory");
+        return;
+    }
+
+    ngx_memcpy(b, new_cl->buf, sizeof(ngx_buf_t));
+
+    b->last = ngx_copy(b->last, cp->pattern.data, cp->state);
+    b->last = ngx_copy(b->last, u->buf_in->buf->pos, size);
+
+    u->buf_in->next = ctx->free_recv_bufs;
+    ctx->free_recv_bufs = u->buf_in;
+
+    u->bufs_in = new_cl;
+    u->buf_in = new_cl;
+
+    /* reset dfa state for future matching */
+    cp->state = 0;
 }
 
 
@@ -4243,6 +4326,11 @@ ngx_http_lua_socket_tcp_finalize(ngx_http_request_t *r,
     ngx_http_lua_socket_tcp_finalize_read_part(r, u);
     ngx_http_lua_socket_tcp_finalize_write_part(r, u);
 
+    if (u->input_filter_ctx != NULL && u->input_filter_ctx != u) {
+        ((ngx_http_lua_socket_compiled_pattern_t *)
+         u->input_filter_ctx)->upstream = NULL;
+    }
+
     if (u->raw_downstream || u->body_downstream) {
         u->peer.connection = NULL;
         return;
@@ -4559,8 +4647,6 @@ ngx_http_lua_socket_receiveuntil_iterator(lua_State *L)
         (u_char *) lua_tolstring(L, lua_upvalueindex(2),
                                  &cp->pattern.len);
 
-    u->input_filter_ctx = cp;
-
     ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
 
     if (u->bufs_in == NULL) {
@@ -4586,6 +4672,8 @@ ngx_http_lua_socket_receiveuntil_iterator(lua_State *L)
 
     u->read_waiting = 0;
     u->read_co_ctx = NULL;
+
+    ngx_http_lua_socket_tcp_read_prepare(r, u, cp, L);
 
     rc = ngx_http_lua_socket_tcp_read(r, u);
 
@@ -4915,13 +5003,28 @@ ngx_http_lua_socket_cleanup_compiled_pattern(lua_State *L)
 {
     ngx_http_lua_socket_compiled_pattern_t      *cp;
 
-    ngx_http_lua_dfa_edge_t         *edge, *p;
-    unsigned                         i;
+    ngx_http_lua_socket_tcp_upstream_t      *u;
+    ngx_http_lua_dfa_edge_t                 *edge, *p;
+    unsigned                                 i;
 
     dd("cleanup compiled pattern");
 
     cp = lua_touserdata(L, 1);
-    if (cp == NULL || cp->recovering == NULL) {
+    if (cp == NULL) {
+        return 0;
+    }
+
+    u = cp->upstream;
+    if (u != NULL) {
+        /* ensure request not released */
+        if (u->cleanup != NULL) {
+            ngx_http_lua_socket_tcp_read_prepare(u->request, u, NULL, L);
+        }
+
+        u->input_filter_ctx = NULL;
+    }
+
+    if (cp->recovering == NULL) {
         return 0;
     }
 

--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -5016,11 +5016,7 @@ ngx_http_lua_socket_cleanup_compiled_pattern(lua_State *L)
 
     u = cp->upstream;
     if (u != NULL) {
-        /* ensure request not released */
-        if (u->cleanup != NULL) {
-            ngx_http_lua_socket_tcp_read_prepare(u->request, u, NULL, L);
-        }
-
+        ngx_http_lua_socket_tcp_read_prepare(u->request, u, NULL, L);
         u->input_filter_ctx = NULL;
     }
 

--- a/t/066-socket-receiveuntil.t
+++ b/t/066-socket-receiveuntil.t
@@ -1411,7 +1411,7 @@ close: 1 nil
     location /t {
         set $port $TEST_NGINX_SERVER_PORT;
 
-        content_by_lua '
+        content_by_lua_block {
             -- collectgarbage("collect")
 
             local sock = ngx.socket.tcp()
@@ -1425,7 +1425,7 @@ close: 1 nil
 
             ngx.say("connected: ", ok)
 
-            local req = "GET /foo HTTP/1.0\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n"
+            local req = "GET /foo HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n"
 
             local bytes, err = sock:send(req)
             if not bytes then
@@ -1434,7 +1434,7 @@ close: 1 nil
             end
             ngx.say("request sent: ", bytes)
 
-            local read_headers = sock:receiveuntil("\\r\\n\\r\\n")
+            local read_headers = sock:receiveuntil("\r\n\r\n")
             local headers, err, part = read_headers()
             if not headers then
                 ngx.say("failed to read headers: ", err, " [", part, "]")
@@ -1472,7 +1472,7 @@ close: 1 nil
 
             ok, err = sock:close()
             ngx.say("close: ", ok, " ", err)
-        ';
+        }
     }
 
     location /foo {
@@ -1509,7 +1509,7 @@ close: 1 nil
     location /t {
         set $port $TEST_NGINX_SERVER_PORT;
 
-        content_by_lua '
+        content_by_lua_block {
             -- collectgarbage("collect")
 
             local sock = ngx.socket.tcp()
@@ -1523,7 +1523,7 @@ close: 1 nil
 
             ngx.say("connected: ", ok)
 
-            local req = "GET /foo HTTP/1.0\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n"
+            local req = "GET /foo HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n"
 
             local bytes, err = sock:send(req)
             if not bytes then
@@ -1532,7 +1532,7 @@ close: 1 nil
             end
             ngx.say("request sent: ", bytes)
 
-            local read_headers = sock:receiveuntil("\\r\\n\\r\\n")
+            local read_headers = sock:receiveuntil("\r\n\r\n")
             local headers, err, part = read_headers()
             if not headers then
                 ngx.say("failed to read headers: ", err, " [", part, "]")
@@ -1591,7 +1591,7 @@ close: 1 nil
 
             ok, err = sock:close()
             ngx.say("close: ", ok, " ", err)
-        ';
+        }
     }
 
     location /foo {
@@ -1625,7 +1625,7 @@ close: 1 nil
     location /t {
         set $port $TEST_NGINX_SERVER_PORT;
 
-        content_by_lua '
+        content_by_lua_block {
             -- collectgarbage("collect")
 
             local sock = ngx.socket.tcp()
@@ -1639,7 +1639,7 @@ close: 1 nil
 
             ngx.say("connected: ", ok)
 
-            local req = "GET /foo HTTP/1.0\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n"
+            local req = "GET /foo HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n"
 
             local bytes, err = sock:send(req)
             if not bytes then
@@ -1648,7 +1648,7 @@ close: 1 nil
             end
             ngx.say("request sent: ", bytes)
 
-            local read_headers = sock:receiveuntil("\\r\\n\\r\\n")
+            local read_headers = sock:receiveuntil("\r\n\r\n")
             local headers, err, part = read_headers()
             if not headers then
                 ngx.say("failed to read headers: ", err, " [", part, "]")
@@ -1686,7 +1686,7 @@ close: 1 nil
 
             ok, err = sock:close()
             ngx.say("close: ", ok, " ", err)
-        ';
+        }
     }
 
     location /foo {
@@ -1724,7 +1724,7 @@ close: 1 nil
     location /t {
         set $port $TEST_NGINX_SERVER_PORT;
 
-        content_by_lua '
+        content_by_lua_block {
             -- collectgarbage("collect")
 
             local sock = ngx.socket.tcp()
@@ -1738,7 +1738,7 @@ close: 1 nil
 
             ngx.say("connected: ", ok)
 
-            local req = "GET /foo HTTP/1.0\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n"
+            local req = "GET /foo HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n"
 
             local bytes, err = sock:send(req)
             if not bytes then
@@ -1747,7 +1747,7 @@ close: 1 nil
             end
             ngx.say("request sent: ", bytes)
 
-            local read_headers = sock:receiveuntil("\\r\\n\\r\\n")
+            local read_headers = sock:receiveuntil("\r\n\r\n")
             local headers, err, part = read_headers()
             if not headers then
                 ngx.say("failed to read headers: ", err, " [", part, "]")
@@ -1806,7 +1806,7 @@ close: 1 nil
 
             ok, err = sock:close()
             ngx.say("close: ", ok, " ", err)
-        ';
+        }
     }
 
     location /foo {
@@ -1839,7 +1839,7 @@ close: 1 nil
     location /t {
         set $port $TEST_NGINX_SERVER_PORT;
 
-        content_by_lua '
+        content_by_lua_block {
             -- collectgarbage("collect")
 
             local sock = ngx.socket.tcp()
@@ -1853,7 +1853,7 @@ close: 1 nil
 
             ngx.say("connected: ", ok)
 
-            local req = "GET /foo HTTP/1.0\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n"
+            local req = "GET /foo HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n"
 
             local bytes, err = sock:send(req)
             if not bytes then
@@ -1862,7 +1862,7 @@ close: 1 nil
             end
             ngx.say("request sent: ", bytes)
 
-            local read_headers = sock:receiveuntil("\\r\\n\\r\\n")
+            local read_headers = sock:receiveuntil("\r\n\r\n")
             local headers, err, part = read_headers()
             if not headers then
                 ngx.say("failed to read headers: ", err, " [", part, "]")
@@ -1892,7 +1892,7 @@ close: 1 nil
 
             ok, err = sock:close()
             ngx.say("close: ", ok, " ", err)
-        ';
+        }
     }
 
     location /foo {
@@ -1921,7 +1921,7 @@ close: 1 nil
     location /t {
         set $port $TEST_NGINX_SERVER_PORT;
 
-        content_by_lua '
+        content_by_lua_block {
             -- collectgarbage("collect")
 
             local sock = ngx.socket.tcp()
@@ -1935,7 +1935,7 @@ close: 1 nil
 
             ngx.say("connected: ", ok)
 
-            local req = "GET /foo HTTP/1.0\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n"
+            local req = "GET /foo HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n"
 
             local bytes, err = sock:send(req)
             if not bytes then
@@ -1944,7 +1944,7 @@ close: 1 nil
             end
             ngx.say("request sent: ", bytes)
 
-            local read_headers = sock:receiveuntil("\\r\\n\\r\\n")
+            local read_headers = sock:receiveuntil("\r\n\r\n")
             local headers, err, part = read_headers()
             if not headers then
                 ngx.say("failed to read headers: ", err, " [", part, "]")
@@ -1974,7 +1974,7 @@ close: 1 nil
 
             ok, err = sock:close()
             ngx.say("close: ", ok, " ", err)
-        ';
+        }
     }
 
     location /foo {

--- a/t/066-socket-receiveuntil.t
+++ b/t/066-socket-receiveuntil.t
@@ -1402,3 +1402,594 @@ close: 1 nil
 }
 --- no_error_log
 [error]
+
+
+
+=== TEST 21: ambiguous boundary patterns (--abc), mixed by other reading calls consume boundary
+--- config
+    server_tokens off;
+    location /t {
+        set $port $TEST_NGINX_SERVER_PORT;
+
+        content_by_lua '
+            -- collectgarbage("collect")
+
+            local sock = ngx.socket.tcp()
+            local port = ngx.var.port
+
+            local ok, err = sock:connect("127.0.0.1", port)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected: ", ok)
+
+            local req = "GET /foo HTTP/1.0\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n"
+
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send request: ", err)
+                return
+            end
+            ngx.say("request sent: ", bytes)
+
+            local read_headers = sock:receiveuntil("\\r\\n\\r\\n")
+            local headers, err, part = read_headers()
+            if not headers then
+                ngx.say("failed to read headers: ", err, " [", part, "]")
+            end
+
+            local reader = sock:receiveuntil("--abc")
+
+            for i = 1, 5 do
+                local line, err, part = reader(2)
+                if not line then
+                    ngx.say("failed to read a line: ", err, " [", part, "]")
+                    break
+
+                else
+                    ngx.say("read: ", line)
+                end
+
+                local data, err, part = sock:receive(1)
+                if not data then
+                    ngx.say("failed to read a byte: ", err, " [", part, "]")
+                    break
+
+                else
+                    ngx.say("read one byte: ", data)
+                end
+            end
+
+            local line, err, part = reader(2)
+            if not line then
+                ngx.say("failed to read a line: ", err, " [", part, "]")
+
+            else
+                ngx.say("read: ", line)
+            end
+
+            ok, err = sock:close()
+            ngx.say("close: ", ok, " ", err)
+        ';
+    }
+
+    location /foo {
+        echo -- ----abc----abc-;
+        more_clear_headers Date;
+    }
+--- request
+GET /t
+
+--- response_body eval
+qq{connected: 1
+request sent: 57
+read: --
+read one byte: -
+read: -a
+read one byte: b
+read: c-
+read one byte: -
+read: 
+read one byte: -
+failed to read a line: nil [nil]
+failed to read a line: closed [
+]
+close: 1 nil
+}
+--- no_error_log
+[error]
+
+
+
+=== TEST 22: ambiguous boundary patterns (--abc), mixed by other reading calls (including receiveuntil) consume boundary
+--- config
+    server_tokens off;
+    location /t {
+        set $port $TEST_NGINX_SERVER_PORT;
+
+        content_by_lua '
+            -- collectgarbage("collect")
+
+            local sock = ngx.socket.tcp()
+            local port = ngx.var.port
+
+            local ok, err = sock:connect("127.0.0.1", port)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected: ", ok)
+
+            local req = "GET /foo HTTP/1.0\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n"
+
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send request: ", err)
+                return
+            end
+            ngx.say("request sent: ", bytes)
+
+            local read_headers = sock:receiveuntil("\\r\\n\\r\\n")
+            local headers, err, part = read_headers()
+            if not headers then
+                ngx.say("failed to read headers: ", err, " [", part, "]")
+            end
+
+            local reader1 = sock:receiveuntil("--abc")
+            local reader2 = sock:receiveuntil("-ab")
+
+            local line, err, part = reader1(2)
+            if not line then
+                ngx.say("failed to read a line: ", err, " [", part, "]")
+
+            else
+                ngx.say("read: ", line)
+            end
+
+            local data, err, part = sock:receive(1)
+            if not data then
+                ngx.say("failed to read a byte: ", err, " [", part, "]")
+
+            else
+                ngx.say("read one byte: ", data)
+            end
+
+            local line, err, part = reader1(1)
+            if not line then
+                ngx.say("failed to read a line: ", err, " [", part, "]")
+
+            else
+                ngx.say("read: ", line)
+            end
+
+            local line, err, part = reader2(2)
+            if not line then
+                ngx.say("failed to read a line: ", err, " [", part, "]")
+
+            else
+                ngx.say("read: ", line)
+            end
+
+            local line, err, part = reader1()
+            if not line then
+                ngx.say("failed to read a line: ", err, " [", part, "]")
+
+            else
+                ngx.say("read: ", line)
+            end
+
+            local line, err, part = reader1()
+            if not line then
+                ngx.say("failed to read a line: ", err, " [", part, "]")
+
+            else
+                ngx.say("read: ", line)
+            end
+
+            ok, err = sock:close()
+            ngx.say("close: ", ok, " ", err)
+        ';
+    }
+
+    location /foo {
+        echo -- ------abd----abc;
+        more_clear_headers Date;
+    }
+--- request
+GET /t
+
+--- response_body eval
+qq{connected: 1
+request sent: 57
+read: --
+read one byte: -
+read: -
+read: -
+read: d--
+failed to read a line: closed [
+]
+close: 1 nil
+}
+--- no_error_log
+[error]
+
+
+
+=== TEST 23: ambiguous boundary patterns (--abc), mixed by other reading calls consume boundary, small buffer
+--- config
+    lua_socket_buffer_size 3;
+    server_tokens off;
+    location /t {
+        set $port $TEST_NGINX_SERVER_PORT;
+
+        content_by_lua '
+            -- collectgarbage("collect")
+
+            local sock = ngx.socket.tcp()
+            local port = ngx.var.port
+
+            local ok, err = sock:connect("127.0.0.1", port)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected: ", ok)
+
+            local req = "GET /foo HTTP/1.0\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n"
+
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send request: ", err)
+                return
+            end
+            ngx.say("request sent: ", bytes)
+
+            local read_headers = sock:receiveuntil("\\r\\n\\r\\n")
+            local headers, err, part = read_headers()
+            if not headers then
+                ngx.say("failed to read headers: ", err, " [", part, "]")
+            end
+
+            local reader = sock:receiveuntil("--abc")
+
+            for i = 1, 5 do
+                local line, err, part = reader(2)
+                if not line then
+                    ngx.say("failed to read a line: ", err, " [", part, "]")
+                    break
+
+                else
+                    ngx.say("read: ", line)
+                end
+
+                local data, err, part = sock:receive(1)
+                if not data then
+                    ngx.say("failed to read a byte: ", err, " [", part, "]")
+                    break
+
+                else
+                    ngx.say("read one byte: ", data)
+                end
+            end
+
+            local line, err, part = reader(2)
+            if not line then
+                ngx.say("failed to read a line: ", err, " [", part, "]")
+
+            else
+                ngx.say("read: ", line)
+            end
+
+            ok, err = sock:close()
+            ngx.say("close: ", ok, " ", err)
+        ';
+    }
+
+    location /foo {
+        echo -- ----abc----abc-;
+        more_clear_headers Date;
+    }
+--- request
+GET /t
+
+--- response_body eval
+qq{connected: 1
+request sent: 57
+read: --
+read one byte: -
+read: -a
+read one byte: b
+read: c-
+read one byte: -
+read: 
+read one byte: -
+failed to read a line: nil [nil]
+failed to read a line: closed [
+]
+close: 1 nil
+}
+--- no_error_log
+[error]
+
+
+
+=== TEST 24: ambiguous boundary patterns (--abc), mixed by other reading calls (including receiveuntil) consume boundary, small buffer
+--- config
+    lua_socket_buffer_size 3;
+    server_tokens off;
+    location /t {
+        set $port $TEST_NGINX_SERVER_PORT;
+
+        content_by_lua '
+            -- collectgarbage("collect")
+
+            local sock = ngx.socket.tcp()
+            local port = ngx.var.port
+
+            local ok, err = sock:connect("127.0.0.1", port)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected: ", ok)
+
+            local req = "GET /foo HTTP/1.0\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n"
+
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send request: ", err)
+                return
+            end
+            ngx.say("request sent: ", bytes)
+
+            local read_headers = sock:receiveuntil("\\r\\n\\r\\n")
+            local headers, err, part = read_headers()
+            if not headers then
+                ngx.say("failed to read headers: ", err, " [", part, "]")
+            end
+
+            local reader1 = sock:receiveuntil("--abc")
+            local reader2 = sock:receiveuntil("-ab")
+
+            local line, err, part = reader1(2)
+            if not line then
+                ngx.say("failed to read a line: ", err, " [", part, "]")
+
+            else
+                ngx.say("read: ", line)
+            end
+
+            local data, err, part = sock:receive(1)
+            if not data then
+                ngx.say("failed to read a byte: ", err, " [", part, "]")
+
+            else
+                ngx.say("read one byte: ", data)
+            end
+
+            local line, err, part = reader1(1)
+            if not line then
+                ngx.say("failed to read a line: ", err, " [", part, "]")
+
+            else
+                ngx.say("read: ", line)
+            end
+
+            local line, err, part = reader2(2)
+            if not line then
+                ngx.say("failed to read a line: ", err, " [", part, "]")
+
+            else
+                ngx.say("read: ", line)
+            end
+
+            local line, err, part = reader1()
+            if not line then
+                ngx.say("failed to read a line: ", err, " [", part, "]")
+
+            else
+                ngx.say("read: ", line)
+            end
+
+            local line, err, part = reader1()
+            if not line then
+                ngx.say("failed to read a line: ", err, " [", part, "]")
+
+            else
+                ngx.say("read: ", line)
+            end
+
+            ok, err = sock:close()
+            ngx.say("close: ", ok, " ", err)
+        ';
+    }
+
+    location /foo {
+        echo -- ------abd----abc;
+        more_clear_headers Date;
+    }
+--- request
+GET /t
+
+--- response_body eval
+qq{connected: 1
+request sent: 57
+read: --
+read one byte: -
+read: -
+read: -
+read: d--
+failed to read a line: closed [
+]
+close: 1 nil
+}
+--- no_error_log
+[error]
+
+
+
+=== TEST 25: ambiguous boundary patterns (ab1ab2), ends half way
+--- config
+    server_tokens off;
+    location /t {
+        set $port $TEST_NGINX_SERVER_PORT;
+
+        content_by_lua '
+            -- collectgarbage("collect")
+
+            local sock = ngx.socket.tcp()
+            local port = ngx.var.port
+
+            local ok, err = sock:connect("127.0.0.1", port)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected: ", ok)
+
+            local req = "GET /foo HTTP/1.0\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n"
+
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send request: ", err)
+                return
+            end
+            ngx.say("request sent: ", bytes)
+
+            local read_headers = sock:receiveuntil("\\r\\n\\r\\n")
+            local headers, err, part = read_headers()
+            if not headers then
+                ngx.say("failed to read headers: ", err, " [", part, "]")
+            end
+
+            if true then
+                local reader = sock:receiveuntil("ab1ab2")
+
+                local line, err, part = reader(2)
+                if not line then
+                    ngx.say("failed to read a line: ", err, " [", part, "]")
+
+                else
+                    ngx.say("read: ", line)
+                end
+            end
+
+            collectgarbage("collect")
+
+            local data, err, part = sock:receive(3)
+            if not data then
+                ngx.say("failed to read three bytes: ", err, " [", part, "]")
+
+            else
+                ngx.say("read three bytes: ", data)
+            end
+
+            ok, err = sock:close()
+            ngx.say("close: ", ok, " ", err)
+        ';
+    }
+
+    location /foo {
+        echo -- ab1ab1;
+        more_clear_headers Date;
+    }
+--- request
+GET /t
+
+--- response_body eval
+qq{connected: 1
+request sent: 57
+read: ab1
+read three bytes: ab1
+close: 1 nil
+}
+--- no_error_log
+[error]
+
+
+
+=== TEST 26: ambiguous boundary patterns (ab1ab2), ends half way, small buffer
+--- config
+    lua_socket_buffer_size 3;
+    server_tokens off;
+    location /t {
+        set $port $TEST_NGINX_SERVER_PORT;
+
+        content_by_lua '
+            -- collectgarbage("collect")
+
+            local sock = ngx.socket.tcp()
+            local port = ngx.var.port
+
+            local ok, err = sock:connect("127.0.0.1", port)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected: ", ok)
+
+            local req = "GET /foo HTTP/1.0\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n"
+
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send request: ", err)
+                return
+            end
+            ngx.say("request sent: ", bytes)
+
+            local read_headers = sock:receiveuntil("\\r\\n\\r\\n")
+            local headers, err, part = read_headers()
+            if not headers then
+                ngx.say("failed to read headers: ", err, " [", part, "]")
+            end
+
+            if true then
+                local reader = sock:receiveuntil("ab1ab2")
+
+                local line, err, part = reader(2)
+                if not line then
+                    ngx.say("failed to read a line: ", err, " [", part, "]")
+
+                else
+                    ngx.say("read: ", line)
+                end
+            end
+
+            collectgarbage("collect")
+
+            local data, err, part = sock:receive(3)
+            if not data then
+                ngx.say("failed to read three bytes: ", err, " [", part, "]")
+
+            else
+                ngx.say("read three bytes: ", data)
+            end
+
+            ok, err = sock:close()
+            ngx.say("close: ", ok, " ", err)
+        ';
+    }
+
+    location /foo {
+        echo -- ab1ab1;
+        more_clear_headers Date;
+    }
+--- request
+GET /t
+
+--- response_body eval
+qq{connected: 1
+request sent: 57
+read: ab1
+read three bytes: ab1
+close: 1 nil
+}
+--- no_error_log
+[error]


### PR DESCRIPTION
Please see https://github.com/openresty/lua-nginx-module/issues/2131 for more details.

Through recovering bytes from compiled pattern, other read calls are able to read these pending bytes instead of the following data, which avoids generating unexpected result. More details could be seen in code and comment.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
