### PR TITLE
bugfix: Fix remove bad white space from headers

### DIFF
--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -4361,6 +4361,42 @@ ngx_http_lua_escape_log(u_char *dst, u_char *src, size_t size)
     return 0;
 }
 
+ngx_int_t
+ngx_http_lua_strip_whitespace(ngx_str_t *dst, size_t size)
+{
+    size_t       len;
+    u_char      *data;
+    ngx_int_t   i;
+    ngx_int_t   j;
+
+    data = dst->data;
+    len = dst->len;
+
+    for (i = 0; i < len; i++) {
+        if (data[i] == ' ' || data[i] == '\t'|| data[i] == CR || data[i] == LF) {
+            continue;
+        } else {
+            break;
+        }
+    }
+
+    if (i == len) {
+        return NGX_ERROR;
+    }
+
+    for(j = len - 1; j >= 0; j--) {
+        if (data[j] == ' ' || data[j] == '\t'|| data[j] == CR || data[j] == LF) {
+            continue;
+        } else {
+            break;
+        }
+    }
+
+    data=data+i;
+    dst->data=data;
+    dst->len = j - i + 1;
+    return NGX_OK;
+}
 
 ngx_int_t
 ngx_http_lua_copy_escaped_header(ngx_http_request_t *r,
@@ -4370,9 +4406,17 @@ ngx_http_lua_copy_escaped_header(ngx_http_request_t *r,
     size_t       len;
     u_char      *data;
     int          type;
+    ngx_int_t    rc;
 
     type = is_name
         ? NGX_HTTP_LUA_ESCAPE_HEADER_NAME : NGX_HTTP_LUA_ESCAPE_HEADER_VALUE;
+
+    rc = is_name
+      ? ngx_http_lua_strip_whitespace(dst, len): NGX_OK;
+
+    if (rc != NGX_OK) {
+        return NGX_ERROR;
+    }
 
     data = dst->data;
     len = dst->len;

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -4374,7 +4374,7 @@ ngx_http_lua_strip_whitespace(ngx_str_t *dst, size_t size)
     len = dst->len;
 
     for (i = 0; i < len; i++) {
-        if (data[i] == ' ' || data[i] == '\t'|| data[i] == CR || data[i] == LF)
+        if (data[i] == ' ' || data[i] == '\t' || data[i] == CR || data[i] == LF)
         {
             continue;
 
@@ -4387,8 +4387,8 @@ ngx_http_lua_strip_whitespace(ngx_str_t *dst, size_t size)
         return NGX_ERROR;
     }
 
-    for(j = len - 1; j >= 0; j--) {
-        if (data[j] == ' ' || data[j] == '\t'|| data[j] == CR || data[j] == LF)
+    for (j = len - 1; j >= 0; j--) {
+        if (data[j] == ' ' || data[j] == '\t' || data[j] == CR || data[j] == LF)
         {
             continue;
 

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -4367,8 +4367,8 @@ ngx_http_lua_strip_whitespace(ngx_str_t *dst)
 {
     size_t       len;
     u_char      *data;
-    ngx_int_t    i;
-    ngx_int_t    j;
+    ngx_uint_t   i;
+    ngx_uint_t   j;
 
     data = dst->data;
     len = dst->len;

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -4368,7 +4368,7 @@ ngx_http_lua_strip_whitespace(ngx_str_t *dst)
     size_t       len;
     u_char      *data;
     ngx_uint_t   i;
-    ngx_uint_t   j;
+    ngx_int_t    j;
 
     data = dst->data;
     len = dst->len;

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -4390,7 +4390,10 @@ ngx_http_lua_strip_whitespace(ngx_str_t *dst, size_t size)
     }
 
     for (j = len - 1; j >= 0; j--) {
-        if (data[j] == ' ' || data[j] == '\t' || data[j] == CR || data[j] == LF) {
+        if (data[j] == ' '
+            || data[j] == '\t'
+            || data[j] == CR
+            || data[j] == LF) {
             continue;
 
         } else {

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -4361,21 +4361,23 @@ ngx_http_lua_escape_log(u_char *dst, u_char *src, size_t size)
     return 0;
 }
 
+
 ngx_int_t
 ngx_http_lua_strip_whitespace(ngx_str_t *dst, size_t size)
 {
     size_t       len;
     u_char      *data;
-    ngx_int_t   i;
-    ngx_int_t   j;
+    ngx_int_t    i;
+    ngx_int_t    j;
 
     data = dst->data;
     len = dst->len;
 
     for (i = 0; i < len; i++) {
-        if (data[i] == ' ' || data[i] == '\t'|| data[i] == CR || data[i] == LF) 
+        if (data[i] == ' ' || data[i] == '\t'|| data[i] == CR || data[i] == LF)
         {
             continue;
+        
         } else {
             break;
         }
@@ -4386,19 +4388,21 @@ ngx_http_lua_strip_whitespace(ngx_str_t *dst, size_t size)
     }
 
     for(j = len - 1; j >= 0; j--) {
-        if (data[j] == ' ' || data[j] == '\t'|| data[j] == CR || data[j] == LF) 
+        if (data[j] == ' ' || data[j] == '\t'|| data[j] == CR || data[j] == LF)
         {
             continue;
+        
         } else {
             break;
         }
     }
 
-    data=data+i;
-    dst->data=data;
+    data = data + i;
+    dst->data = data;
     dst->len = j - i + 1;
     return NGX_OK;
 }
+
 
 ngx_int_t
 ngx_http_lua_copy_escaped_header(ngx_http_request_t *r,

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -4363,7 +4363,7 @@ ngx_http_lua_escape_log(u_char *dst, u_char *src, size_t size)
 
 
 ngx_int_t
-ngx_http_lua_strip_whitespace(ngx_str_t *dst, size_t size)
+ngx_http_lua_strip_whitespace(ngx_str_t *dst)
 {
     size_t       len;
     u_char      *data;
@@ -4424,7 +4424,7 @@ ngx_http_lua_copy_escaped_header(ngx_http_request_t *r,
         ? NGX_HTTP_LUA_ESCAPE_HEADER_NAME : NGX_HTTP_LUA_ESCAPE_HEADER_VALUE;
 
     rc = is_name
-      ? ngx_http_lua_strip_whitespace(dst, len): NGX_OK;
+      ? ngx_http_lua_strip_whitespace(dst): NGX_OK;
 
     if (rc != NGX_OK) {
         return NGX_ERROR;

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -4377,7 +4377,8 @@ ngx_http_lua_strip_whitespace(ngx_str_t *dst, size_t size)
         if (data[i] == ' '
             || data[i] == '\t'
             || data[i] == CR
-            || data[i] == LF) {
+            || data[i] == LF)
+        {
             continue;
 
         } else {
@@ -4393,7 +4394,8 @@ ngx_http_lua_strip_whitespace(ngx_str_t *dst, size_t size)
         if (data[j] == ' '
             || data[j] == '\t'
             || data[j] == CR
-            || data[j] == LF) {
+            || data[j] == LF)
+        {
             continue;
 
         } else {

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -4374,8 +4374,7 @@ ngx_http_lua_strip_whitespace(ngx_str_t *dst, size_t size)
     len = dst->len;
 
     for (i = 0; i < len; i++) {
-        if (data[i] == ' ' || data[i] == '\t' || data[i] == CR || data[i] == LF)
-        {
+        if (data[i] == ' ' || data[i] == '\t' || data[i] == CR || data[i] == LF) {
             continue;
 
         } else {
@@ -4388,8 +4387,7 @@ ngx_http_lua_strip_whitespace(ngx_str_t *dst, size_t size)
     }
 
     for (j = len - 1; j >= 0; j--) {
-        if (data[j] == ' ' || data[j] == '\t' || data[j] == CR || data[j] == LF)
-        {
+        if (data[j] == ' ' || data[j] == '\t' || data[j] == CR || data[j] == LF) {
             continue;
 
         } else {

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -4373,7 +4373,8 @@ ngx_http_lua_strip_whitespace(ngx_str_t *dst, size_t size)
     len = dst->len;
 
     for (i = 0; i < len; i++) {
-        if (data[i] == ' ' || data[i] == '\t'|| data[i] == CR || data[i] == LF) {
+        if (data[i] == ' ' || data[i] == '\t'|| data[i] == CR || data[i] == LF) 
+        {
             continue;
         } else {
             break;
@@ -4385,7 +4386,8 @@ ngx_http_lua_strip_whitespace(ngx_str_t *dst, size_t size)
     }
 
     for(j = len - 1; j >= 0; j--) {
-        if (data[j] == ' ' || data[j] == '\t'|| data[j] == CR || data[j] == LF) {
+        if (data[j] == ' ' || data[j] == '\t'|| data[j] == CR || data[j] == LF) 
+        {
             continue;
         } else {
             break;

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -4377,7 +4377,7 @@ ngx_http_lua_strip_whitespace(ngx_str_t *dst, size_t size)
         if (data[i] == ' ' || data[i] == '\t'|| data[i] == CR || data[i] == LF)
         {
             continue;
-        
+
         } else {
             break;
         }
@@ -4391,7 +4391,7 @@ ngx_http_lua_strip_whitespace(ngx_str_t *dst, size_t size)
         if (data[j] == ' ' || data[j] == '\t'|| data[j] == CR || data[j] == LF)
         {
             continue;
-        
+
         } else {
             break;
         }

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -4374,7 +4374,10 @@ ngx_http_lua_strip_whitespace(ngx_str_t *dst, size_t size)
     len = dst->len;
 
     for (i = 0; i < len; i++) {
-        if (data[i] == ' ' || data[i] == '\t' || data[i] == CR || data[i] == LF) {
+        if (data[i] == ' '
+            || data[i] == '\t'
+            || data[i] == CR
+            || data[i] == LF) {
             continue;
 
         } else {

--- a/src/ngx_http_lua_util.h
+++ b/src/ngx_http_lua_util.h
@@ -190,6 +190,9 @@ uintptr_t ngx_http_lua_escape_uri(u_char *dst, u_char *src,
 ngx_int_t ngx_http_lua_copy_escaped_header(ngx_http_request_t *r,
     ngx_str_t *dst, int is_name);
 
+ngx_int_t ngx_http_lua_copy_escaped_header(ngx_http_request_t *r,
+    ngx_str_t *dst, int is_name);
+
 void ngx_http_lua_inject_req_api(ngx_log_t *log, lua_State *L);
 
 void ngx_http_lua_process_args_option(ngx_http_request_t *r,

--- a/t/016-resp-header.t
+++ b/t/016-resp-header.t
@@ -2055,7 +2055,7 @@ bar:
 --- request
 GET /t
 --- response_headers
-%0Dheader%3A%20value%0Dfoo%3Abar%0Abar%3Afoo: xx
+header%3A%20value%0Dfoo%3Abar%0Abar%3Afoo: xx
 header:
 foo:
 bar:

--- a/t/016-resp-header.t
+++ b/t/016-resp-header.t
@@ -8,7 +8,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 3 + 85);
+plan tests => repeat_each() * (blocks() * 3 + 83);
 
 #no_diff();
 no_long_string();

--- a/t/016-resp-header.t
+++ b/t/016-resp-header.t
@@ -2075,7 +2075,7 @@ bar:
 --- request
 GET /t
 --- response_headers
-%0Aheader%3A%20value%0Afoo%3Abar%0Dbar%3Afoo: xx
+header%3A%20value%0Afoo%3Abar%0Dbar%3Afoo: xx
 header:
 foo:
 bar:

--- a/t/016-resp-header.t
+++ b/t/016-resp-header.t
@@ -8,7 +8,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 3 + 79);
+plan tests => repeat_each() * (blocks() * 3 + 85);
 
 #no_diff();
 no_long_string();

--- a/t/016-resp-header.t
+++ b/t/016-resp-header.t
@@ -2240,7 +2240,7 @@ Hello World
 --- request
 GET /t
 --- response_headers
-%0Dheader%3A%20value%0Dfoo%3Abar%0Abar%3Afoo: xx
+header%3A%20value%0Dfoo%3Abar%0Abar%3Afoo: xx
 header:
 foo:
 bar:
@@ -2260,9 +2260,7 @@ bar:
 --- request
 GET /t
 --- response_headers
-%0Dheader%3A%20value%0Dfoo%3Abar%0Abar%3Afoo: xx
 header:
 foo:
 bar:
---- no_error_log
-[error]
+--- error_code: 500

--- a/t/016-resp-header.t
+++ b/t/016-resp-header.t
@@ -2226,3 +2226,43 @@ GET /test
 Hello World
 --- no_error_log
 [error]
+
+
+
+=== TEST 98: unsafe header name (with prefix ' ' and suffix ' ')
+--- config
+    location = /t {
+        content_by_lua_block {
+            ngx.header[" header: value\rfoo:bar\nbar:foo "] = "xx"
+            ngx.say("foo")
+        }
+    }
+--- request
+GET /t
+--- response_headers
+%0Dheader%3A%20value%0Dfoo%3Abar%0Abar%3Afoo: xx
+header:
+foo:
+bar:
+--- no_error_log
+[error]
+
+
+
+=== TEST 99: unsafe header name (with blank header)
+--- config
+    location = /t {
+        content_by_lua_block {
+            ngx.header["  "] = "xx"
+            ngx.say("foo")
+        }
+    }
+--- request
+GET /t
+--- response_headers
+%0Dheader%3A%20value%0Dfoo%3Abar%0Abar%3Afoo: xx
+header:
+foo:
+bar:
+--- no_error_log
+[error]

--- a/t/028-req-header.t
+++ b/t/028-req-header.t
@@ -2124,7 +2124,7 @@ GET /req-header
 --- request
 GET /bar
 --- response_body_like chomp
-\bFoo%0D: 123%0D%0A\b
+\bFoo: 123%0D%0A\b
 
 
 


### PR DESCRIPTION
Please Check Issue #2140
removing leading and trailing bad white-space from key of ngx.req.set_header(key, value) and ngx.header["key "] = 'value' as they are causing failure in the frameworks that are using openresty .
#2140

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
