### PR TITLE
change: lua-ssl-protocols: Disabled SSLv3 and enable TLSv1.3 by default.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3323,13 +3323,14 @@ lua_ssl_protocols
 
 **syntax:** *lua_ssl_protocols \[SSLv2\] \[SSLv3\] \[TLSv1\] [TLSv1.1] [TLSv1.2] [TLSv1.3]*
 
-**default:** *lua_ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2*
+**default:** *lua_ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3*
 
 **context:** *http, server, location*
 
 Enables the specified protocols for requests to a SSL/TLS server in the [tcpsock:sslhandshake](#tcpsocksslhandshake) method.
 
 The support for the `TLSv1.3` parameter requires version `v0.10.12` *and* OpenSSL 1.1.1.
+From version v0.10.25, the default value change from `SSLV3 TLSv1 TLSv1.1 TLSv1.2` to `TLSv1 TLSv1.1 TLSv1.2 TLSv1.3`.
 
 This directive was first introduced in the `v0.9.11` release.
 

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -1465,9 +1465,9 @@ ngx_http_lua_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 #if (NGX_HTTP_SSL)
 
     ngx_conf_merge_bitmask_value(conf->ssl_protocols, prev->ssl_protocols,
-                                 (NGX_CONF_BITMASK_SET|NGX_SSL_SSLv3
+                                 (NGX_CONF_BITMASK_SET
                                   |NGX_SSL_TLSv1|NGX_SSL_TLSv1_1
-                                  |NGX_SSL_TLSv1_2));
+                                  |NGX_SSL_TLSv1_2|NGX_SSL_TLSv1_3));
 
     ngx_conf_merge_str_value(conf->ssl_ciphers, prev->ssl_ciphers,
                              "DEFAULT");

--- a/t/025-codecache.t
+++ b/t/025-codecache.t
@@ -1720,6 +1720,7 @@ grep me: b
     }
 --- config
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location = /proxy {
         proxy_pass http://backend;

--- a/t/129-ssl-socket.t
+++ b/t/129-ssl-socket.t
@@ -1034,6 +1034,8 @@ SSL reused session
 --- config
     server_tokens off;
     resolver $TEST_NGINX_RESOLVER ipv6=off;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
+
     location /t {
         #set $port 5000;
         set $port $TEST_NGINX_MEMCACHED_PORT;

--- a/t/143-ssl-session-fetch.t
+++ b/t/143-ssl-session-fetch.t
@@ -41,6 +41,7 @@ __DATA__
     server_tokens off;
     resolver $TEST_NGINX_RESOLVER ipv6=off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         set $port $TEST_NGINX_MEMCACHED_PORT;
@@ -141,6 +142,7 @@ ssl_session_fetch_by_lua\(nginx\.conf:25\):1: ssl fetch sess by lua is running!,
     server_tokens off;
     resolver $TEST_NGINX_RESOLVER ipv6=off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         set $port $TEST_NGINX_MEMCACHED_PORT;
@@ -225,6 +227,7 @@ qr/elapsed in ssl fetch session by lua: 0.(?:09|1[01])\d+,/,
     server_tokens off;
     resolver $TEST_NGINX_RESOLVER ipv6=off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         set $port $TEST_NGINX_MEMCACHED_PORT;
@@ -326,6 +329,7 @@ qr/my timer run!/s
     server_tokens off;
     resolver $TEST_NGINX_RESOLVER ipv6=off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         set $port $TEST_NGINX_MEMCACHED_PORT;
@@ -407,6 +411,7 @@ qr/received memc reply: OK/s
     resolver $TEST_NGINX_RESOLVER ipv6=off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
     lua_ssl_verify_depth 3;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         set $port $TEST_NGINX_MEMCACHED_PORT;
@@ -488,6 +493,7 @@ should never reached here
     resolver $TEST_NGINX_RESOLVER ipv6=off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
     lua_ssl_verify_depth 3;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         set $port $TEST_NGINX_MEMCACHED_PORT;
@@ -570,6 +576,7 @@ should never reached here
     resolver $TEST_NGINX_RESOLVER ipv6=off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
     lua_ssl_verify_depth 3;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         set $port $TEST_NGINX_MEMCACHED_PORT;
@@ -650,6 +657,7 @@ should never reached here
     server_tokens off;
     resolver $TEST_NGINX_RESOLVER ipv6=off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
     lua_ssl_verify_depth 3;
 
     location /t {
@@ -733,6 +741,7 @@ should never reached here
     server_tokens off;
     resolver $TEST_NGINX_RESOLVER ipv6=off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
     lua_ssl_verify_depth 3;
 
     location /t {
@@ -814,6 +823,7 @@ should never reached here
     server_tokens off;
     resolver $TEST_NGINX_RESOLVER ipv6=off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         set $port $TEST_NGINX_MEMCACHED_PORT;
@@ -900,6 +910,7 @@ qr/get_phase: ssl_session_fetch/s
     server_tokens off;
     resolver $TEST_NGINX_RESOLVER ipv6=off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         set $port $TEST_NGINX_MEMCACHED_PORT;
@@ -982,6 +993,7 @@ ssl store session by lua is running!
 --- config
     server_tokens off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         set $port $TEST_NGINX_MEMCACHED_PORT;
@@ -1070,6 +1082,7 @@ qr/\S+:\d+: ssl fetch sess by lua is running!/s
     server_tokens off;
     resolver $TEST_NGINX_RESOLVER ipv6=off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         set $port $TEST_NGINX_MEMCACHED_PORT;
@@ -1170,6 +1183,7 @@ qr/ssl_session_fetch_by_lua\(nginx.conf:\d+\):1: ssl fetch sess by lua is runnin
 --- config
     server_tokens off;
     lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         content_by_lua_block {
@@ -1249,6 +1263,7 @@ GET /t
 --- config
     server_tokens off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         content_by_lua_block {
@@ -1406,6 +1421,7 @@ ssl_session_fetch_by_lua\(nginx\.conf:\d+\):1: ssl_session_fetch_by_lua\* is run
 --- config
     server_tokens off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         set $port $TEST_NGINX_MEMCACHED_PORT;
@@ -1501,6 +1517,7 @@ qr/elapsed in ssl_session_fetch_by_lua\*: 0\.(?:09|1[01])\d+,/,
 --- config
     server_tokens off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         content_by_lua_block {
@@ -1596,6 +1613,7 @@ close: 1 nil
 --- config
     server_tokens off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         content_by_lua_block {
@@ -1696,6 +1714,7 @@ uthread: failed to kill: already waited or killed
 --- config
     server_tokens off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2;
 
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
