### PR TITLE
bugfix: add missing checking context in ngx_http_lua_socket_tcp_bind

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -865,7 +865,9 @@ ngx_http_lua_socket_tcp_bind(lua_State *L)
                                | NGX_HTTP_LUA_CONTEXT_ACCESS
                                | NGX_HTTP_LUA_CONTEXT_CONTENT
                                | NGX_HTTP_LUA_CONTEXT_TIMER
-                               | NGX_HTTP_LUA_CONTEXT_SSL_CERT);
+                               | NGX_HTTP_LUA_CONTEXT_SSL_CERT
+                               | NGX_HTTP_LUA_CONTEXT_SSL_SESS_FETCH
+                               | NGX_HTTP_LUA_CONTEXT_SSL_CLIENT_HELLO);
 
     luaL_checktype(L, 1, LUA_TTABLE);
 


### PR DESCRIPTION
* according to doc of tcpsock:bind, add missing checking context
![image](https://github.com/openresty/lua-nginx-module/assets/11711429/aea48814-4087-4274-b1d8-5e23c2aac4e0)
