### PR TITLE
bugfix: don't include pcre.h with PCRE2 used

### DIFF
--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -54,7 +54,7 @@ typedef struct {
 #endif
 
 
-#if (NGX_PCRE)
+#if defined(NGX_PCRE) && !defined(NGX_PCRE2)
 #include <pcre.h>
 #   if (PCRE_MAJOR > 8) || (PCRE_MAJOR == 8 && PCRE_MINOR >= 21)
 #       define LUA_HAVE_PCRE_JIT 1


### PR DESCRIPTION
pcre.h is a PCRE header and is not exposed by PCRE2 library causing compilation error as the header is not found.

Don't include pcre.h if nginx is compiled with PCRE2 support enabled.

Fixes: cb83e33e2657 ("feature: support pcre2")