### PR TITLE
changes: modify ngx.read_body api limitation in HTTP/2 and HTTP/3

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2722,7 +2722,7 @@ lua_need_request_body
 
 **phase:** *depends on usage*
 
-Due to the stream processing feature of HTTP2, it does not support HTTP2 connection.
+Due to the stream processing feature of HTTP/2 or HTTP/3, this configuration could potentially block the entire request. Therefore, this configuration is effective only when HTTP/2 or HTTP/3 requests send content-length header. For requests with versions lower than HTTP/2, this configuration can still be used without any problems.
 
 Determines whether to force the request body data to be read before running rewrite/access/content_by_lua* or not. The Nginx core does not read the client request body by default and if request body data is required, then this directive should be turned `on` or the [ngx.req.read_body](#ngxreqread_body) function should be called within the Lua code.
 
@@ -5426,7 +5426,7 @@ Reads the client request body synchronously without blocking the Nginx event loo
  local args = ngx.req.get_post_args()
 ```
 
-Due to the stream processing feature of HTTP2, it does not support HTTP2 connection.
+Due to the stream processing feature of HTTP/2 or HTTP/3, this api could potentially block the entire request. Therefore, this api is effective only when HTTP/2 or HTTP/3 requests send content-length header. For requests with versions lower than HTTP/2, this api can still be used without any problems.
 
 If the request body is already read previously by turning on [lua_need_request_body](#lua_need_request_body) or by using other modules, then this function does not run and returns immediately.
 

--- a/src/ngx_http_lua_accessby.c
+++ b/src/ngx_http_lua_accessby.c
@@ -136,11 +136,26 @@ ngx_http_lua_access_handler(ngx_http_request_t *r)
         return NGX_DONE;
     }
 
-/* http2 read body may break http2 stream process */
-#if (NGX_HTTP_V2)
-    if (llcf->force_read_body && !ctx->read_body_done && !r->main->stream) {
-#else
     if (llcf->force_read_body && !ctx->read_body_done) {
+
+#if (NGX_HTTP_V2)
+        if (r->main->stream && r->headers_in.content_length_n < 0) {
+            ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+                          "disable lua_need_request_body, since "
+                          "http2 read_body may break http2 stream process");
+            goto done;
+        }
+#endif
+
+#if (NGX_HTTP_V3)
+        if (r->http_version == NGX_HTTP_VERSION_30
+            && r->headers_in.content_length_n < 0)
+        {
+            ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+                          "disable lua_need_request_body, since "
+                          "http2 read_body may break http2 stream process");
+            goto done;
+        }
 #endif
         r->request_body_in_single_buf = 1;
         r->request_body_in_persistent_file = 1;
@@ -158,6 +173,8 @@ ngx_http_lua_access_handler(ngx_http_request_t *r)
             return NGX_DONE;
         }
     }
+
+done:
 
     dd("calling access handler");
     return llcf->access_handler(r);

--- a/src/ngx_http_lua_contentby.c
+++ b/src/ngx_http_lua_contentby.c
@@ -195,11 +195,26 @@ ngx_http_lua_content_handler(ngx_http_request_t *r)
         return rc;
     }
 
-/* http2 read body may break http2 stream process */
-#if (NGX_HTTP_V2)
-    if (llcf->force_read_body && !ctx->read_body_done && !r->main->stream) {
-#else
     if (llcf->force_read_body && !ctx->read_body_done) {
+
+#if (NGX_HTTP_V2)
+        if (r->main->stream && r->headers_in.content_length_n < 0) {
+            ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+                          "disable lua_need_request_body, since "
+                          "http2 read_body may break http2 stream process");
+            goto done;
+        }
+#endif
+
+#if (NGX_HTTP_V3)
+        if (r->http_version == NGX_HTTP_VERSION_30
+            && r->headers_in.content_length_n < 0)
+        {
+            ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+                          "disable lua_need_request_body, since "
+                          "http2 read_body may break http2 stream process");
+            goto done;
+        }
 #endif
         r->request_body_in_single_buf = 1;
         r->request_body_in_persistent_file = 1;
@@ -218,6 +233,8 @@ ngx_http_lua_content_handler(ngx_http_request_t *r)
             return NGX_DONE;
         }
     }
+
+done:
 
     dd("setting entered");
 

--- a/src/ngx_http_lua_req_body.c
+++ b/src/ngx_http_lua_req_body.c
@@ -87,8 +87,18 @@ ngx_http_lua_ngx_req_read_body(lua_State *L)
 
 /* http2 read body may break http2 stream process */
 #if (NGX_HTTP_V2)
-    if (r->main->stream) {
-        return luaL_error(L, "http2 requests are not supported yet");
+    if (r->main->stream && r->headers_in.content_length_n < 0) {
+        return luaL_error(L, "http2 requests are not supported"
+                          " without content-length header");
+    }
+#endif
+
+#if (NGX_HTTP_V3)
+    if (r->http_version == NGX_HTTP_VERSION_30
+        && r->headers_in.content_length_n < 0)
+    {
+        return luaL_error(L, "http3 requests are not supported"
+                          " without content-length header");
     }
 #endif
 
@@ -321,8 +331,18 @@ ngx_http_lua_ngx_req_get_body_file(lua_State *L)
 
 /* http2 read body may break http2 stream process */
 #if (NGX_HTTP_V2)
-    if (r->main->stream) {
-        return luaL_error(L, "http2 requests are not supported yet");
+    if (r->main->stream && r->headers_in.content_length_n < 0) {
+        return luaL_error(L, "http2 requests are not supported"
+                          " without content-length header");
+    }
+#endif
+
+#if (NGX_HTTP_V3)
+    if (r->http_version == NGX_HTTP_VERSION_30
+        && r->headers_in.content_length_n < 0)
+    {
+        return luaL_error(L, "http3 requests are not supported"
+                          " without content-length header");
     }
 #endif
 

--- a/t/023-rewrite/request_body.t
+++ b/t/023-rewrite/request_body.t
@@ -187,6 +187,8 @@ http finalize request: 500, "/echo_body?" a:1, c:0
 "POST /echo_body
 hello\x00\x01\x02
 world\x03\x04\xff"
+--- more_headers
+Content-Length:
 --- response_body eval
 "nil"
 --- no_error_log

--- a/t/024-access/request_body.t
+++ b/t/024-access/request_body.t
@@ -187,6 +187,8 @@ http finalize request: 500, "/echo_body?" a:1, c:0
 "POST /echo_body
 hello\x00\x01\x02
 world\x03\x04\xff"
+--- more_headers
+Content-Length:
 --- response_body eval
 "nil"
 --- no_error_log

--- a/t/044-req-body.t
+++ b/t/044-req-body.t
@@ -1787,5 +1787,7 @@ content length: 5
 --- request
 POST /test
 hello, world
+--- more_headers
+Content-Length:
 --- error_code: 500
---- error_log: http2 requests are not supported yet
+--- error_log: http2 requests are not supported without content-length header


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

#2174 mentioned an issue where there is a chance of blocking the ngx.read_body API when using HTTP/2. As a result, #2174 disabled the _ngx.read_body_ API in HTTP/2. However, #2211 also suggested that perhaps we should not completely disable the _ngx.read_body_ API in HTTP/2, as many HTTP/2 requests could still benefit from this.

To address this, I attempted to define the minimum limitations for using ngx.read_body in HTTP/2. From what I understand, ngx.read_body is based on the Nginx core to handle the client's body, and the Nginx core typically reads the entire client body before calling the callback registered by the lua-nginx-module. There are two scenarios in which HTTP/2 can trigger this callback. First, when the Content-Length header is used, Nginx core can determine the exact number of bytes to read from the client side. The second scenario is when an HTTP/2 request sends the entire body and immediately closes the HTTP/2 stream. Additionally, HTTP/2 does not support the chunked transfer encoding.

The first scenario is relatively straightforward to detect in the lua-nginx-module. However, the second scenario is challenging to identify because Nginx core takes over the remaining part, and the lua-nginx-module can only wait to be called by the Nginx core. Therefore, in this pull request, I propose to only allow HTTP/2 requests that carry the Content-Length header. So in the second scenario, If someone want to use _ngx.read_body_, need to add the Content-Length header.

I also considered adding a timeout option for the read_body API. However, I decided against it for two reasons:

Nginx already has a timeout option for reading the client's body, which is configured using _client_body_timeout_. This configuration terminates the HTTP request when a timeout occurs. Introducing another timeout option, which would keep the rest of the Lua thread logic running, seemed redundant.

Secondly, I believe that scenarios causing the blocking of the _ngx.read_body_ API should not use _ngx.read_body_. Adding a timeout option may not immediately expose the real problem.

It's worth noting that HTTP/3 faces a similar problem, and this pr implemented the same solution for it.