### PR TITLE
bugfix: fixed #1612 subrequest's header must be case-insensitive.

### DIFF
--- a/src/ngx_http_lua_subrequest.c
+++ b/src/ngx_http_lua_subrequest.c
@@ -1199,12 +1199,12 @@ ngx_http_lua_handle_subreq_responses(ngx_http_request_t *r,
         lua_createtable(co, 0, 2);
 
         lua_pushlightuserdata(co, ngx_http_lua_lightudata_mask(
-            subrequest_headers_metatable_index_key));
+                              subrequest_headers_metatable_index_key));
         lua_rawget(co, LUA_REGISTRYINDEX);
         lua_setfield(co, -2, "__index");
 
         lua_pushlightuserdata(co, ngx_http_lua_lightudata_mask(
-            subrequest_headers_metatable_newindex_key));
+                              subrequest_headers_metatable_newindex_key));
         lua_rawget(co, LUA_REGISTRYINDEX);
         lua_setfield(co, -2, "__newindex");
 
@@ -1783,7 +1783,7 @@ ngx_http_lua_create_subrequest_headers_metatable(ngx_log_t *log, lua_State *L)
                           subrequest_headers_metatable_index_key));
 
     rc = luaL_loadbuffer(L, index_buf, sizeof(index_buf) - 1,
-        "=subrequest headers metatable __index");
+                         "=subrequest headers metatable __index");
     if (rc != 0) {
         ngx_log_error(NGX_LOG_ERR, log, 0,
                       "failed to load Lua code for the __index metamethod for "
@@ -1796,11 +1796,11 @@ ngx_http_lua_create_subrequest_headers_metatable(ngx_log_t *log, lua_State *L)
     lua_rawset(L, LUA_REGISTRYINDEX);
 
     lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
-                        subrequest_headers_metatable_newindex_key));
+                          subrequest_headers_metatable_newindex_key));
 
 
     rc = luaL_loadbuffer(L, newindex_buf, sizeof(newindex_buf) - 1,
-        "=subrequest headers metatable __newindex");
+                         "=subrequest headers metatable __newindex");
     if (rc != 0) {
         ngx_log_error(NGX_LOG_ERR, log, 0,
                       "failed to load Lua code for the newindex metamethod for "

--- a/src/ngx_http_lua_subrequest.h
+++ b/src/ngx_http_lua_subrequest.h
@@ -12,7 +12,7 @@
 #include "ngx_http_lua_common.h"
 
 
-void ngx_http_lua_inject_subrequest_api(lua_State *L);
+void ngx_http_lua_inject_subrequest_api(ngx_log_t *log, lua_State *L);
 ngx_int_t ngx_http_lua_post_subrequest(ngx_http_request_t *r, void *data,
     ngx_int_t rc);
 

--- a/src/ngx_http_lua_util.c
+++ b/src/ngx_http_lua_util.c
@@ -839,7 +839,7 @@ ngx_http_lua_inject_ngx_api(lua_State *L, ngx_http_lua_main_conf_t *lmcf,
     ngx_http_lua_inject_output_api(L);
     ngx_http_lua_inject_string_api(L);
     ngx_http_lua_inject_control_api(log, L);
-    ngx_http_lua_inject_subrequest_api(L);
+    ngx_http_lua_inject_subrequest_api(log, L);
     ngx_http_lua_inject_sleep_api(L);
 
     ngx_http_lua_inject_req_api(log, L);


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

PR introduces two features for ngx.location.capture().header:
- case-insensitive lookups (same as ngx.header.HEADER or ngx.req.get_headers())
- keeps original case for header names
