### PR TITLE
doc: module function instead of require

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -731,7 +731,7 @@ instead of the old deprecated form:
 
 ```lua
 
- require('xxx')
+ module('xxx')
 ```
 
 Here is the reason: by design, the global environment has exactly the same lifetime as the Nginx request handler associated with it. Each request handler has its own set of Lua global variables and that is the idea of request isolation. The Lua module is actually loaded by the first Nginx request handler and is cached by the `require()` built-in in the `package.loaded` table for later reference, and the `module()` builtin used by some Lua modules has the side effect of setting a global variable to the loaded module table. But this global variable will be cleared at the end of the request handler,  and every subsequent request handler all has its own (clean) global environment. So one will get Lua exception for accessing the `nil` value.


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

Isn't `module` an old form of requiring modules?
