### PR TITLE
feature: get_body_data() return max bytes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5473,7 +5473,7 @@ ngx.req.get_body_data
 
 Retrieves in-memory request body data. It returns a Lua string rather than a Lua table holding all the parsed query arguments. Use the [ngx.req.get_post_args](#ngxreqget_post_args) function instead if a Lua table is required.
 
-The optional <code>max_bytes</code> function argument can be used when you don't need the entire body.
+The optional `max_bytes` argument can be used when you don't need the entire body.
 
 This function returns `nil` if
 

--- a/README.markdown
+++ b/README.markdown
@@ -5467,11 +5467,13 @@ See also [ngx.req.read_body](#ngxreqread_body).
 ngx.req.get_body_data
 ---------------------
 
-**syntax:** *data = ngx.req.get_body_data()*
+**syntax:** *data = ngx.req.get_body_data(max_bytes?)*
 
 **context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, log_by_lua&#42;*
 
 Retrieves in-memory request body data. It returns a Lua string rather than a Lua table holding all the parsed query arguments. Use the [ngx.req.get_post_args](#ngxreqget_post_args) function instead if a Lua table is required.
+
+The optional <code>max_bytes</code> function argument can be used when you don't need the entire body.
 
 This function returns `nil` if
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -4587,11 +4587,13 @@ See also [[#ngx.req.read_body|ngx.req.read_body]].
 
 == ngx.req.get_body_data ==
 
-'''syntax:''' ''data = ngx.req.get_body_data()''
+'''syntax:''' ''data = ngx.req.get_body_data(max_bytes?)''
 
 '''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*, log_by_lua*''
 
 Retrieves in-memory request body data. It returns a Lua string rather than a Lua table holding all the parsed query arguments. Use the [[#ngx.req.get_post_args|ngx.req.get_post_args]] function instead if a Lua table is required.
+
+The optional <code>max_bytes</code> function argument can be used when you don't need the entire body.
 
 This function returns <code>nil</code> if
 

--- a/src/ngx_http_lua_req_body.c
+++ b/src/ngx_http_lua_req_body.c
@@ -288,7 +288,7 @@ ngx_http_lua_ngx_req_get_body_data(lua_State *L)
             return 1;
         }
 
-        len = (max && len > max) ? max : len;
+        len = (max > 0 && len > max) ? max : len;
         lua_pushlstring(L, (char *) cl->buf->pos, len);
         return 1;
     }
@@ -300,7 +300,7 @@ ngx_http_lua_ngx_req_get_body_data(lua_State *L)
     for (; cl; cl = cl->next) {
         dd("body chunk len: %d", (int) ngx_buf_size(cl->buf));
         size = cl->buf->last - cl->buf->pos;
-        if (max && (len + size > max)) {
+        if (max > 0 && (len + size > max)) {
             len = max;
             break;
         }

--- a/src/ngx_http_lua_req_body.c
+++ b/src/ngx_http_lua_req_body.c
@@ -288,7 +288,7 @@ ngx_http_lua_ngx_req_get_body_data(lua_State *L)
             return 1;
         }
 
-        len = (max && len > max) ? max: len;
+        len = (max && len > max) ? max : len;
         lua_pushlstring(L, (char *) cl->buf->pos, len);
         return 1;
     }
@@ -304,6 +304,7 @@ ngx_http_lua_ngx_req_get_body_data(lua_State *L)
             len = max;
             break;
         }
+
         len += size;
     }
 
@@ -316,11 +317,12 @@ ngx_http_lua_ngx_req_get_body_data(lua_State *L)
 
     p = buf;
     rest = len;
-    for (cl = r->request_body->bufs; cl && rest; cl = cl->next) {
+    for (cl = r->request_body->bufs; cl != NULL && rest > 0; cl = cl->next) {
         size = ngx_buf_size(cl->buf);
         if (size > rest) { /* reach limit*/
             size = rest;
         }
+
         p = ngx_copy(p, cl->buf->pos, size);
         rest -= size;
     }

--- a/src/ngx_http_lua_req_body.c
+++ b/src/ngx_http_lua_req_body.c
@@ -246,15 +246,21 @@ ngx_http_lua_ngx_req_get_body_data(lua_State *L)
 {
     ngx_http_request_t          *r;
     int                          n;
-    size_t                       len;
+    size_t                       len, max;
+    size_t                       size, rest;
     ngx_chain_t                 *cl;
     u_char                      *p;
     u_char                      *buf;
 
     n = lua_gettop(L);
 
-    if (n != 0) {
-        return luaL_error(L, "expecting 0 arguments but seen %d", n);
+    if (n != 0 && n != 1) {
+        return luaL_error(L, "expecting 0 or 1 arguments but seen %d", n);
+    }
+
+    max = 0;
+    if (n == 1) {
+        max = (size_t) luaL_checknumber(L, 1);
     }
 
     r = ngx_http_lua_get_req(L);
@@ -282,6 +288,7 @@ ngx_http_lua_ngx_req_get_body_data(lua_State *L)
             return 1;
         }
 
+        len = (max && len > max) ? max: len;
         lua_pushlstring(L, (char *) cl->buf->pos, len);
         return 1;
     }
@@ -292,7 +299,12 @@ ngx_http_lua_ngx_req_get_body_data(lua_State *L)
 
     for (; cl; cl = cl->next) {
         dd("body chunk len: %d", (int) ngx_buf_size(cl->buf));
-        len += cl->buf->last - cl->buf->pos;
+        size = cl->buf->last - cl->buf->pos;
+        if (max && (len + size > max)) {
+            len = max;
+            break;
+        }
+        len += size;
     }
 
     if (len == 0) {
@@ -303,8 +315,14 @@ ngx_http_lua_ngx_req_get_body_data(lua_State *L)
     buf = (u_char *) lua_newuserdata(L, len);
 
     p = buf;
-    for (cl = r->request_body->bufs; cl; cl = cl->next) {
-        p = ngx_copy(p, cl->buf->pos, cl->buf->last - cl->buf->pos);
+    rest = len;
+    for (cl = r->request_body->bufs; cl && rest; cl = cl->next) {
+        size = ngx_buf_size(cl->buf);
+        if (size > rest) { /* reach limit*/
+            size = rest;
+        }
+        p = ngx_copy(p, cl->buf->pos, size);
+        rest -= size;
     }
 
     lua_pushlstring(L, (char *) buf, len);

--- a/t/010-request_body.t
+++ b/t/010-request_body.t
@@ -270,3 +270,23 @@ Expect: 100-Continue
 http finalize request: 500, "/echo_body?" a:1, c:2
 http finalize request: 500, "/echo_body?" a:1, c:0
 --- log_level: debug
+
+
+
+=== TEST 13: test reading the first n bytes of request body
+--- config
+    location /echo_body {
+        lua_need_request_body on;
+        content_by_lua '
+            local data = ngx.req.get_body_data(1)
+            ngx.say(data)
+        ';
+    }
+--- request
+POST /echo_body
+hello
+--- response_body
+h
+
+
+

--- a/t/010-request_body.t
+++ b/t/010-request_body.t
@@ -277,16 +277,13 @@ http finalize request: 500, "/echo_body?" a:1, c:0
 --- config
     location /echo_body {
         lua_need_request_body on;
-        content_by_lua '
+        content_by_lua_block {
             local data = ngx.req.get_body_data(1)
             ngx.say(data)
-        ';
-    }
+        }
+    } 
 --- request
 POST /echo_body
 hello
 --- response_body
 h
-
-
-


### PR DESCRIPTION
In some scenarios(WAF,  logging，for example), we only want to read the first n bytes of the HTTP body. However, the ngx.req.get_body_data() always returns all the data.  If the body size is large, the overhead of copying memory between the Lua VM and the Nginx worker will be even greater.

so i add this feature to resolve #2252 

```lua
-- return first 1024
ngx.req.get_body_data(1024)
-- return all
ngx.req.get_body_data()
```

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
