### PR TITLE
feature: support client_hello_by_lua with boringssl

### DIFF
--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -1249,8 +1249,13 @@ ngx_http_lua_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
                                     ngx_http_lua_ssl_client_hello_handler,
                                     NULL);
 
-#else
+#elif defined(OPENSSL_IS_BORINGSSL)
 
+        SSL_CTX_set_select_certificate_cb(sscf->ssl.ctx,
+                                         ngx_http_lua_ssl_client_hello_handler);
+
+
+#else
         ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
                       "OpenSSL too old to support "
                       "ssl_client_hello_by_lua*");

--- a/src/ngx_http_lua_ssl.h
+++ b/src/ngx_http_lua_ssl.h
@@ -32,6 +32,10 @@ typedef struct {
                                            request ctx data in lua
                                            registry */
 
+#ifdef OPENSSL_IS_BORINGSSL
+    const SSL_CLIENT_HELLO  *client_hello;
+#endif
+
     unsigned                 done:1;
     unsigned                 aborted:1;
 

--- a/src/ngx_http_lua_ssl_client_helloby.h
+++ b/src/ngx_http_lua_ssl_client_helloby.h
@@ -23,8 +23,13 @@ char *ngx_http_lua_ssl_client_hello_by_lua_block(ngx_conf_t *cf,
 char *ngx_http_lua_ssl_client_hello_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 
+#ifdef OPENSSL_IS_BORINGSSL
+int ngx_http_lua_ssl_client_hello_handler(const SSL_CLIENT_HELLO *);
+#else
 int ngx_http_lua_ssl_client_hello_handler(ngx_ssl_conn_t *ssl_conn,
     int *al, void *arg);
+#endif
+
 
 
 #endif  /* NGX_HTTP_SSL */

--- a/t/166-ssl-client-hello.t
+++ b/t/166-ssl-client-hello.t
@@ -4,17 +4,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(3);
 
-# All these tests need to have new openssl
-my $NginxBinary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
-my $openssl_version = eval { `$NginxBinary -V 2>&1` };
-
-if ($openssl_version =~ m/built with OpenSSL (0\S*|1\.0\S*|1\.1\.0\S*)/) {
-    plan(skip_all => "too old OpenSSL, need 1.1.1, was $1");
-} elsif ($openssl_version =~ m/running with BoringSSL/) {
-    plan(skip_all => "does not support BoringSSL");
-} else {
-    plan tests => repeat_each() * (blocks() * 6 + 8);
-}
+plan tests => repeat_each() * (blocks() * 6 + 8);
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 $ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
@@ -580,8 +570,8 @@ failed to do SSL handshake: handshake failed
 
 --- error_log eval
 [
-'lua_client_hello_by_lua: handler return value: -1, client hello cb exit code: 0',
-qr/\[info\] .*? SSL_do_handshake\(\) failed .*?callback failed/,
+'lua_client_hello_by_lua: handler return value: -1, client hello cb exit code: ',
+qr/.*? SSL_do_handshake\(\) failed .*?/,
 'lua exit with code -1',
 ]
 
@@ -721,8 +711,8 @@ failed to do SSL handshake: handshake failed
 
 --- error_log eval
 [
-'lua_client_hello_by_lua: client hello cb exit code: 0',
-qr/\[info\] .*? SSL_do_handshake\(\) failed .*?callback failed/,
+'lua_client_hello_by_lua: client hello cb exit code: ',
+qr/.*? SSL_do_handshake\(\) failed .*?/,
 'lua exit with code -1',
 ]
 
@@ -792,8 +782,8 @@ failed to do SSL handshake: handshake failed
 --- error_log eval
 [
 'runtime error: ssl_client_hello_by_lua(nginx.conf:28):2: bad bad bad',
-'lua_client_hello_by_lua: handler return value: 500, client hello cb exit code: 0',
-qr/\[info\] .*? SSL_do_handshake\(\) failed .*?callback failed/,
+'lua_client_hello_by_lua: handler return value: 500, client hello cb exit code:',
+qr/.*? SSL_do_handshake\(\) failed .*?/,
 qr/context: ssl_client_hello_by_lua\*, client: \d+\.\d+\.\d+\.\d+, server: \d+\.\d+\.\d+\.\d+:\d+/,
 ]
 
@@ -864,8 +854,8 @@ failed to do SSL handshake: handshake failed
 --- error_log eval
 [
 'runtime error: ssl_client_hello_by_lua(nginx.conf:28):3: bad bad bad',
-'lua_client_hello_by_lua: client hello cb exit code: 0',
-qr/\[info\] .*? SSL_do_handshake\(\) failed .*?callback failed/,
+'lua_client_hello_by_lua: client hello cb exit code: ',
+qr/.*? SSL_do_handshake\(\) failed .*?/,
 ]
 
 --- no_error_log
@@ -1051,7 +1041,7 @@ failed to do SSL handshake: handshake failed
 [
 'lua ssl server name: "test.com"',
 'ssl_client_hello_by_lua(nginx.conf:28):1: API disabled in the context of ssl_client_hello_by_lua*',
-qr/\[info\] .*?callback failed/,
+qr/.*? SSL_do_handshake\(\) failed .*?/,
 ]
 
 --- no_error_log


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

The Lua-nginx-module recently added support for building with BoringSSL. However, due to differences between the APIs of OpenSSL and BoringSSL, the _client_hello_by_lua_ directive wasn't supported. Therefore, I submitted this pull request. There will be other pull requests for stream-lua-nginx-module and lua-resty-core.