### PR TITLE
tests: t/129-ssl-socket.t: use the same IP to ensure that the ssl session can be reused.

### DIFF
--- a/t/129-ssl-socket.t
+++ b/t/129-ssl-socket.t
@@ -24,8 +24,7 @@ $ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
 $ENV{TEST_NGINX_RESOLVER} ||= '8.8.8.8';
 $ENV{TEST_NGINX_SERVER_SSL_PORT} ||= 12345;
 $ENV{TEST_NGINX_CERT_DIR} ||= dirname(realpath(abs_path(__FILE__)));
-$ENV{TEST_NGINX_OPENRESTY_ORG_IP} ||= resolve($ENV{TEST_NGINX_RESOLVER},
-    "openresty.org");
+$ENV{TEST_NGINX_OPENRESTY_ORG_IP} ||= resolve("openresty.org", $ENV{TEST_NGINX_RESOLVER});
 
 my $NginxBinary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
 my $openssl_version = eval { `$NginxBinary -V 2>&1` };
@@ -49,7 +48,7 @@ sub read_file {
 }
 
 sub resolve ($$) {
-    my ($resolver, $domain) = @_;
+    my ($domain, $resolver) = @_;
     my $ips = qx/dig \@$resolver +short $domain/;
 
     my $exit_code = $? >> 8;


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.