### PR TITLE
bugfix: fixed memory leak in the case of connection in dubious.

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -5601,6 +5601,7 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
     if (c->read->ready) {
         rc = ngx_http_lua_socket_keepalive_close_handler(c->read);
         if (rc != NGX_OK) {
+            ngx_http_lua_socket_tcp_finalize(r, u);
             lua_pushnil(L);
             lua_pushliteral(L, "connection in dubious state");
             return 2;


### PR DESCRIPTION
Can be reproduced in valgrind mode in t/129-ssl-socket.t:

==55579== 13 bytes in 1 blocks are definitely lost in loss record 3 of 19
==55579==    at 0x483A809: malloc (vg_replace_malloc.c:307)
==55579==    by 0x44F522: ngx_alloc (ngx_alloc.c:22)
==55579==    by 0x549DDD: ngx_http_lua_ffi_socket_tcp_sslhandshake (ngx_http_lua_socket_tcp.c:1828)
==55579==    by 0x4897FEA: lj_vm_ffi_call (in /opt/luajit21/lib/libluajit-5.1.so.2.1.1700206165)
==55579==    by 0x48F7980: lj_ccall_func (lj_ccall.c:1402)
==55579==    by 0x4910E74: lj_cf_ffi_meta___call (lib_ffi.c:230)
==55579==    by 0x4895B7D: lj_BC_FUNCC (in /opt/luajit21/lib/libluajit-5.1.so.2.1.1700206165)
==55579==    by 0x5360E6: ngx_http_lua_run_thread (ngx_http_lua_util.c:1184)
==55579==    by 0x54203E: ngx_http_lua_socket_tcp_resume_helper (ngx_http_lua_socket_tcp.c:6207)
==55579==    by 0x542123: ngx_http_lua_socket_tcp_conn_resume (ngx_http_lua_socket_tcp.c:6113)
==55579==    by 0x5393B1: ngx_http_lua_content_wev_handler (ngx_http_lua_contentby.c:152)
==55579==    by 0x54014B: ngx_http_lua_socket_handle_conn_success (ngx_http_lua_socket_tcp.c:3638)
==55579==    by 0x54504E: ngx_http_lua_socket_connected_handler (ngx_http_lua_socket_tcp.c:3906)
==55579==    by 0x5405A7: ngx_http_lua_socket_tcp_handler (ngx_http_lua_socket_tcp.c:3426)
==55579==    by 0x4567C0: ngx_epoll_process_events (ngx_epoll_module.c:930)
==55579==    by 0x44AAB3: ngx_process_events_and_timers (ngx_event.c:258)
==55579==    by 0x454623: ngx_worker_process_cycle (ngx_process_cycle.c:793)
==55579==    by 0x45295B: ngx_spawn_process (ngx_process.c:199)
==55579==    by 0x45340E: ngx_start_worker_processes (ngx_process_cycle.c:382)
==55579==    by 0x4551F1: ngx_master_process_cycle (ngx_process_cycle.c:241)
==55579==    by 0x429DD6: main (nginx.c:387)

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
