### PR TITLE
bugfix: the connection won't be closed normally when set arg[1] = "" before arg[2] = true

### DIFF
--- a/src/ngx_http_lua_bodyfilterby.c
+++ b/src/ngx_http_lua_bodyfilterby.c
@@ -546,7 +546,8 @@ ngx_http_lua_body_filter_param_set(lua_State *L, ngx_http_request_t *r,
                 lmcf->body_filter_chain = in;
             }
 
-            /* we set the "last_buf" or "last_in_chain" flag in the last buf of "in" */
+            /* we set the "last_buf" or "last_in_chain" flag
+             * in the last buf of "in" */
             for (cl = in; cl; cl = cl->next) {
                 if (cl->next == NULL) {
                     if (r == r->main) {

--- a/src/ngx_http_lua_bodyfilterby.c
+++ b/src/ngx_http_lua_bodyfilterby.c
@@ -536,8 +536,8 @@ ngx_http_lua_body_filter_param_set(lua_State *L, ngx_http_request_t *r,
              * before arg[2] = true*/
             if (in == NULL) {
                 in = ngx_http_lua_chain_get_free_buf(r->connection->log,
-                                                    r->pool,
-                                                    &ctx->free_bufs, 0);
+                                                     r->pool,
+                                                     &ctx->free_bufs, 0);
                 if (in == NULL) {
                     return luaL_error(L, "no memory");
                 }

--- a/src/ngx_http_lua_bodyfilterby.c
+++ b/src/ngx_http_lua_bodyfilterby.c
@@ -532,9 +532,20 @@ ngx_http_lua_body_filter_param_set(lua_State *L, ngx_http_request_t *r,
         if (last) {
             ctx->seen_last_in_filter = 1;
 
-            /* the "in" chain cannot be NULL and we set the "last_buf" or
-             * "last_in_chain" flag in the last buf of "in" */
+            /* the "in" chain cannot be NULL except that we set arg[1] = "" before arg[2] = true*/
+            if (in == NULL) {
+                in = ngx_http_lua_chain_get_free_buf(r->connection->log,
+                                                    r->pool,
+                                                    &ctx->free_bufs, 0);
+                if (in == NULL) {
+                    return luaL_error(L, "no memory");
+                }
 
+                in->buf->tag = (ngx_buf_tag_t) &ngx_http_lua_body_filter;
+                lmcf->body_filter_chain = in;
+            }
+
+            /* we set the "last_buf" or "last_in_chain" flag in the last buf of "in" */
             for (cl = in; cl; cl = cl->next) {
                 if (cl->next == NULL) {
                     if (r == r->main) {

--- a/src/ngx_http_lua_bodyfilterby.c
+++ b/src/ngx_http_lua_bodyfilterby.c
@@ -532,7 +532,8 @@ ngx_http_lua_body_filter_param_set(lua_State *L, ngx_http_request_t *r,
         if (last) {
             ctx->seen_last_in_filter = 1;
 
-            /* the "in" chain cannot be NULL except that we set arg[1] = "" before arg[2] = true*/
+            /* the "in" chain cannot be NULL except that we set arg[1] = ""
+             * before arg[2] = true*/
             if (in == NULL) {
                 in = ngx_http_lua_chain_get_free_buf(r->connection->log,
                                                     r->pool,

--- a/src/ngx_http_lua_bodyfilterby.c
+++ b/src/ngx_http_lua_bodyfilterby.c
@@ -533,7 +533,8 @@ ngx_http_lua_body_filter_param_set(lua_State *L, ngx_http_request_t *r,
             ctx->seen_last_in_filter = 1;
 
             /* the "in" chain cannot be NULL except that we set arg[1] = ""
-             * before arg[2] = true*/
+             * before arg[2] = true
+             */
             if (in == NULL) {
                 in = ngx_http_lua_chain_get_free_buf(r->connection->log,
                                                      r->pool,

--- a/t/082-body-filter-2.t
+++ b/t/082-body-filter-2.t
@@ -34,7 +34,7 @@ log_level('debug');
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 5);
+plan tests => repeat_each() * (blocks() * 5 - 4);
 
 #no_diff();
 no_long_string();

--- a/t/082-body-filter-2.t
+++ b/t/082-body-filter-2.t
@@ -245,6 +245,8 @@ GET /t
 --- response_body
 --- no_error_log
 [error]
+[alert]
+[crit]
 
 
 
@@ -265,3 +267,5 @@ GET /t
 --- response_body
 --- no_error_log
 [error]
+[alert]
+[crit]

--- a/t/082-body-filter-2.t
+++ b/t/082-body-filter-2.t
@@ -225,3 +225,43 @@ GET /t
 [error]
 [alert]
 [crit]
+
+
+
+=== TEST 4: set resp body nil with ngx.arg[1] first
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say("Hello World!")
+        }
+
+        body_filter_by_lua_block {
+            ngx.arg[1] = ""
+            ngx.arg[2] = true
+        }
+    }
+--- request
+GET /t
+--- response_body
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: set resp body nil with ngx.arg[2] first
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say("Hello World!")
+        }
+
+        body_filter_by_lua_block {
+            ngx.arg[2] = true
+            ngx.arg[1] = ""
+        }
+    }
+--- request
+GET /t
+--- response_body
+--- no_error_log
+[error]

--- a/t/082-body-filter-2.t
+++ b/t/082-body-filter-2.t
@@ -34,7 +34,7 @@ log_level('debug');
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 5 - 4);
+plan tests => repeat_each() * (blocks() * 5);
 
 #no_diff();
 no_long_string();


### PR DESCRIPTION
fix #2301

The reason is that when we set  `arg[1] = ""` first, the `lmcf->body_filter_chain` will be null
![image](https://github.com/openresty/lua-nginx-module/assets/9354193/a79c1650-5b5c-47f1-aba9-09b8f59067e8)
https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_bodyfilterby.c#L633-L646

![image](https://github.com/openresty/lua-nginx-module/assets/9354193/44df2aed-d31f-45a3-8f9f-50fa75bfae1d)
https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_bodyfilterby.c#L668-L700

Then we can't set the right end flag
![image](https://github.com/openresty/lua-nginx-module/assets/9354193/cdd2c7b3-2de4-4543-8063-c31ca6c9b81c)
https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_bodyfilterby.c#L526-L549

