### PR TITLE
bugfix: fix config test for signalfd with gcc 11

### DIFF
--- a/config
+++ b/config
@@ -462,7 +462,8 @@ ngx_feature_libs=
 ngx_feature_name="NGX_HTTP_LUA_HAVE_SIGNALFD"
 ngx_feature_run=no
 ngx_feature_incs="#include <sys/signalfd.h>"
-ngx_feature_test="sigset_t set; signalfd(-1, &set, SFD_NONBLOCK|SFD_CLOEXEC);"
+ngx_feature_test="sigset_t set = { 0 };
+                  signalfd(-1, &set, SFD_NONBLOCK|SFD_CLOEXEC);"
 SAVED_CC_TEST_FLAGS="$CC_TEST_FLAGS"
 CC_TEST_FLAGS="-Werror -Wall $CC_TEST_FLAGS"
 


### PR DESCRIPTION
Without the initialization, the feature test ends with:

```
error: 'set' may be used uninitialized [-Werror=maybe-uninitialized]
```

It is because of the [-Wmaybe-uninitialized](https://gcc.gnu.org/onlinedocs/gcc-11.1.0/gcc/Warning-Options.html#index-Wmaybe-uninitialized) enhancements in the gcc 11.

---

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
