### PR TITLE
bugfix: append new parameters to ngx_http_lua_ffi_balancer_set_curren…

### DIFF
--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -860,8 +860,8 @@ ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc, void *data)
 int
 ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
     const u_char *addr, size_t addr_len, int port,
-    const u_char *host, size_t host_len,
-    char **err)
+    char **err,
+    const u_char *host, size_t host_len)
 {
     ngx_url_t              url;
     ngx_http_lua_ctx_t    *ctx;


### PR DESCRIPTION
…t_peer at function end.

Avoid inserting new parameters in the middle of the function to prevent core dumps when using old lua-resty-core with new lua-nginx-module.

Example stack trace:

```
Message: Process 1414245 (nginx) of user 1000 dumped core.

        Stack trace of thread 1414245:
        #0  0x00007ff596938285 __strlen_avx2 (libc.so.6 + 0x162285)
        #1  0x00007ff596f623d2 lj_cf_ffi_string (libluajit-5.1.so.2 + 0x523d2)
        #2  0x00007ff596f1bb4b lj_BC_FUNCC (libluajit-5.1.so.2 + 0xbb4b)
        #3  0x00007ff596f74223 lua_pcall (libluajit-5.1.so.2 + 0x64223)
        #4  0x00000000005044b7 n/a (/home/jiahao/work/org/lua-resty-core/work/nginx/sbin/nginx + 0x1044b7)
```

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
