### PR TITLE
bugfix: let `balancer.recreate_request` API work for body data changed case

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5563,6 +5563,8 @@ If the request body has been read into memory, try calling the [ngx.req.get_body
 
 To force in-file request bodies, try turning on [client_body_in_file_only](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_in_file_only).
 
+Note that this function is also work for balancer phase but it needs to call [balancer.recreate_request](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/balancer.md#recreate_request) to make the change take effect after set the request body data or headers.
+
 This function was first introduced in the `v0.3.1rc17` release.
 
 See also [ngx.req.get_body_data](#ngxreqget_body_data).
@@ -5574,13 +5576,15 @@ ngx.req.set_body_data
 
 **syntax:** *ngx.req.set_body_data(data)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, balancer_by_lua&#42;,*
 
 Set the current request's request body using the in-memory data specified by the `data` argument.
 
 If the request body has not been read yet, call [ngx.req.read_body](#ngxreqread_body) first (or turn on [lua_need_request_body](#lua_need_request_body) to force this module to read the request body. This is not recommended however). Additionally, the request body must not have been previously discarded by [ngx.req.discard_body](#ngxreqdiscard_body).
 
 Whether the previous request body has been read into memory or buffered into a disk file, it will be freed or the disk file will be cleaned up immediately, respectively.
+
+Note that this function is also work for balancer phase but it needs to call [balancer.recreate_request](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/balancer.md#recreate_request) to make the change take effect after set the request body data or headers.
 
 This function was first introduced in the `v0.3.1rc18` release.
 
@@ -5593,7 +5597,7 @@ ngx.req.set_body_file
 
 **syntax:** *ngx.req.set_body_file(file_name, auto_clean?)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, balancer_by_lua&#42;,*
 
 Set the current request's request body using the in-file data specified by the `file_name` argument.
 

--- a/doc/HttpLuaModule.wiki
+++ b/doc/HttpLuaModule.wiki
@@ -4657,13 +4657,15 @@ See also [[#ngx.req.get_body_data|ngx.req.get_body_data]].
 
 '''syntax:''' ''ngx.req.set_body_data(data)''
 
-'''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*''
+'''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*, balancer_by_lua*''
 
 Set the current request's request body using the in-memory data specified by the <code>data</code> argument.
 
 If the request body has not been read yet, call [[#ngx.req.read_body|ngx.req.read_body]] first (or turn on [[#lua_need_request_body|lua_need_request_body]] to force this module to read the request body. This is not recommended however). Additionally, the request body must not have been previously discarded by [[#ngx.req.discard_body|ngx.req.discard_body]].
 
 Whether the previous request body has been read into memory or buffered into a disk file, it will be freed or the disk file will be cleaned up immediately, respectively.
+
+Note that this function is also work for balancer phase but it needs to call [https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/balancer.md#recreate_request balancer.recreate_request] to make the change take effect after set the request body data or headers.
 
 This function was first introduced in the <code>v0.3.1rc18</code> release.
 
@@ -4673,7 +4675,7 @@ See also [[#ngx.req.set_body_file|ngx.req.set_body_file]].
 
 '''syntax:''' ''ngx.req.set_body_file(file_name, auto_clean?)''
 
-'''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*''
+'''context:''' ''rewrite_by_lua*, access_by_lua*, content_by_lua*, balancer_by_lua*''
 
 Set the current request's request body using the in-file data specified by the <code>file_name</code> argument.
 
@@ -4684,6 +4686,8 @@ If the optional <code>auto_clean</code> argument is given a <code>true</code> va
 Please ensure that the file specified by the <code>file_name</code> argument exists and is readable by an Nginx worker process by setting its permission properly to avoid Lua exception errors.
 
 Whether the previous request body has been read into memory or buffered into a disk file, it will be freed or the disk file will be cleaned up immediately, respectively.
+
+Note that this function is also work for balancer phase but it needs to call [https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/balancer.md#recreate_request balancer.recreate_request] to make the change take effect after set the request body data or headers.
 
 This function was first introduced in the <code>v0.3.1rc18</code> release.
 

--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -1288,7 +1288,7 @@ ngx_http_lua_ffi_balancer_recreate_request(ngx_http_request_t *r,
         /* u->request_bufs already contains a valid request buffer
          * remove it from chain first
          */
-        u->request_bufs = u->request_bufs->next;
+        u->request_bufs = r->request_body->bufs;
     }
 
     return u->create_request(r);

--- a/t/138-balancer.t
+++ b/t/138-balancer.t
@@ -12,7 +12,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 4 + 9);
+plan tests => repeat_each() * (blocks() * 4 + 16);
 
 #no_diff();
 no_long_string();
@@ -637,3 +637,43 @@ ok
 --- no_error_log
 [error]
 [cirt]
+
+
+=== TEST 20: recreate_request refresh body buffer when ngx.req.set_body_data is used in balancer phase
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;;";
+
+    server {
+        listen 127.0.0.1:$TEST_NGINX_RAND_PORT_1;
+
+        location / {
+            content_by_lua_block {
+                ngx.req.read_body()
+                local body = ngx.req.get_body_data()
+                ngx.log(ngx.ERR, "body: ", body)
+                ngx.say(body)
+            }
+        }
+    }
+
+    upstream foo {
+        server 127.0.0.1:$TEST_NGINX_RAND_PORT_1 max_fails=0;
+
+        balancer_by_lua_block {
+            local bal = require "ngx.balancer"
+            ngx.req.set_body_data("hello world")
+            assert(bal.recreate_request())
+        }
+    }
+
+--- config
+    location = /t {
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_pass http://foo;
+    }
+--- request
+GET /t
+--- error_code: 200
+--- response_body
+hello world

--- a/t/138-balancer.t
+++ b/t/138-balancer.t
@@ -12,7 +12,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 4 + 16);
+plan tests => repeat_each() * (blocks() * 4 + 7);
 
 #no_diff();
 no_long_string();


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

Context: https://github.com/openresty/lua-nginx-module/issues/2333