### PR TITLE
bugfix: append new parameters to ngx_http_lua_ffi_ssl_verify_client a…

### DIFF
--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -1469,7 +1469,7 @@ ngx_http_lua_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
 
 int
 ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *client_certs,
-    void *trusted_certs, int depth, char **err)
+    int depth, char **err, void *trusted_certs)
 {
 #ifdef LIBRESSL_VERSION_NUMBER
 


### PR DESCRIPTION
…t function end.

Avoid inserting new parameters in the middle of the function to prevent core dumps when using old lua-resty-core with new lua-nginx-module.

Example stack trace:

```
Message: Process 2199905 (nginx) of user 1000 dumped core.

Stack trace of thread 2199905:
    #0  0x00007ffaf1e4b385 in OPENSSL_sk_num (st=st@entry=0xffffffff) at crypto/stack/stack.c:382
    #1  0x0000000000510aba in sk_X509_num (sk=0xffffffff) at /opt/ssl/include/openssl/x509.h:99
    #2  ngx_http_lua_ffi_ssl_verify_client (r=<optimized out>, client_certs=<optimized out>, trusted_certs=0xffffffff, depth=<optimized out>, err=0x0)
        at /home/jiahao/work/org/lua-nginx-module/src/ngx_http_lua_ssl_certby.c:1588
```

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
