### PR TITLE
bugfix: nginx crashed when binding local address failed from lua.

### DIFF
--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -994,7 +994,7 @@ ngx_http_lua_ffi_balancer_bind_to_local_addr(ngx_http_request_t *r,
     bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
 
     if (bp->local == NULL) {
-        bp->local = ngx_palloc(r->pool, sizeof(ngx_addr_t));
+        bp->local = ngx_palloc(r->pool, sizeof(ngx_addr_t) + addr_len + 1);
         if (bp->local == NULL) {
             p = ngx_snprintf(errbuf, *errbuf_size, "no memory");
             *errbuf_size = p - errbuf;
@@ -1008,6 +1008,11 @@ ngx_http_lua_ffi_balancer_bind_to_local_addr(ngx_http_request_t *r,
         *errbuf_size = p - errbuf;
         return NGX_ERROR;
     }
+
+    bp->local->name.len = addr_len;
+    bp->local->name.data = (u_char *) (bp->local + 1);
+    memcpy(bp->local->name.data, addr, addr_len);
+    bp->local->name.data[addr_len] = '\0';
 
     return NGX_OK;
 }

--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -1011,7 +1011,7 @@ ngx_http_lua_ffi_balancer_bind_to_local_addr(ngx_http_request_t *r,
 
     bp->local->name.len = addr_len;
     bp->local->name.data = (u_char *) (bp->local + 1);
-    memcpy(bp->local->name.data, addr, addr_len);
+    ngx_memcpy(bp->local->name.data, addr, addr_len);
 
     return NGX_OK;
 }

--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -994,7 +994,7 @@ ngx_http_lua_ffi_balancer_bind_to_local_addr(ngx_http_request_t *r,
     bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
 
     if (bp->local == NULL) {
-        bp->local = ngx_palloc(r->pool, sizeof(ngx_addr_t) + addr_len + 1);
+        bp->local = ngx_palloc(r->pool, sizeof(ngx_addr_t) + addr_len);
         if (bp->local == NULL) {
             p = ngx_snprintf(errbuf, *errbuf_size, "no memory");
             *errbuf_size = p - errbuf;
@@ -1012,7 +1012,6 @@ ngx_http_lua_ffi_balancer_bind_to_local_addr(ngx_http_request_t *r,
     bp->local->name.len = addr_len;
     bp->local->name.data = (u_char *) (bp->local + 1);
     memcpy(bp->local->name.data, addr, addr_len);
-    bp->local->name.data[addr_len] = '\0';
 
     return NGX_OK;
 }


### PR DESCRIPTION
    fmt@entry=0x59c7f6 "bind(%V) failed", args=args@entry=0x7fff82779258) at src/core/ngx_string.c:255

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
