### PR TITLE
bugfix: compatible-lower-ssl-version

### DIFF
--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -1514,7 +1514,11 @@ ngx_http_lua_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_bitmask_value(conf->ssl_protocols, prev->ssl_protocols,
                                  (NGX_CONF_BITMASK_SET
                                   |NGX_SSL_TLSv1|NGX_SSL_TLSv1_1
-                                  |NGX_SSL_TLSv1_2|NGX_SSL_TLSv1_3));
+                                  |NGX_SSL_TLSv1_2
+                                  #if defined(NGX_SSL_TLSv1_3)
+                                  |NGX_SSL_TLSv1_3
+                                  #endif
+                                  ));
 
     ngx_conf_merge_str_value(conf->ssl_ciphers, prev->ssl_ciphers,
                              "DEFAULT");


### PR DESCRIPTION
When I compile nginx that does not support tls1.3, it will report  errors

it show NGX_SSL_TLSv1_3 not define.
 

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
