### PR TITLE
bugfix: fixed keepalive error in cosocket.

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -5747,6 +5747,16 @@ ngx_http_lua_socket_keepalive_close_handler(ngx_event_t *ev)
                    "lua tcp socket keepalive close handler check stale events");
 
     n = recv(c->fd, buf, 1, MSG_PEEK);
+#if (NGX_HTTP_SSL)
+    /* ignore ssl protocol data like change cipher spec */
+    if (n == 1 && c->ssl != NULL) {
+        n = c->recv(c, (unsigned char *) buf, 1);
+        if (n == NGX_AGAIN) {
+            n = -1;
+            ngx_socket_errno = NGX_EAGAIN;
+        }
+    }
+#endif
 
     if (n == -1 && ngx_socket_errno == NGX_EAGAIN) {
         /* stale event */


### PR DESCRIPTION
This bug was found in t/129-ssl-socket.t Test 18 when TEST_NGINX_EVENT_TYPE=poll enabled.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
