### PR TITLE
bugfix: `setkeepalive` failure on TLSv1.3

### DIFF
--- a/t/058-tcp-socket.t
+++ b/t/058-tcp-socket.t
@@ -10,6 +10,7 @@ our $HtmlDir = html_dir;
 
 $ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
 $ENV{TEST_NGINX_RESOLVER} ||= '8.8.8.8';
+$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 
 #log_level 'warn';
 log_level 'debug';
@@ -4497,3 +4498,67 @@ reused times: 3, setkeepalive err: closed
 --- no_error_log
 [error]
 --- skip_eval: 3: $ENV{TEST_NGINX_EVENT_TYPE} && $ENV{TEST_NGINX_EVENT_TYPE} ne 'epoll'
+
+
+
+=== TEST 74: setkeepalive with TLSv1.3
+--- skip_openssl: 3: < 1.1.1
+--- stream_server_config
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        ssl_certificate     ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+        ssl_protocols TLSv1.3;
+
+        content_by_lua_block {
+            local sock = assert(ngx.req.socket(true))
+            local data
+            while true do
+                data = assert(sock:receive())
+                assert(data == "hello")
+            end
+        }
+--- config
+    location /test {
+        lua_ssl_protocols TLSv1.3;
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            sock:settimeout(2000)
+
+            local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected: ", ok)
+
+            local ok, err = sock:sslhandshake(false, nil, false)
+            if not ok then
+                ngx.say("failed to sslhandshake: ", err)
+                return
+            end
+
+            local ok, err = sock:send("hello\n")
+            if not ok then
+                ngx.say("failed to send: ", err)
+                return
+            end
+
+            -- sleep a while to make sure the NewSessionTicket message has arrived
+            ngx.sleep(1)
+
+            local ok, err = sock:setkeepalive()
+            if not ok then
+                ngx.say("failed to setkeepalive: ", err)
+            else
+                ngx.say("setkeepalive: ", ok)
+            end
+        }
+    }
+--- request
+GET /test
+--- response_body
+connected: 1
+setkeepalive: 1
+--- no_error_log
+[error]

--- a/t/058-tcp-socket.t
+++ b/t/058-tcp-socket.t
@@ -1,6 +1,7 @@
 # vim:set ft= ts=4 sw=4 et fdm=marker:
 
 use Test::Nginx::Socket::Lua;
+use Test::Nginx::Socket::Lua::Stream;
 
 repeat_each(2);
 
@@ -10,6 +11,7 @@ our $HtmlDir = html_dir;
 
 $ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
 $ENV{TEST_NGINX_RESOLVER} ||= '8.8.8.8';
+$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 
 #log_level 'warn';
 log_level 'debug';
@@ -4503,7 +4505,7 @@ reused times: 3, setkeepalive err: closed
 === TEST 74: setkeepalive with TLSv1.3
 --- skip_openssl: 3: < 1.1.1
 --- stream_server_config
-        listen 11443 ssl;
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         ssl_certificate     ../../cert/test.crt;
         ssl_certificate_key ../../cert/test.key;
         ssl_protocols TLSv1.3;
@@ -4523,7 +4525,7 @@ reused times: 3, setkeepalive err: closed
             local sock = ngx.socket.tcp()
             sock:settimeout(2000)
 
-            local ok, err = sock:connect("127.0.0.1", 11443)
+            local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
             if not ok then
                 ngx.say("failed to connect: ", err)
                 return

--- a/t/058-tcp-socket.t
+++ b/t/058-tcp-socket.t
@@ -10,7 +10,6 @@ our $HtmlDir = html_dir;
 
 $ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
 $ENV{TEST_NGINX_RESOLVER} ||= '8.8.8.8';
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 
 #log_level 'warn';
 log_level 'debug';
@@ -4504,7 +4503,7 @@ reused times: 3, setkeepalive err: closed
 === TEST 74: setkeepalive with TLSv1.3
 --- skip_openssl: 3: < 1.1.1
 --- stream_server_config
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        listen 11443 ssl;
         ssl_certificate     ../../cert/test.crt;
         ssl_certificate_key ../../cert/test.key;
         ssl_protocols TLSv1.3;
@@ -4524,7 +4523,7 @@ reused times: 3, setkeepalive err: closed
             local sock = ngx.socket.tcp()
             sock:settimeout(2000)
 
-            local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+            local ok, err = sock:connect("127.0.0.1", 11443)
             if not ok then
                 ngx.say("failed to connect: ", err)
                 return


### PR DESCRIPTION
When TLSv1.3 is used, the server may send a NewSessionTicket message after the handshake. While this message is ssl-layer data, `tcpsock:sslhandshake` does not consume it.

In the implementation of `setkeepalive`, `recv` is used to confirm the connection is still open and there is no unread data in the buffer. But it treats the NewSessionTicket message as application layer data and then `setkeepalive` fails with this error `connection in dubious state`.

In fact we don't need to peek here, because if the application data is read successfully then the connection is going to be closed anyway. Therefore, `c->recv` can be used instead which will consume the ssl-layer data implicitly.

A quick reproduction:

```
openssl s_server --debug -msg -port 11443 -cert server.crt -key server.key
```

```
$ cat test.lua
local host = "127.0.0.1"
local port = 11443
local say = ngx.say

local sock = ngx.socket.tcp()
sock:settimeouts(60, 60, 1)

for i=1, 2 do
  assert(sock:connect(host, port))

  local times = assert(sock:getreusedtimes())
  say("reusedtime " .. times)

  if true and times == 0 then
    assert(sock:sslhandshake(false, nil, false))
  end

  local message = "hello"
  assert(sock:send(message .. "\n"))
  say("sent: ", message)

  -- sleep a while to make sure the NewSessionTicket message has arrived
  ngx.sleep(2)

  local ok, err = sock:setkeepalive(60000, 200)
  if not ok then
    say("failed to keepalive to ", host, ":", tostring(port), ": ", err)
    sock:close()
  end
end

$ resty --http-conf 'lua_ssl_protocols TLSv1.3;' test.lua
reusedtime 0
sent: hello
failed to keepalive to 127.0.0.1:11443: connection in dubious state
reusedtime 0
sent: hello
failed to keepalive to 127.0.0.1:11443: connection in dubious state
```

After the fix:

```
$ resty --http-conf 'lua_ssl_protocols TLSv1.3;' test.lua
reusedtime 0
sent: hello
reusedtime 1
sent: hello
```

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
