### PR TITLE
feature: support AWS-LC SSL Library.

### DIFF
--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -1345,7 +1345,7 @@ ngx_http_lua_ffi_set_cert(ngx_http_request_t *r,
 
 #   else
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     size_t             i;
 #else
     int                i;
@@ -1487,7 +1487,7 @@ ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *client_certs,
     X509                        *x509 = NULL;
     X509_NAME                   *subject = NULL;
     X509_STORE                  *ca_store = NULL;
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     size_t                      i;
 #else
     int                         i;

--- a/src/ngx_http_lua_ssl_export_keying_material.c
+++ b/src/ngx_http_lua_ssl_export_keying_material.c
@@ -31,7 +31,7 @@ ngx_http_lua_ffi_ssl_export_keying_material(ngx_http_request_t *r,
     u_char *out, size_t out_size, const char *label, size_t llen,
     const u_char *context, size_t ctxlen, int use_ctx, char **err)
 {
-#if defined(OPENSSL_IS_BORINGSSL) || OPENSSL_VERSION_NUMBER < 0x10101000L
+#if defined(OPENSSL_IS_BORINGSSL)
     *err = "BoringSSL does not support SSL_export_keying_material";
     return NGX_ERROR;
 #elif defined(LIBRESSL_VERSION_NUMBER)
@@ -79,11 +79,14 @@ ngx_http_lua_ffi_ssl_export_keying_material_early(ngx_http_request_t *r,
     u_char *out, size_t out_size, const char *label, size_t llen,
     const u_char *context, size_t ctxlen, char **err)
 {
-#if defined(OPENSSL_IS_BORINGSSL) || OPENSSL_VERSION_NUMBER < 0x10101000L
-    *err = "BoringSSL does not support SSL_export_keying_material";
+#if defined(OPENSSL_IS_BORINGSSL)
+    *err = "BoringSSL does not support SSL_export_keying_material_early";
     return NGX_ERROR;
 #elif defined(LIBRESSL_VERSION_NUMBER)
-    *err = "LibreSSL does not support SSL_export_keying_material";
+    *err = "LibreSSL does not support SSL_export_keying_material_early";
+    return NGX_ERROR;
+#elif defined(OPENSSL_IS_AWSLC)
+    *err = "AWS-LC does not support SSL_export_keying_material_early";
     return NGX_ERROR;
 #elif OPENSSL_VERSION_NUMBER < 0x10101000L
     *err = "OpenSSL too old";

--- a/src/ngx_http_lua_ssl_ocsp.c
+++ b/src/ngx_http_lua_ssl_ocsp.c
@@ -511,7 +511,7 @@ ngx_http_lua_ffi_ssl_set_ocsp_status_resp(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-#ifdef SSL_CTRL_GET_TLSEXT_STATUS_REQ_TYPE
+#if defined(SSL_CTRL_GET_TLSEXT_STATUS_REQ_TYPE) || defined(OPENSSL_IS_AWSLC)
     if (SSL_get_tlsext_status_type(ssl_conn) == -1) {
 #else
     if (ssl_conn->tlsext_status_type == -1) {


### PR DESCRIPTION
This PR enables lua-nginx-module to be compiled with [AWS-LC](https://github.com/aws/aws-lc), tested on OpenResty 1.27.1.1.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
