### PR TITLE
bugfix: ensure context is restorable when fd writable events

### DIFF
--- a/src/ngx_http_lua_bodyfilterby.c
+++ b/src/ngx_http_lua_bodyfilterby.c
@@ -368,6 +368,7 @@ ngx_http_lua_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
         }
 
     } else {
+        ctx->context = old_context;
         out = NULL;
     }
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

Fix: #2410