### PR TITLE
feature: use the actual ngx_connection_t * in ssl_client_hello_by

### DIFF
--- a/src/ngx_http_lua_ssl_client_helloby.c
+++ b/src/ngx_http_lua_ssl_client_helloby.c
@@ -685,7 +685,7 @@ ngx_http_lua_ffi_ssl_get_client_hello_ext_present(ngx_http_request_t *r,
 
     c = ngx_ssl_get_connection(ssl_conn);
     if (c == NULL) {
-        *err = "bad ssl conn";
+        *err = "couldn't get real ngx_connection_t pointer";
         return NGX_ERROR;
     }
 


### PR DESCRIPTION
Do we really need to create a fake connection here? Sure, the request struct wasn't even created yet but the conneciton does exist.
I personally need it because I need to allocate memory that will live for as long as the connection exists, not until the Lua chunk returns.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

![image](https://github.com/user-attachments/assets/181c6fe5-33a1-40bc-966d-cf9b8a9d48f1)


Also, surely there must be a better way to do this.
    c = ngx_ssl_get_connection(ssl_conn);
This line already does exist at the very top of ngx_http_lua_ssl_client_hello_handler().

If the real connection exists, can't we make it available in the Lua code itself?
The same way we make the fake request available by resty.core.base.get_request