### PR TITLE
[skip ci] feature: ngx_http_lua_ffi_ssl_get_client_hello_ciphers()

### DIFF
--- a/src/ngx_http_lua_ssl_client_helloby.c
+++ b/src/ngx_http_lua_ssl_client_helloby.c
@@ -662,57 +662,14 @@ ngx_http_lua_ffi_ssl_get_client_hello_ext(ngx_http_request_t *r,
 }
 
 
-int
-ngx_http_lua_ffi_ssl_get_client_hello_ext_present(ngx_http_request_t *r,
-    int **extensions, size_t *extensions_len, char **err)
-{
-    ngx_ssl_conn_t          *ssl_conn;
-    int                      got_extensions;
-    size_t                   ext_len;
-    int                     *ext_out;
-    /* OPENSSL will allocate memory for us and make the ext_out point to it */
-
-
-    if (r->connection == NULL || r->connection->ssl == NULL) {
-        *err = "bad request";
-        return NGX_ERROR;
-    }
-
-    ssl_conn = r->connection->ssl->connection;
-    if (ssl_conn == NULL) {
-        *err = "bad ssl conn";
-        return NGX_ERROR;
-    }
-
-#ifdef SSL_ERROR_WANT_CLIENT_HELLO_CB
-    got_extensions = SSL_client_hello_get1_extensions_present(ssl_conn,
-                                                           &ext_out, &ext_len);
-    if (!got_extensions || !ext_out || !ext_len) {
-        *err = "failed SSL_client_hello_get1_extensions_present()";
-        return NGX_DECLINED;
-    }
-
-    *extensions = ngx_palloc(r->connection->pool, sizeof(int) * ext_len);
-    if (*extensions != NULL) {
-        ngx_memcpy(*extensions, ext_out, sizeof(int) * ext_len);
-        *extensions_len = ext_len;
-    }
-
-    OPENSSL_free(ext_out);
-    return NGX_OK;
-#else
-    *err = "OpenSSL too old to support this function";
-    return NGX_ERROR;
-#endif
-}
-
-
 int ngx_http_lua_ffi_ssl_get_client_hello_ciphers(ngx_http_request_t *r,
-                      unsigned short **ciphers,  size_t *cipherslen, char **err)
+                     unsigned short **ciphers,  size_t *ciphers_cnt, char **err)
 {
     ngx_ssl_conn_t          *ssl_conn;
-    size_t                   ciphersuites_length;
+    size_t                   ciphersuites_bytes;
     const unsigned char     *ciphers_raw;
+    unsigned short          *ciphers_ja3;
+    ngx_connection_t        *c;
 
 
     if (r->connection == NULL || r->connection->ssl == NULL) {
@@ -726,32 +683,38 @@ int ngx_http_lua_ffi_ssl_get_client_hello_ciphers(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-#ifdef SSL_ERROR_WANT_CLIENT_HELLO_CB
-    ciphersuites_length = SSL_client_hello_get0_ciphers(ssl_conn, &ciphers_raw);
+    c = ngx_ssl_get_connection(ssl_conn);
+    if (c == NULL) {
+        *err = "couldn't get real ngx_connection_t pointer";
+        return NGX_ERROR;
+    }
 
-    if (!ciphersuites_length) {
+#ifdef SSL_ERROR_WANT_CLIENT_HELLO_CB
+    ciphersuites_bytes = SSL_client_hello_get0_ciphers(ssl_conn, &ciphers_raw);
+
+    if (!ciphersuites_bytes) {
         *err = "failed SSL_client_hello_get0_ciphers()";
         return NGX_DECLINED;
     }
 
-    if (ciphersuites_length %2 != 0) {
-        *err = "SSL_client_hello_get0_ciphers() odd ciphersuites_length";
+    if (ciphersuites_bytes % 2 != 0) {
+        *err = "SSL_client_hello_get0_ciphers() odd ciphersuites_bytes";
         return NGX_DECLINED;
     }
 
-    *cipherslen = ciphersuites_length / 2;
+    *ciphers_cnt = ciphersuites_bytes / 2;
 
-    *ciphers = ngx_palloc(r->connection->pool, sizeof(int) * (*cipherslen));
+    *ciphers = ngx_palloc(c->pool, sizeof(short) * (*ciphers_cnt));
     if (*ciphers == NULL) {
-        *err = "failed to ngx_palloc() for the ciphers' array";
+        *err = "ngx_palloc() failed for the ciphers array";
         return NGX_ERROR;
     }
 
-    for (int i = 0 ; i < *cipherslen ; i++) {
+    for (int i = 0 ; i < *ciphers_cnt ; i++) {
         uint16_t cipher = (ciphers_raw[i*2] << 8) | ciphers_raw[i*2 + 1];
-
-        (*ciphers)[i] = cipher;
+        (*ciphers)[i] = cipher; /* like ntohs but more portable, supposedly */
     }
+
 
     return NGX_OK;
 #else

--- a/src/ngx_http_lua_ssl_client_helloby.c
+++ b/src/ngx_http_lua_ssl_client_helloby.c
@@ -707,6 +707,60 @@ ngx_http_lua_ffi_ssl_get_client_hello_ext_present(ngx_http_request_t *r,
 }
 
 
+int ngx_http_lua_ffi_ssl_get_client_hello_ciphers(ngx_http_request_t *r,
+                      unsigned short **ciphers,  size_t *cipherslen, char **err)
+{
+    ngx_ssl_conn_t          *ssl_conn;
+    size_t                   ciphersuites_length;
+    const unsigned char     *ciphers_raw;
+
+
+    if (r->connection == NULL || r->connection->ssl == NULL) {
+        *err = "bad request";
+        return NGX_ERROR;
+    }
+
+    ssl_conn = r->connection->ssl->connection;
+    if (ssl_conn == NULL) {
+        *err = "bad ssl conn";
+        return NGX_ERROR;
+    }
+
+#ifdef SSL_ERROR_WANT_CLIENT_HELLO_CB
+    ciphersuites_length = SSL_client_hello_get0_ciphers(ssl_conn, &ciphers_raw);
+
+    if (!ciphersuites_length) {
+        *err = "failed SSL_client_hello_get0_ciphers()";
+        return NGX_DECLINED;
+    }
+
+    if (ciphersuites_length %2 != 0) {
+        *err = "SSL_client_hello_get0_ciphers() odd ciphersuites_length";
+        return NGX_DECLINED;
+    }
+
+    *cipherslen = ciphersuites_length / 2;
+
+    *ciphers = ngx_palloc(r->connection->pool, sizeof(int) * (*cipherslen));
+    if (*ciphers == NULL) {
+        *err = "failed to ngx_palloc() for the ciphers' array";
+        return NGX_ERROR;
+    }
+
+    for (int i = 0 ; i < *cipherslen ; i++) {
+        uint16_t cipher = (ciphers_raw[i*2] << 8) | ciphers_raw[i*2 + 1];
+
+        (*ciphers)[i] = cipher;
+    }
+
+    return NGX_OK;
+#else
+    *err = "OpenSSL too old to support this function";
+    return NGX_ERROR;
+#endif
+}
+
+
 int
 ngx_http_lua_ffi_ssl_set_protocols(ngx_http_request_t *r,
     int protocols, char **err)


### PR DESCRIPTION
Partially inspired by:
	https://github.com/naofumi0628/haproxy/blob/fefb9e37714bd2e3ad2adc3a321e165fc1dafae2/src/ssl_sock.c#L2252

Relevant:
	https://github.com/fooinha/nginx-ssl-ja3/issues/64
        https://github.com/openssl/openssl/issues/27580

And especially:
	https://github.com/openresty/lua-nginx-module#:~:text=after%20SSL%20handshake%2C-,the%20ngx.ctx%20created,-in%20ssl_certificate_by_lua*

It might be pointless for me to pull all this data into Lua-land if I don't find a way to store those values. I need some kind of ngx.ctx but related not a request but to a connection instead of a request.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
