### PR TITLE
bugfix: Semaphore not cleaned up on request timeout

### DIFF
--- a/src/ngx_http_lua_semaphore.h
+++ b/src/ngx_http_lua_semaphore.h
@@ -41,6 +41,11 @@ typedef struct ngx_http_lua_sema_s {
 } ngx_http_lua_sema_t;
 
 
+typedef struct ngx_http_lua_sema_ctx_s {
+    ngx_http_lua_sema_t                 *sem;
+} ngx_http_lua_sema_ctx_t;
+
+
 void ngx_http_lua_sema_mm_cleanup(void *data);
 ngx_int_t ngx_http_lua_sema_mm_init(ngx_conf_t *cf,
     ngx_http_lua_main_conf_t *lmcf);


### PR DESCRIPTION
After a ngx.semaphore.wait() call, if the current request is terminated by Nginx due to client_header_timeout or client_body_timeout, the corresponding post() is never executed. As a result, all subsequent attempts to wait() on the same semaphore hang until they time out, because the semaphore count was never restored.

https://github.com/openresty/lua-nginx-module/issues/2422

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
