### PR TITLE
bugfix: improve HTTP/3 SSL Lua callback yield handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,7 +137,7 @@ script:
   - cd lua-cjson/ && make -j$JOBS && sudo make install && cd ..
   #- if [ -n "$PCRE2_VER" ]; then tar zxf download-cache/pcre2-$PCRE2_VER.tar.gz; cd pcre2-$PCRE2_VER/; ./configure --prefix=$PCRE2_PREFIX --enable-jit --enable-utf > build.log 2>&1 || (cat build.log && exit 1); make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1); sudo PATH=$PATH make install > build.log 2>&1 || (cat build.log && exit 1); cd ..; fi
   #- if [ -n "$OPENSSL_VER" ]; then tar zxf download-cache/openssl-$OPENSSL_VER.tar.gz; cd openssl-$OPENSSL_VER/; patch -p1 < ../../openresty/patches/openssl-$OPENSSL_PATCH_VER-sess_set_get_cb_yield.patch; ./config shared enable-ssl3 enable-ssl3-method -g --prefix=$OPENSSL_PREFIX --libdir=lib -DPURIFY > build.log 2>&1 || (cat build.log && exit 1); make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1); sudo make PATH=$PATH install_sw > build.log 2>&1 || (cat build.log && exit 1); cd ..; fi
-  - if [ -n "$BORINGSSL" ]; then sudo rm -fr /usr/local/openresty/openssl3/ && sudo tar -C /usr/local/openresty/openssl3 -xf boringssl-20230902-x64-focal.tar.gz --strip-components=1; fi
+  - if [ -n "$BORINGSSL" ]; then sudo rm -fr /usr/local/openresty/openssl3/ && sudo mkdir -p /usr/local/openresty/openssl3 && sudo tar -C /usr/local/openresty/openssl3 -xf boringssl-20230902-x64-focal.tar.gz --strip-components=1; fi
   - export NGX_BUILD_CC=$CC
   - sh util/build-without-ssl.sh $NGINX_VERSION > build.log 2>&1 || (cat build.log && exit 1)
   - sh util/build-with-dd.sh $NGINX_VERSION > build.log 2>&1 || (cat build.log && exit 1)

--- a/src/ngx_http_lua_ssl_certby.c
+++ b/src/ngx_http_lua_ssl_certby.c
@@ -346,7 +346,6 @@ ngx_http_lua_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
 
     return -1;
 
-#if 1
 failed:
 
     if (r && r->pool) {
@@ -358,15 +357,14 @@ failed:
     }
 
     return 0;
-#endif
 }
 
 
 static void
 ngx_http_lua_ssl_cert_done(void *data)
 {
-    ngx_connection_t                *c;
-    ngx_http_lua_ssl_ctx_t          *cctx = data;
+    ngx_connection_t        *c;
+    ngx_http_lua_ssl_ctx_t  *cctx = data;
 
     dd("lua ssl cert done");
 
@@ -387,6 +385,12 @@ ngx_http_lua_ssl_cert_done(void *data)
     c->log->action = "SSL handshaking";
 
     ngx_post_event(c->write, &ngx_posted_events);
+
+#if (NGX_HTTP_V3) && OPENSSL_VERSION_NUMBER >= 0x1000205fL
+#   if (NGX_QUIC_OPENSSL_COMPAT)
+    ngx_http_lua_resume_quic_ssl_handshake(c);
+#   endif
+#endif
 }
 
 

--- a/src/ngx_http_lua_ssl_client_helloby.c
+++ b/src/ngx_http_lua_ssl_client_helloby.c
@@ -341,7 +341,6 @@ ngx_http_lua_ssl_client_hello_handler(ngx_ssl_conn_t *ssl_conn,
 
     return -1;
 
-#if 1
 failed:
 
     if (r && r->pool) {
@@ -353,15 +352,14 @@ failed:
     }
 
     return 0;
-#endif
 }
 
 
 static void
 ngx_http_lua_ssl_client_hello_done(void *data)
 {
-    ngx_connection_t                *c;
-    ngx_http_lua_ssl_ctx_t          *cctx = data;
+    ngx_connection_t        *c;
+    ngx_http_lua_ssl_ctx_t  *cctx = data;
 
     dd("lua ssl client hello done");
 
@@ -382,6 +380,12 @@ ngx_http_lua_ssl_client_hello_done(void *data)
     c->log->action = "SSL handshaking";
 
     ngx_post_event(c->write, &ngx_posted_events);
+
+#if (NGX_HTTP_V3) && defined(SSL_ERROR_WANT_CLIENT_HELLO_CB)
+#   if (NGX_QUIC_OPENSSL_COMPAT)
+    ngx_http_lua_resume_quic_ssl_handshake(c);
+#   endif
+#endif
 }
 
 
@@ -666,6 +670,7 @@ int
 ngx_http_lua_ffi_ssl_get_client_hello_ext_present(ngx_http_request_t *r,
     int **extensions, size_t *extensions_len, char **err)
 {
+#ifdef SSL_ERROR_WANT_CLIENT_HELLO_CB
     ngx_ssl_conn_t          *ssl_conn;
     int                      got_extensions;
     size_t                   ext_len;
@@ -684,7 +689,6 @@ ngx_http_lua_ffi_ssl_get_client_hello_ext_present(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-#ifdef SSL_ERROR_WANT_CLIENT_HELLO_CB
     got_extensions = SSL_client_hello_get1_extensions_present(ssl_conn,
                                                            &ext_out, &ext_len);
     if (!got_extensions || !ext_out || !ext_len) {
@@ -710,6 +714,7 @@ ngx_http_lua_ffi_ssl_get_client_hello_ext_present(ngx_http_request_t *r,
 int ngx_http_lua_ffi_ssl_get_client_hello_ciphers(ngx_http_request_t *r,
     unsigned short *ciphers,  size_t ciphers_size, char **err)
 {
+#ifdef SSL_ERROR_WANT_CLIENT_HELLO_CB
     int                      i;
     size_t                   ciphers_cnt;
     size_t                   ciphersuites_bytes;
@@ -727,8 +732,6 @@ int ngx_http_lua_ffi_ssl_get_client_hello_ciphers(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-
-#ifdef SSL_ERROR_WANT_CLIENT_HELLO_CB
     ciphersuites_bytes = SSL_client_hello_get0_ciphers(ssl_conn, &ciphers_raw);
 
     if (ciphersuites_bytes == 0) {

--- a/src/ngx_http_lua_util.h
+++ b/src/ngx_http_lua_util.h
@@ -267,6 +267,10 @@ ngx_addr_t *ngx_http_lua_parse_addr(lua_State *L, u_char *text, size_t len);
 
 size_t ngx_http_lua_escape_log(u_char *dst, u_char *src, size_t size);
 
+#if (NGX_HTTP_V3)
+void ngx_http_lua_resume_quic_ssl_handshake(ngx_connection_t *c);
+#endif
+
 
 static ngx_inline void
 ngx_http_lua_init_ctx(ngx_http_request_t *r, ngx_http_lua_ctx_t *ctx)

--- a/t/143-ssl-session-fetch.t
+++ b/t/143-ssl-session-fetch.t
@@ -9,6 +9,12 @@ repeat_each(3);
 
 plan tests => repeat_each() * (blocks() * 6) - 3;
 
+my $NginxBinary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
+my $openssl_version = eval { `$NginxBinary -V 2>&1` };
+if ($openssl_version =~ m/BoringSSL/) {
+    $ENV{TEST_NGINX_USE_BORINGSSL} = 1;
+}
+
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 
 $ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
@@ -138,11 +144,12 @@ ssl_session_fetch_by_lua\(nginx\.conf:25\):1: ssl fetch sess by lua is running!,
 
         server_tokens off;
     }
+--- skip_eval: 6:$ENV{TEST_NGINX_USE_BORINGSSL}
 --- config
     server_tokens off;
     resolver $TEST_NGINX_RESOLVER ipv6=off;
     lua_ssl_trusted_certificate $TEST_NGINX_CERT_DIR/cert/test.crt;
-    lua_ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+    lua_ssl_protocols TLSv1 TLSv1.1 TLSV1.2 TLSv1.3;
 
     location /t {
         set $port $TEST_NGINX_MEMCACHED_PORT;


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

https://github.com/openresty/openresty/pull/1063
https://github.com/openresty/openresty-devel-utils/pull/58

### Problem Description
When using HTTP/3, yield Lua APIs (such as ngx.sleep, cosocket, ngx.thread.*, etc.) in ssl_certificate_by_lua* and ssl_client_hello_by_lua* directives cannot work properly, causing HTTP/3 request connections to be abnormally disconnected.

### Root Cause
HTTP/3 in nginx is implemented through QUIC code, and its SSL handling mechanism is significantly different from traditional HTTP/1.x and HTTP/2. 

### Solution
Currently, nginx QUIC SSL has three implementation approaches:

1. OpenSSL traditional interface compatibility mode (target of this fix)
2. BoringSSL implementation
3. OpenSSL 3.5+ official external QUIC library interface

Since OpenResty has not yet been upgraded to adapt to the latest nginx version, currently only the first compatibility mode is supported by default.

This fix specifically targets the first approach - the OpenSSL traditional interface compatibility mode. The implementation requires some simple modifications to nginx to ensure that nginx does not treat callback yield errors during ssl_do_handshake as fatal errors https://github.com/openresty/openresty/pull/1063
 . Additionally, the lua-nginx-module needs to explicitly call ssl_do_handshake after successful Lua script execution to further advance the QUIC handshake interaction.

### TODO:

1. Future nginx version adaptation: Support for OpenSSL 3.5 latest standard interface when adapting to the newest nginx versions
2. Session fetch limitation: This fix currently does not include ssl_session_fetch_by_lua Lua functionality, as nginx QUIC implemented through the first approach (OpenSSL traditional interface) does not support Zero RTT, making the fix unnecessary at this time. However, future support will be considered.
3. OpenResty has incomplete support for BoringSSL, but adding full support may be considered in the future.
