### PR TITLE
bugfix: resolve subrequest cycle issue when Lua code cache is disabled

### DIFF
--- a/src/ngx_http_lua_accessby.c
+++ b/src/ngx_http_lua_accessby.c
@@ -173,6 +173,10 @@ ngx_http_lua_access_handler_inline(ngx_http_request_t *r)
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
+    if (!llcf->enable_code_cache) {
+        llcf->access_src_ref = LUA_REFNIL;
+    }
+
     /*  load Lua inline script (w/ cache) sp = 1 */
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->access_src.value.data,
@@ -213,6 +217,10 @@ ngx_http_lua_access_handler_file(ngx_http_request_t *r)
     }
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
+
+    if (!llcf->enable_code_cache) {
+        llcf->access_src_ref = LUA_REFNIL;
+    }
 
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,

--- a/src/ngx_http_lua_bodyfilterby.c
+++ b/src/ngx_http_lua_bodyfilterby.c
@@ -155,6 +155,10 @@ ngx_http_lua_body_filter_inline(ngx_http_request_t *r, ngx_chain_t *in)
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
+    if (!llcf->enable_code_cache) {
+        llcf->body_filter_src_ref = LUA_REFNIL;
+    }
+
     /*  load Lua inline script (w/ cache) sp = 1 */
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->body_filter_src.value.data,
@@ -205,6 +209,10 @@ ngx_http_lua_body_filter_file(ngx_http_request_t *r, ngx_chain_t *in)
     }
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
+
+    if (!llcf->enable_code_cache) {
+        llcf->body_filter_src_ref = LUA_REFNIL;
+    }
 
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,

--- a/src/ngx_http_lua_contentby.c
+++ b/src/ngx_http_lua_contentby.c
@@ -267,6 +267,10 @@ ngx_http_lua_content_handler_file(ngx_http_request_t *r)
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
+    if (!llcf->enable_code_cache) {
+        llcf->content_src_ref = LUA_REFNIL;
+    }
+
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,
                                      &llcf->content_src_ref,
@@ -296,6 +300,10 @@ ngx_http_lua_content_handler_inline(ngx_http_request_t *r)
     llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
+
+    if (!llcf->enable_code_cache) {
+        llcf->content_src_ref = LUA_REFNIL;
+    }
 
     /*  load Lua inline script (w/ cache) sp = 1 */
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,

--- a/src/ngx_http_lua_headerfilterby.c
+++ b/src/ngx_http_lua_headerfilterby.c
@@ -165,6 +165,10 @@ ngx_http_lua_header_filter_inline(ngx_http_request_t *r)
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
+    if (!llcf->enable_code_cache) {
+        llcf->header_filter_src_ref = LUA_REFNIL;
+    }
+
     /*  load Lua inline script (w/ cache) sp = 1 */
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->header_filter_src.value.data,
@@ -209,6 +213,10 @@ ngx_http_lua_header_filter_file(ngx_http_request_t *r)
     }
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
+
+    if (!llcf->enable_code_cache) {
+        llcf->header_filter_src_ref = LUA_REFNIL;
+    }
 
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,

--- a/src/ngx_http_lua_logby.c
+++ b/src/ngx_http_lua_logby.c
@@ -149,6 +149,10 @@ ngx_http_lua_log_handler_inline(ngx_http_request_t *r)
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
+    if (!llcf->enable_code_cache) {
+        llcf->log_src_ref = LUA_REFNIL;
+    }
+
     /*  load Lua inline script (w/ cache) sp = 1 */
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->log_src.value.data,
@@ -187,6 +191,10 @@ ngx_http_lua_log_handler_file(ngx_http_request_t *r)
     }
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
+
+    if (!llcf->enable_code_cache) {
+        llcf->log_src_ref = LUA_REFNIL;
+    }
 
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,

--- a/src/ngx_http_lua_rewriteby.c
+++ b/src/ngx_http_lua_rewriteby.c
@@ -177,6 +177,10 @@ ngx_http_lua_rewrite_handler_inline(ngx_http_request_t *r)
     llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
     L = ngx_http_lua_get_lua_vm(r, NULL);
 
+    if (!llcf->enable_code_cache) {
+        llcf->rewrite_src_ref = LUA_REFNIL;
+    }
+
     /*  load Lua inline script (w/ cache) sp = 1 */
     rc = ngx_http_lua_cache_loadbuffer(r->connection->log, L,
                                        llcf->rewrite_src.value.data,
@@ -216,6 +220,10 @@ ngx_http_lua_rewrite_handler_file(ngx_http_request_t *r)
     }
 
     L = ngx_http_lua_get_lua_vm(r, NULL);
+
+    if (!llcf->enable_code_cache) {
+        llcf->rewrite_src_ref = LUA_REFNIL;
+    }
 
     /*  load Lua script file (w/ cache)        sp = 1 */
     rc = ngx_http_lua_cache_loadfile(r->connection->log, L, script_path,


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

Fix https://github.com/openresty/lua-nginx-module/issues/2041

Thanks for pointing out #2041, @rubyist1982.