### PR TITLE
optimize: add compatibility for freenginx

### DIFF
--- a/src/ngx_http_lua_subrequest.c
+++ b/src/ngx_http_lua_subrequest.c
@@ -1373,7 +1373,9 @@ ngx_http_lua_subrequest(ngx_http_request_t *r,
     ngx_str_t *uri, ngx_str_t *args, ngx_http_request_t **psr,
     ngx_http_post_subrequest_t *ps, ngx_uint_t flags)
 {
+#if !defined freenginx
     ngx_time_t                    *tp;
+#endif
     ngx_connection_t              *c;
     ngx_http_request_t            *sr;
     ngx_http_core_srv_conf_t      *cscf;
@@ -1501,9 +1503,13 @@ ngx_http_lua_subrequest(ngx_http_request_t *r,
     sr->subrequests = r->subrequests - 1;
 #endif
 
+#if (defined freenginx && nginx_version >= 1029000)
+    sr->start_time = ngx_current_msec;
+#else
     tp = ngx_timeofday();
     sr->start_sec = tp->sec;
     sr->start_msec = tp->msec;
+#endif
 
     r->main->count++;
 

--- a/src/ngx_http_lua_time.c
+++ b/src/ngx_http_lua_time.c
@@ -28,7 +28,21 @@ ngx_http_lua_ffi_now(void)
 double
 ngx_http_lua_ffi_req_start_time(ngx_http_request_t *r)
 {
+#if (defined freenginx && nginx_version >= 1029000)
+    ngx_time_t              *tp;
+
+    tp = ngx_timeofday();
+    tp->sec -= (ngx_current_msec - r->start_time) / 1000;
+    tp->msec -= (ngx_current_msec - r->start_time) % 1000;
+    if (tp->msec > NGX_MAX_INT_T_VALUE) {
+        tp->msec += 1000;
+        tp->sec -= 1;
+    }
+
+    return tp->sec + tp->msec / 1000.0;
+#else
     return r->start_sec + r->start_msec / 1000.0;
+#endif
 }
 
 


### PR DESCRIPTION
Commit freenginx/nginx@3329aa9 updated the ngx_http_request_t structure with the start_time; the start_sec and start_msec were removed.

Sponsored by:	tipi.work