### PR TITLE
feature: add ffi functions ngx_http_lua_ffi_socket_tcp_get_ssl_pointer() and ngx_http_lua_ffi_socket_tcp_get_ssl_ctx().

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3899,6 +3899,9 @@ Nginx API for Lua
 * [tcpsock:setoption](#tcpsocksetoption)
 * [tcpsock:setkeepalive](#tcpsocksetkeepalive)
 * [tcpsock:getreusedtimes](#tcpsockgetreusedtimes)
+* [tcpsock:getsslpointer](#tcpsockgetsslpointer)
+* [tcpsock:getsslctx](#tcpsockgetsslctx)
+* [tcpsock:getsslsession](#tcpsockgetsslsession)
 * [ngx.socket.connect](#ngxsocketconnect)
 * [ngx.get_phase](#ngxget_phase)
 * [ngx.thread.spawn](#ngxthreadspawn)
@@ -7962,6 +7965,9 @@ Creates and returns a TCP or stream-oriented unix domain socket object (also kno
 * [receiveuntil](#tcpsockreceiveuntil)
 * [setkeepalive](#tcpsocksetkeepalive)
 * [getreusedtimes](#tcpsockgetreusedtimes)
+* [tcpsock:getsslpointer](#tcpsockgetsslpointer)
+* [tcpsock:getsslctx](#tcpsockgetsslctx)
+* [tcpsock:getsslsession](#tcpsockgetsslsession)
 
 It is intended to be compatible with the TCP API of the [LuaSocket](http://w3.impa.br/~diego/software/luasocket/tcp.html) library but is 100% nonblocking out of the box. Also, we introduce some new APIs to provide more functionalities.
 
@@ -8230,6 +8236,51 @@ For connections that have already done SSL/TLS handshake, this method returns
 immediately.
 
 This method was first introduced in the `v0.9.11` release.
+
+[Back to TOC](#nginx-api-for-lua)
+
+tcpsock:getsslpointer
+--------------------
+
+**syntax:** *sslpointer, err = tcpsock:getsslpointer()*
+
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+
+Retrieves the underlying SSL pointer (SSL_CTX structure) of the cosocket connection.
+
+This method provides access to the raw OpenSSL SSL pointer, which is useful when third-party modules or FFI code need to perform low-level SSL operations directly on the connection. This enables cross-module operations and advanced SSL manipulations that are not exposed through the standard cosocket API.
+
+On success, returns the SSL pointer as a light userdata that can be passed to C functions via FFI. On failure, returns `nil` and a string describing the error.
+
+[Back to TOC](#nginx-api-for-lua)
+
+tcpsock:getsslctx
+--------------------
+
+**syntax:** *sslctx, err = tcpsock:getsslctx()*
+
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+
+Retrieves the underlying SSL pointer (SSL_CTX structure) of the cosocket connection.
+
+This method provides access to the raw OpenSSL SSL pointer, which is useful when third-party modules or FFI code need to perform low-level SSL operations directly on the connection. This enables cross-module operations and advanced SSL manipulations that are not exposed through the standard cosocket API.
+
+On success, returns the SSL pointer as a light userdata that can be passed to C functions via FFI. On failure, returns `nil` and a string describing the error.
+
+[Back to TOC](#nginx-api-for-lua)
+
+tcpsock:getsslsession
+-----------------------
+
+**syntax:** *session, err = tcpsock:getsslsession()*
+
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+
+Retrieves the SSL session object from the cosocket connection for session resumption purposes.
+
+While `tcpsock:sslhandshake()` also returns an SSL session, the server may not have sent the session resumption ticket to the client yet at that point, making the session non-reusable. By calling `getsslsession` after the request completes, you can obtain an SSL session that is more likely to be reusable for future connections. This session can then be passed to subsequent `sslhandshake()` calls to enable SSL session resumption, which reduces handshake overhead and improves connection performance.
+
+On success, returns the SSL session as a light userdata. On failure, returns `nil` and a string describing the error.
 
 [Back to TOC](#nginx-api-for-lua)
 

--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -2130,6 +2130,62 @@ ngx_http_lua_ffi_ssl_free_session(ngx_ssl_session_t *sess)
 }
 
 
+int
+ngx_http_lua_ffi_socket_tcp_get_ssl_pointer(ngx_http_request_t *r,
+    ngx_http_lua_socket_tcp_upstream_t *u, ngx_ssl_conn_t **pssl,
+    const char **errmsg)
+{
+    ngx_connection_t                      *c;
+
+    *pssl = NULL;
+    if (u == NULL
+        || u->peer.connection == NULL
+        || (u->read_closed && u->write_closed))
+    {
+        *errmsg = "closed";
+        return NGX_ERROR;
+    }
+
+    c = u->peer.connection;
+    if (c == NULL || c->ssl == NULL || c->ssl->connection == NULL) {
+        *errmsg = "no ssl connection";
+        return NGX_ERROR;
+    }
+
+    *pssl = c->ssl->connection;
+
+    return NGX_OK;
+}
+
+
+int
+ngx_http_lua_ffi_socket_tcp_get_ssl_ctx(ngx_http_request_t *r,
+    ngx_http_lua_socket_tcp_upstream_t *u, SSL_CTX **pctx,
+    const char **errmsg)
+{
+    ngx_connection_t                      *c;
+
+    *pctx = NULL;
+    if (u == NULL
+        || u->peer.connection == NULL
+        || (u->read_closed && u->write_closed))
+    {
+        *errmsg = "closed";
+        return NGX_ERROR;
+    }
+
+    c = u->peer.connection;
+    if (c == NULL || c->ssl == NULL || c->ssl->session_ctx == NULL) {
+        *errmsg = "no ssl context";
+        return NGX_ERROR;
+    }
+
+    *pctx = c->ssl->session_ctx;
+
+    return NGX_OK;
+}
+
+
 #endif  /* NGX_HTTP_SSL */
 
 


### PR DESCRIPTION
…i ngx_http_lua_ffi_socket_tcp_get_ssl_ctx().

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
