### PR TITLE
bugfix: fix the compatibility issue for freenginx.

### DIFF
--- a/src/ngx_http_lua_ssl_client_helloby.c
+++ b/src/ngx_http_lua_ssl_client_helloby.c
@@ -222,12 +222,14 @@ ngx_http_lua_ssl_client_hello_handler(ngx_ssl_conn_t *ssl_conn,
 
 #if (nginx_version > 1029001)
 #ifdef SSL_CLIENT_HELLO_SUCCESS
+#if !defined freenginx
     /* see commit 0373fe5d98c1515640 for more details */
     rc = ngx_ssl_client_hello_callback(ssl_conn, al, arg);
 
     if (rc == 0) {
         return rc;
     }
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

We encountered the following build failure because the freenginx has been defined `ngx_ssl_client_hello_callback`.
We should fix to build issue for freenginx.
```
$ make
make -f objs/Makefile
make[1]: Entering directory '/home/ubuntu/freenginx'
cc -c -I/usr/local/include/luajit-2.1  -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g  -DNDK_SET_VAR  -I src/core -I src/event -I src/event/modules -I src/event/quic -I src/os/unix -I /home/ubuntu/ngx_devel_kit/objs -I objs/addon/ndk -I /home/ubuntu/lua-nginx-module/src/api -I objs -I src/http -I src/http/modules -I /home/ubuntu/ngx_devel_kit/src -I /home/ubuntu/ngx_devel_kit/src -I /home/ubuntu/ngx_devel_kit/objs -I objs/addon/ndk -I /usr/local/include/luajit-2.1 \
        -o objs/addon/src/ngx_http_lua_ssl_client_helloby.o \
        /home/ubuntu/lua-nginx-module/src/ngx_http_lua_ssl_client_helloby.c
/home/ubuntu/lua-nginx-module/src/ngx_http_lua_ssl_client_helloby.c: In function ‘ngx_http_lua_ssl_client_hello_handler’:
/home/ubuntu/lua-nginx-module/src/ngx_http_lua_ssl_client_helloby.c:226:10: error: implicit declaration of function ‘ngx_ssl_client_hello_callback’ [-Werror=implicit-function-declaration]
  226 |     rc = ngx_ssl_client_hello_callback(ssl_conn, al, arg);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [objs/Makefile:1792: objs/addon/src/ngx_http_lua_ssl_client_helloby.o] Error 1
make[1]: Leaving directory '/home/ubuntu/freenginx'
make: *** [Makefile:10: build] Error 2
```