### PR TITLE
bugfix: allow table for multiple values in ngx.header['WWW-Authenticate'] fixes.

### DIFF
--- a/src/ngx_http_lua_headers_out.c
+++ b/src/ngx_http_lua_headers_out.c
@@ -80,7 +80,7 @@ static ngx_http_lua_set_header_t  ngx_http_lua_set_handlers[] = {
 
     { ngx_string("WWW-Authenticate"),
                  offsetof(ngx_http_headers_out_t, www_authenticate),
-                 ngx_http_set_builtin_header },
+                 ngx_http_set_builtin_multi_header },
 
     { ngx_string("Expires"),
                  offsetof(ngx_http_headers_out_t, expires),


### PR DESCRIPTION
With this patch it's possible to send multiple WWW-Authenticate headers from Lua:

Like so:
```
ngx.header["WWW-Authenticate"] = {"Negotiate", "NTLM", "Basic"}
```

And actually get:
```
www-authenticate: Negotiate
www-authenticate: NTLM
www-authenticate: Basic
```

instead of just one of them.

Fixes https://github.com/openresty/lua-nginx-module/issues/2400