### PR TITLE
doc: fix unencoded characters with ngx.escape_uri

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6432,7 +6432,7 @@ It accepts the following values (defaults to `2`):
 `?`, 0x00 ~ 0x1F, 0x7F ~ 0xFF will be escaped.
 * `2`: escape `str` as a URI component. All characters except
 alphabetic characters, digits, `-`, `.`, `_`,
-`~` will be encoded as `%XX`.
+`~`, `!`, `'`, `(`, `)`, `*` will be encoded as `%XX`.
 
 [Back to TOC](#nginx-api-for-lua)
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.


Fixes: #2468 

 It seems to be incorrect its document. *()'! are defined as sub-delims characters which should not be encoded in case of their delimiter in RFC3986. To keep backward compatibilities, and follow nginx behavior, we should fix its doc now.
https://www.rfc-editor.org/rfc/rfc3986#section-2.2