### PR TITLE
bugfix: reject settrustedstore on already-handshaked cosocket

### DIFF
--- a/src/ngx_http_lua_socket_tcp.c
+++ b/src/ngx_http_lua_socket_tcp.c
@@ -2283,6 +2283,14 @@ ngx_http_lua_ffi_socket_tcp_settrustedstore(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
+    if (u->peer.connection->ssl
+        && u->peer.connection->ssl->handshaked)
+    {
+        *errmsg = "ssl handshake already done; trusted store cannot be "
+                  "changed on an established TLS connection";
+        return NGX_ERROR;
+    }
+
     u->ssl_trusted_store = store;
 
     return NGX_OK;

--- a/t/193-ssl-trusted-store.t
+++ b/t/193-ssl-trusted-store.t
@@ -352,3 +352,68 @@ settrustedstore: true nil
 [alert]
 [crit]
 [emerg]
+
+
+
+=== TEST 6: settrustedstore is rejected after the TLS handshake has completed
+--- http_config eval: $::tls_http_config
+--- config eval
+"
+    location /t {
+        content_by_lua_block {
+            local f = assert(io.open('$::HtmlDir/mtls_ca.crt'))
+            local ca_pem = f:read('*a')
+            f:close()
+
+            local store1 = assert(load_store_from_pem(ca_pem))
+
+            local sock = ngx.socket.tcp()
+            assert(sock:connect('unix:$::HtmlDir/tls.sock'))
+
+            assert(settrustedstore(sock, store1))
+
+            local sess, err = sock:sslhandshake(nil, 'example.com', true)
+            if not sess then
+                ngx.say('failed to do SSL handshake: ', err)
+                return
+            end
+
+            -- second settrustedstore on an already-handshaked cosocket
+            -- must fail with a clear error rather than silently no-op.
+            local f2 = assert(io.open('$::HtmlDir/unrelated_ca.crt'))
+            local ca_pem2 = f2:read('*a')
+            f2:close()
+            local store2 = assert(load_store_from_pem(ca_pem2))
+
+            local ok, err = settrustedstore(sock, store2)
+            ngx.say('settrustedstore after handshake: ', ok, ' ', err)
+
+            -- connection must still be usable after the rejected call.
+            local bytes, err = sock:send('GET / HTTP/1.0\\r\\nHost: example.com\\r\\n\\r\\n')
+            if not bytes then
+                ngx.say('failed to send: ', err)
+                return
+            end
+
+            local line, err = sock:receive('*l')
+            if not line then
+                ngx.say('failed to receive: ', err)
+                return
+            end
+
+            ngx.say('received: ', line)
+            sock:close()
+        }
+    }
+"
+--- user_files eval: $::tls_user_files
+--- request
+GET /t
+--- response_body_like
+^settrustedstore after handshake: nil ssl handshake already done; trusted store cannot be changed on an established TLS connection
+received: HTTP/1\.[01] 200 OK$
+--- no_error_log
+[error]
+[alert]
+[crit]
+[emerg]


### PR DESCRIPTION
## Summary

`tcpsock:settrustedstore()` called on a cosocket whose TLS handshake has already completed silently became a no-op, while appearing to succeed. The new `X509_STORE` was stashed into `u->ssl_trusted_store`, but a subsequent `tcpsock:sslhandshake()` short-circuits via the `c->ssl->handshaked` early return in `ngx_http_lua_ffi_socket_tcp_sslhandshake` and never reaches the `SSL_set1_verify_cert_store()` block at `src/ngx_http_lua_socket_tcp.c:1942`. As a result the connection continued to verify the peer against the trust anchor configured before the first handshake — users believed they had swapped trust anchors, but they had not.

## Fix

Reject the call at the FFI entry when the underlying TLS connection is already established, so callers get a clear error instead of a silently ineffective swap.

```c
if (u->peer.connection->ssl
    && u->peer.connection->ssl->handshaked)
{
    *errmsg = "ssl handshake already done; trusted store cannot be "
              "changed on an established TLS connection";
    return NGX_ERROR;
}
```

- Scope is intentionally narrow: only `ngx_http_lua_ffi_socket_tcp_settrustedstore` is touched.
- The handshake state machine and session-reuse semantics are unchanged.
- Returning `NGX_ERROR` here is the existing FFI argument-validation path — it does not close the connection; the Lua wrapper just surfaces `nil, err` to the caller.

## Reproduce (before patch)

```lua
local sock = ngx.socket.tcp()
sock:connect(host, 443)
sock:settrustedstore(store_a)
sock:sslhandshake(false, host, true)   -- verified against store_a

sock:settrustedstore(store_b)          -- silently stored
sock:sslhandshake(false, host, true)   -- returns OK, still verified against store_a
```

After the patch the second `settrustedstore` returns `nil, "ssl handshake already done; trusted store cannot be changed on an established TLS connection"`.

## Notes

The same early-return path in `ffi_socket_tcp_sslhandshake` also ignores re-supplied `verify`, SNI, OCSP and client cert/key when the cosocket is already handshaked. Those are out of scope for this PR — happy to do a follow-up if maintainers want symmetric protection at the same layer.