### PR TITLE
bugfix: change return values to NGX_DECLINED in precontent_by_lua

### DIFF
--- a/src/ngx_http_lua_precontentby.c
+++ b/src/ngx_http_lua_precontentby.c
@@ -97,30 +97,27 @@ ngx_http_lua_precontent_handler(ngx_http_request_t *r)
             return rc;
         }
 
-        if (rc == NGX_OK) {
-            if (r->header_sent
-                || (r->headers_out.status != 0 && ctx->out != NULL))
-            {
-                dd("header already sent");
+        if (rc == NGX_OK
+            && (r->header_sent
+                || (r->headers_out.status != 0 && ctx->out != NULL)))
+        {
+            dd("header already sent");
 
-                /* response header was already generated in precontent_by_lua*,
-                 * so it is no longer safe to proceed to later phases
-                 * which may generate responses again */
+            /* response header was already generated in precontent_by_lua*,
+             * so it is no longer safe to proceed to later phases
+             * which may generate responses again */
 
-                if (!ctx->eof) {
-                    dd("eof not yet sent");
+            if (!ctx->eof) {
+                dd("eof not yet sent");
 
-                    rc = ngx_http_lua_send_chain_link(r, ctx, NULL
-                                                     /* indicate last_buf */);
-                    if (rc == NGX_ERROR || rc > NGX_OK) {
-                        return rc;
-                    }
+                rc = ngx_http_lua_send_chain_link(r, ctx, NULL
+                                                  /* indicate last_buf */);
+                if (rc == NGX_ERROR || rc > NGX_OK) {
+                    return rc;
                 }
-
-                return NGX_HTTP_OK;
             }
 
-            return NGX_OK;
+            return NGX_HTTP_OK;
         }
 
         return NGX_DECLINED;
@@ -373,32 +370,28 @@ ngx_http_lua_precontent_by_chunk(lua_State *L, ngx_http_request_t *r)
         }
     }
 
-#if 1
-    if (rc == NGX_OK) {
-        if (r->header_sent || (r->headers_out.status != 0 && ctx->out != NULL))
-        {
-            dd("header already sent");
+    if (rc == NGX_OK
+        && (r->header_sent
+            || (r->headers_out.status != 0 && ctx->out != NULL)))
+    {
+        dd("header already sent");
 
-            /* response header was already generated in precontent_by_lua*,
-             * so it is no longer safe to proceed to later phases
-             * which may generate responses again */
+        /* response header was already generated in precontent_by_lua*,
+         * so it is no longer safe to proceed to later phases
+         * which may generate responses again */
 
-            if (!ctx->eof) {
-                dd("eof not yet sent");
+        if (!ctx->eof) {
+            dd("eof not yet sent");
 
-                rc = ngx_http_lua_send_chain_link(r, ctx, NULL
-                                                  /* indicate last_buf */);
-                if (rc == NGX_ERROR || rc > NGX_OK) {
-                    return rc;
-                }
+            rc = ngx_http_lua_send_chain_link(r, ctx, NULL
+                                              /* indicate last_buf */);
+            if (rc == NGX_ERROR || rc > NGX_OK) {
+                return rc;
             }
-
-            return NGX_HTTP_OK;
         }
 
-        return NGX_OK;
+        return NGX_HTTP_OK;
     }
-#endif
 
     return NGX_DECLINED;
 }

--- a/t/189-precontent.t
+++ b/t/189-precontent.t
@@ -19,7 +19,7 @@ our $StapScript = $t::StapThread::StapScript;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 3 + 6);
+plan tests => repeat_each() * (blocks() * 3 + 8);
 
 #log_level("info");
 #no_long_string();
@@ -359,5 +359,66 @@ GET /lua
 content phase executed
 --- error_log
 precontent_by_lua_block executed
+--- no_error_log
+[error]
+
+
+
+=== TEST 16: no postpone continues to later precontent handlers
+--- http_config
+    precontent_by_lua_no_postpone on;
+--- config
+    location /lua {
+        precontent_by_lua_block {
+            ngx.log(ngx.INFO, "precontent_by_lua_block executed")
+        }
+        try_files /not-found @fallback;
+        content_by_lua_block {
+            ngx.say("original location")
+        }
+    }
+
+    location @fallback {
+        content_by_lua_block {
+            ngx.say("fallback location")
+        }
+    }
+--- request
+GET /lua
+--- response_body
+fallback location
+--- error_log
+precontent_by_lua_block executed
+--- no_error_log
+[error]
+
+
+
+=== TEST 17: no postpone continues after yielding
+--- http_config
+    precontent_by_lua_no_postpone on;
+--- config
+    location /lua {
+        precontent_by_lua_block {
+            ngx.sleep(0.001)
+            ngx.log(ngx.INFO, "precontent_by_lua_block resumed")
+        }
+        try_files /not-found @fallback;
+        content_by_lua_block {
+            ngx.say("original location")
+        }
+    }
+
+    location @fallback {
+        content_by_lua_block {
+            ngx.say("fallback location")
+        }
+    }
+--- request
+GET /lua
+--- response_body
+fallback location
+--- error_log
+precontent_by_lua_block resumed
 --- no_error_log
 [error]


### PR DESCRIPTION
NGX_HTTP_PRECONTENT_PHASE uses ngx_http_core_generic_phase. Previous implementations were ported from access_by_lua*, and the handler would return NGX_OK at the end. If "preaccess_by_lua_no_postpone on;" is configured, subsequent handlers in the same phase would be skipped. Therefore, it should return NGX_DECLINED instead.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
