### PR TITLE
style: fixed code style.

### DIFF
--- a/src/ngx_http_lua_accessby.c
+++ b/src/ngx_http_lua_accessby.c
@@ -64,8 +64,8 @@ ngx_http_lua_access_handler(ngx_http_request_t *r)
 
             tmp = *cur_ph;
 
-            memmove(cur_ph, cur_ph + 1,
-                    (last_ph - cur_ph) * sizeof (ngx_http_phase_handler_t));
+            ngx_memmove(cur_ph, cur_ph + 1,
+                        (last_ph - cur_ph) * sizeof(ngx_http_phase_handler_t));
 
             *last_ph = tmp;
 

--- a/src/ngx_http_lua_precontentby.c
+++ b/src/ngx_http_lua_precontentby.c
@@ -56,8 +56,8 @@ ngx_http_lua_precontent_handler(ngx_http_request_t *r)
 
             tmp = *cur_ph;
 
-            memmove(cur_ph, cur_ph + 1,
-                    (last_ph - cur_ph) * sizeof (ngx_http_phase_handler_t));
+            ngx_memmove(cur_ph, cur_ph + 1,
+                        (last_ph - cur_ph) * sizeof(ngx_http_phase_handler_t));
 
             *last_ph = tmp;
 

--- a/src/ngx_http_lua_rewriteby.c
+++ b/src/ngx_http_lua_rewriteby.c
@@ -64,10 +64,10 @@ ngx_http_lua_rewrite_handler(ngx_http_request_t *r)
         if (cur_ph < last_ph) {
             dd("swapping the contents of cur_ph and last_ph...");
 
-            tmp      = *cur_ph;
+            tmp = *cur_ph;
 
-            memmove(cur_ph, cur_ph + 1,
-                    (last_ph - cur_ph) * sizeof (ngx_http_phase_handler_t));
+            ngx_memmove(cur_ph, cur_ph + 1,
+                        (last_ph - cur_ph) * sizeof(ngx_http_phase_handler_t));
 
             *last_ph = tmp;
 


### PR DESCRIPTION
Use nginx macros instead of the original "memmove" and remove unnecessary spaces.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
