### PR TITLE
bugfix: avoid truncating Lua context in filters

### DIFF
--- a/src/ngx_http_lua_bodyfilterby.c
+++ b/src/ngx_http_lua_bodyfilterby.c
@@ -241,7 +241,7 @@ ngx_http_lua_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     ngx_http_lua_loc_conf_t     *llcf;
     ngx_http_lua_ctx_t          *ctx;
     ngx_int_t                    rc;
-    uint16_t                     old_context;
+    uint32_t                     old_context;
     ngx_pool_cleanup_t          *cln;
     ngx_chain_t                 *out;
     ngx_chain_t                 *cl, *ln;

--- a/src/ngx_http_lua_headerfilterby.c
+++ b/src/ngx_http_lua_headerfilterby.c
@@ -240,7 +240,7 @@ ngx_http_lua_header_filter(ngx_http_request_t *r)
     ngx_http_lua_ctx_t          *ctx;
     ngx_int_t                    rc;
     ngx_pool_cleanup_t          *cln;
-    uint16_t                     old_context;
+    uint32_t                     old_context;
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "lua header filter for user lua code, uri \"%V\"", &r->uri);


### PR DESCRIPTION
The request context was widened from uint16_t to uint32_t when phase flags grew beyond 16 bits, but the header and body filters continued saving it in a uint16_t old_context variable.

Contexts above 0xffff were truncated while running a filter and restored as zero afterward. Use uint32_t for old_context to preserve the complete phase value.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
