### PR TITLE
feature: support cosocket and other yieldable APIs in init_worker_by_lua*

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1682,6 +1682,8 @@ Starting from this version, cosocket operations (e.g. `ngx.socket.tcp`, `ngx.soc
 
 Note that `ngx.timer.at` callbacks registered during this hook are deferred: they will not run until the init code finishes. This preserves the implicit ordering guarantee that timer callbacks registered in `init_worker_by_lua*` execute only after the init code completes.
 
+Note that the error log prefix for a runtime error in this context has changed: it is now `lua entry thread aborted:` (followed by a full Lua traceback), whereas before this release it was `init_worker_by_lua error:`. Alert rules that match the old string must be updated. Compile-time error messages are unchanged.
+
 [Back to TOC](#directives)
 
 init_worker_by_lua_file
@@ -3596,6 +3598,8 @@ lua_init_worker_timeout
 
 Sets the maximum wall-clock time that `init_worker_by_lua*` code is allowed to block worker startup. When the timeout is reached, the Lua code is forcibly aborted and the worker continues starting normally (the error is logged at the `ERR` level).
 
+When the timeout is reached, the running chunk coroutine is killed without being unwound. Consequently, an `ngx.timer.at` callback that captures locals of the `init_worker_by_lua*` chunk will read `nil` for those upvalues when the callback runs later. To access configuration or shared data from such a callback, use `ngx.shared`, `_G`, or the Lua registry directly instead of closing over chunk locals.
+
 The default value `0` means no timeout: a hung remote connection will block the worker indefinitely.
 
 The `<time>` argument can be an integer with an optional time unit, like `s` (second) or `ms` (millisecond). The default time unit is `s`. **Note: a bare number means seconds** — to specify milliseconds, you must write the `ms` suffix (e.g. `500ms`).
@@ -3621,7 +3625,7 @@ Note the following limitations:
 
 * This only covers errors that occur **before the first yield** (i.e. synchronous errors). Errors during a yielded cosocket operation are logged but do not trigger the abort.
 * When `on` is set, `exit_worker_by_lua*` is **not executed** — the worker exits via `exit(2)`, which bypasses the graceful shutdown hooks.
-* This directive cannot replace `lua_init_worker_timeout`: it only handles Lua runtime errors, not hung I/O operations.
+* This directive also covers a `lua_init_worker_timeout` expiry: with a bounded timeout and `on`, the worker exits with code 2 when the init code times out. Without a timeout, a hung I/O operation is never interrupted, so this directive cannot by itself bound a hung backend.
 * If the error is reproducible, setting `on` will cause a crash loop (the master keeps restarting a worker that immediately errors out).
 
 This directive was first introduced in this release.
@@ -4606,7 +4610,7 @@ ngx.location.capture
 
 **syntax:** *res = ngx.location.capture(uri, options?)*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Issues a synchronous but still non-blocking *Nginx Subrequest* using `uri`.
 
@@ -4928,7 +4932,7 @@ ngx.location.capture_multi
 
 **syntax:** *res1, res2, ... = ngx.location.capture_multi({ {uri, options?}, {uri, options?}, ... })*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Just like [ngx.location.capture](#ngxlocationcapture), but supports multiple subrequests running in parallel.
 
@@ -5020,7 +5024,7 @@ ngx.header.HEADER
 
 **syntax:** *value = ngx.header.HEADER*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;*
 
 Set, add to, or clear the current request's `HEADER` response header that is to be sent.
 
@@ -5568,7 +5572,7 @@ ngx.req.get_post_args
 
 **syntax:** *args, err = ngx.req.get_post_args(max_args?)*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;*
 
 Returns a Lua table holding all the current request POST query arguments (of the MIME type `application/x-www-form-urlencoded`). Call [ngx.req.read_body](#ngxreqread_body) to read the request body first or turn on the [lua_need_request_body](#lua_need_request_body) directive to avoid errors.
 
@@ -5836,7 +5840,7 @@ ngx.req.read_body
 
 **syntax:** *ngx.req.read_body()*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Reads the client request body synchronously without blocking the Nginx event loop.
 
@@ -5868,7 +5872,7 @@ ngx.req.discard_body
 
 **syntax:** *ngx.req.discard_body()*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Explicitly discard the request body, i.e., read the data on the connection and throw it away immediately (without using the request body by any means).
 
@@ -5887,7 +5891,7 @@ ngx.req.get_body_data
 
 **syntax:** *data = ngx.req.get_body_data(max_bytes?)*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, log_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, log_by_lua&#42;*
 
 Retrieves in-memory request body data. It returns a Lua string rather than a Lua table holding all the parsed query arguments. Use the [ngx.req.get_post_args](#ngxreqget_post_args) function instead if a Lua table is required.
 
@@ -5918,7 +5922,7 @@ ngx.req.get_body_file
 
 **syntax:** *file_name = ngx.req.get_body_file()*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Retrieves the file name for the in-file request body data. Returns `nil` if the request body has not been read or has been read into memory.
 
@@ -5943,7 +5947,7 @@ ngx.req.set_body_data
 
 **syntax:** *ngx.req.set_body_data(data)*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, balancer_by_lua&#42;,*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, balancer_by_lua&#42;,*
 
 Set the current request's request body using the in-memory data specified by the `data` argument.
 
@@ -5964,7 +5968,7 @@ ngx.req.set_body_file
 
 **syntax:** *ngx.req.set_body_file(file_name, auto_clean?)*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, balancer_by_lua&#42;,*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, balancer_by_lua&#42;,*
 
 Set the current request's request body using the in-file data specified by the `file_name` argument.
 
@@ -6059,7 +6063,7 @@ ngx.req.socket
 
 **syntax:** *tcpsock, err = ngx.req.socket(raw)*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Returns a read-only cosocket object that wraps the downstream connection. Only [receive](#tcpsockreceive), [receiveany](#tcpsockreceiveany) and [receiveuntil](#tcpsockreceiveuntil) methods are supported on this object.
 
@@ -6087,7 +6091,7 @@ ngx.exec
 
 **syntax:** *ngx.exec(uri, args?)*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Does an internal redirect to `uri` with `args` and is similar to the [echo_exec](http://github.com/openresty/echo-nginx-module#echo_exec) directive of the [echo-nginx-module](http://github.com/openresty/echo-nginx-module).
 
@@ -6155,7 +6159,7 @@ ngx.redirect
 
 **syntax:** *ngx.redirect(uri, status?)*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Issue an `HTTP 301` or `302` redirection to `uri`.
 
@@ -6248,7 +6252,7 @@ ngx.send_headers
 
 **syntax:** *ok, err = ngx.send_headers()*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Explicitly send out the response headers.
 
@@ -6277,7 +6281,7 @@ ngx.print
 
 **syntax:** *ok, err = ngx.print(...)*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Emits arguments concatenated to the HTTP client (as response body). If response headers have not been sent, this function will send headers out first and then output body data.
 
@@ -6319,7 +6323,7 @@ ngx.say
 
 **syntax:** *ok, err = ngx.say(...)*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Just as [ngx.print](#ngxprint) but also emit a trailing newline.
 
@@ -6347,7 +6351,7 @@ ngx.flush
 
 **syntax:** *ok, err = ngx.flush(wait?)*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Flushes response output to the client.
 
@@ -6368,7 +6372,7 @@ ngx.exit
 
 **syntax:** *ngx.exit(status)*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 When `status >= 200` (i.e., `ngx.HTTP_OK` and above), it will interrupt the execution of the current request and return status code to Nginx.
 
@@ -6424,7 +6428,7 @@ ngx.eof
 
 **syntax:** *ok, err = ngx.eof()*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Explicitly specify the end of the response output stream. In the case of HTTP 1.1 chunked encoded output, it will just trigger the Nginx core to send out the "last chunk".
 
@@ -9311,7 +9315,7 @@ ngx.on_abort
 
 **syntax:** *ok, err = ngx.on_abort(callback)*
 
-**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Registers a user Lua function as the callback which gets called automatically when the client closes the (downstream) connection prematurely.
 

--- a/README.markdown
+++ b/README.markdown
@@ -811,7 +811,9 @@ Cosockets Not Available Everywhere
 
 Due to internal limitations in the Nginx core, the cosocket API is disabled in the following contexts: [set_by_lua*](#set_by_lua), [log_by_lua*](#log_by_lua), [header_filter_by_lua*](#header_filter_by_lua), and [body_filter_by_lua](#body_filter_by_lua).
 
-The cosockets are currently also disabled in the [init_by_lua*](#init_by_lua) and [init_worker_by_lua*](#init_worker_by_lua) directive contexts but we may add support for these contexts in the future because there is no limitation in the Nginx core (or the limitation might be worked around).
+The cosockets are currently also disabled in the [init_by_lua*](#init_by_lua) directive contexts but we may add support for these contexts in the future because there is no limitation in the Nginx core (or the limitation might be worked around).
+
+Cosockets **are now supported** in the [init_worker_by_lua*](#init_worker_by_lua_block) directive contexts. When a cosocket operation yields (e.g. during a `connect` or `receive` call), the module runs a lightweight event pump that drives the event loop until the operation completes or the [lua_init_worker_timeout](#lua_init_worker_timeout) budget is exhausted. Note that `ngx.timer.at` callbacks registered in `init_worker_by_lua*` are deferred until the init code finishes running.
 
 There exists a workaround, however, when the original context does *not* need to wait for the cosocket results. That is, creating a zero-delay timer via the [ngx.timer.at](#ngxtimerat) API and do the cosocket results in the timer handler, which runs asynchronously as to the original context creating the timer.
 
@@ -1190,6 +1192,8 @@ Directives
 * [lua_socket_pool_size](#lua_socket_pool_size)
 * [lua_socket_keepalive_timeout](#lua_socket_keepalive_timeout)
 * [lua_socket_log_errors](#lua_socket_log_errors)
+* [lua_init_worker_timeout](#lua_init_worker_timeout)
+* [lua_init_worker_abort_on_error](#lua_init_worker_abort_on_error)
 * [lua_ssl_ciphers](#lua_ssl_ciphers)
 * [lua_ssl_crl](#lua_ssl_crl)
 * [lua_ssl_protocols](#lua_ssl_protocols)
@@ -1673,6 +1677,10 @@ This hook is often used to create per-worker reoccurring timers (via the [ngx.ti
 This directive was first introduced in the `v0.9.17` release.
 
 This hook no longer runs in the cache manager and cache loader processes since the `v0.10.12` release.
+
+Starting from this version, cosocket operations (e.g. `ngx.socket.tcp`, `ngx.socket.udp`, `ngx.sleep`, `ngx.semaphore`, `ngx.thread.spawn`) are supported in this context. When such an operation yields, the module runs a lightweight event pump to drive the Nginx event loop until the operation completes. Use [lua_init_worker_timeout](#lua_init_worker_timeout) to bound how long the init code can block worker startup, and [lua_init_worker_abort_on_error](#lua_init_worker_abort_on_error) to control whether a Lua runtime error should abort the worker process.
+
+Note that `ngx.timer.at` callbacks registered during this hook are deferred: they will not run until the init code finishes. This preserves the implicit ordering guarantee that timer callbacks registered in `init_worker_by_lua*` execute only after the init code completes.
 
 [Back to TOC](#directives)
 
@@ -3577,6 +3585,49 @@ This directive was first introduced in the `v0.5.13` release.
 
 [Back to TOC](#directives)
 
+lua_init_worker_timeout
+-----------------------
+
+**syntax:** *lua_init_worker_timeout &lt;time&gt;*
+
+**default:** *lua_init_worker_timeout 0*
+
+**context:** *http*
+
+Sets the maximum wall-clock time that `init_worker_by_lua*` code is allowed to block worker startup. When the timeout is reached, the Lua code is forcibly aborted and the worker continues starting normally (the error is logged at the `ERR` level).
+
+The default value `0` means no timeout: a hung remote connection will block the worker indefinitely.
+
+The `<time>` argument can be an integer with an optional time unit, like `s` (second) or `ms` (millisecond). The default time unit is `s`. **Note: a bare number means seconds** — to specify milliseconds, you must write the `ms` suffix (e.g. `500ms`).
+
+It is strongly recommended to set this directive to a bounded value whenever cosockets are used in `init_worker_by_lua*`, to prevent a hung backend from indefinitely blocking worker startup.
+
+This directive was first introduced in this release.
+
+[Back to TOC](#directives)
+
+lua_init_worker_abort_on_error
+-------------------------------
+
+**syntax:** *lua_init_worker_abort_on_error on|off*
+
+**default:** *lua_init_worker_abort_on_error off*
+
+**context:** *http*
+
+When set to `on`, a Lua runtime error in `init_worker_by_lua*` causes the worker process to exit with code 2 immediately (the Nginx master will restart it). When `off` (the default), the error is logged but the worker starts normally.
+
+Note the following limitations:
+
+* This only covers errors that occur **before the first yield** (i.e. synchronous errors). Errors during a yielded cosocket operation are logged but do not trigger the abort.
+* When `on` is set, `exit_worker_by_lua*` is **not executed** — the worker exits via `exit(2)`, which bypasses the graceful shutdown hooks.
+* This directive cannot replace `lua_init_worker_timeout`: it only handles Lua runtime errors, not hung I/O operations.
+* If the error is reproducible, setting `on` will cause a crash loop (the master keeps restarting a worker that immediately errors out).
+
+This directive was first introduced in this release.
+
+[Back to TOC](#directives)
+
 lua_ssl_ciphers
 ---------------
 
@@ -4555,7 +4606,7 @@ ngx.location.capture
 
 **syntax:** *res = ngx.location.capture(uri, options?)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Issues a synchronous but still non-blocking *Nginx Subrequest* using `uri`.
 
@@ -4877,7 +4928,7 @@ ngx.location.capture_multi
 
 **syntax:** *res1, res2, ... = ngx.location.capture_multi({ {uri, options?}, {uri, options?}, ... })*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Just like [ngx.location.capture](#ngxlocationcapture), but supports multiple subrequests running in parallel.
 
@@ -4969,7 +5020,7 @@ ngx.header.HEADER
 
 **syntax:** *value = ngx.header.HEADER*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;*
 
 Set, add to, or clear the current request's `HEADER` response header that is to be sent.
 
@@ -5517,7 +5568,7 @@ ngx.req.get_post_args
 
 **syntax:** *args, err = ngx.req.get_post_args(max_args?)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;*
 
 Returns a Lua table holding all the current request POST query arguments (of the MIME type `application/x-www-form-urlencoded`). Call [ngx.req.read_body](#ngxreqread_body) to read the request body first or turn on the [lua_need_request_body](#lua_need_request_body) directive to avoid errors.
 
@@ -5785,7 +5836,7 @@ ngx.req.read_body
 
 **syntax:** *ngx.req.read_body()*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Reads the client request body synchronously without blocking the Nginx event loop.
 
@@ -5817,7 +5868,7 @@ ngx.req.discard_body
 
 **syntax:** *ngx.req.discard_body()*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Explicitly discard the request body, i.e., read the data on the connection and throw it away immediately (without using the request body by any means).
 
@@ -5836,7 +5887,7 @@ ngx.req.get_body_data
 
 **syntax:** *data = ngx.req.get_body_data(max_bytes?)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, log_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, log_by_lua&#42;*
 
 Retrieves in-memory request body data. It returns a Lua string rather than a Lua table holding all the parsed query arguments. Use the [ngx.req.get_post_args](#ngxreqget_post_args) function instead if a Lua table is required.
 
@@ -5867,7 +5918,7 @@ ngx.req.get_body_file
 
 **syntax:** *file_name = ngx.req.get_body_file()*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Retrieves the file name for the in-file request body data. Returns `nil` if the request body has not been read or has been read into memory.
 
@@ -5892,7 +5943,7 @@ ngx.req.set_body_data
 
 **syntax:** *ngx.req.set_body_data(data)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, balancer_by_lua&#42;,*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, balancer_by_lua&#42;,*
 
 Set the current request's request body using the in-memory data specified by the `data` argument.
 
@@ -5913,7 +5964,7 @@ ngx.req.set_body_file
 
 **syntax:** *ngx.req.set_body_file(file_name, auto_clean?)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, balancer_by_lua&#42;,*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, balancer_by_lua&#42;,*
 
 Set the current request's request body using the in-file data specified by the `file_name` argument.
 
@@ -6008,7 +6059,7 @@ ngx.req.socket
 
 **syntax:** *tcpsock, err = ngx.req.socket(raw)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Returns a read-only cosocket object that wraps the downstream connection. Only [receive](#tcpsockreceive), [receiveany](#tcpsockreceiveany) and [receiveuntil](#tcpsockreceiveuntil) methods are supported on this object.
 
@@ -6036,7 +6087,7 @@ ngx.exec
 
 **syntax:** *ngx.exec(uri, args?)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Does an internal redirect to `uri` with `args` and is similar to the [echo_exec](http://github.com/openresty/echo-nginx-module#echo_exec) directive of the [echo-nginx-module](http://github.com/openresty/echo-nginx-module).
 
@@ -6104,7 +6155,7 @@ ngx.redirect
 
 **syntax:** *ngx.redirect(uri, status?)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Issue an `HTTP 301` or `302` redirection to `uri`.
 
@@ -6197,7 +6248,7 @@ ngx.send_headers
 
 **syntax:** *ok, err = ngx.send_headers()*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Explicitly send out the response headers.
 
@@ -6226,7 +6277,7 @@ ngx.print
 
 **syntax:** *ok, err = ngx.print(...)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Emits arguments concatenated to the HTTP client (as response body). If response headers have not been sent, this function will send headers out first and then output body data.
 
@@ -6268,7 +6319,7 @@ ngx.say
 
 **syntax:** *ok, err = ngx.say(...)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Just as [ngx.print](#ngxprint) but also emit a trailing newline.
 
@@ -6296,7 +6347,7 @@ ngx.flush
 
 **syntax:** *ok, err = ngx.flush(wait?)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Flushes response output to the client.
 
@@ -6317,7 +6368,7 @@ ngx.exit
 
 **syntax:** *ngx.exit(status)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 When `status >= 200` (i.e., `ngx.HTTP_OK` and above), it will interrupt the execution of the current request and return status code to Nginx.
 
@@ -6373,7 +6424,7 @@ ngx.eof
 
 **syntax:** *ok, err = ngx.eof()*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Explicitly specify the end of the response output stream. In the case of HTTP 1.1 chunked encoded output, it will just trigger the Nginx core to send out the "last chunk".
 
@@ -6409,7 +6460,7 @@ ngx.sleep
 
 **syntax:** *ngx.sleep(seconds)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Sleeps for the specified seconds without blocking. One can specify time resolution up to 0.001 seconds (i.e., one millisecond).
 
@@ -7911,7 +7962,7 @@ ngx.socket.udp
 
 **syntax:** *udpsock = ngx.socket.udp()*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Creates and returns a UDP or datagram-oriented unix domain socket object (also known as one type of the "cosocket" objects). The following methods are supported on this object:
 
@@ -7934,7 +7985,7 @@ udpsock:bind
 ------------
 **syntax:** *ok, err = udpsock:bind(address)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;,ssl_session_fetch_by_lua&#42;,ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;,ssl_session_fetch_by_lua&#42;,ssl_client_hello_by_lua&#42;*
 
 Just like the standard [proxy_bind](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_bind) directive, this api makes the outgoing connection to a upstream server originate from the specified local IP address.
 
@@ -7967,7 +8018,7 @@ udpsock:setpeername
 
 **syntax:** *ok, err = udpsock:setpeername("unix:/path/to/unix-domain.socket")*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Attempts to connect a UDP socket object to a remote server or to a datagram unix domain socket file. Because the datagram protocol is actually connection-less, this method does not really establish a "connection", but only just set the name of the remote peer for subsequent read/write operations.
 
@@ -8030,7 +8081,7 @@ udpsock:send
 
 **syntax:** *ok, err = udpsock:send(data)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Sends data on the current UDP or datagram unix domain socket object.
 
@@ -8047,7 +8098,7 @@ udpsock:receive
 
 **syntax:** *data, err = udpsock:receive(size?)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Receives data from the UDP or datagram unix domain socket object with an optional receive buffer size argument, `size`.
 
@@ -8083,7 +8134,7 @@ udpsock:close
 
 **syntax:** *ok, err = udpsock:close()*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Closes the current UDP or datagram unix domain socket. It returns the `1` in case of success and returns `nil` with a string describing the error otherwise.
 
@@ -8098,7 +8149,7 @@ udpsock:settimeout
 
 **syntax:** *udpsock:settimeout(time)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Set the timeout value in milliseconds for subsequent socket operations (like [receive](#udpsockreceive)).
 
@@ -8123,7 +8174,7 @@ ngx.socket.tcp
 
 **syntax:** *tcpsock = ngx.socket.tcp()*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Creates and returns a TCP or stream-oriented unix domain socket object (also known as one type of the "cosocket" objects). The following methods are supported on this object:
 
@@ -8175,7 +8226,7 @@ tcpsock:bind
 ------------
 **syntax:** *ok, err = tcpsock:bind(address, port?)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;,ssl_session_fetch_by_lua&#42;,ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;,ssl_session_fetch_by_lua&#42;,ssl_client_hello_by_lua&#42;*
 
 Just like the standard [proxy_bind](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_bind) directive, this api makes the outgoing connection to a upstream server originate from the specified local IP address.
 
@@ -8215,7 +8266,7 @@ tcpsock:connect
 
 **syntax:** *ok, err = tcpsock:connect("unix:/path/to/unix-domain.socket", options_table?)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Attempts to connect a TCP socket object to a remote server or to a stream unix domain socket file without blocking.
 
@@ -8336,7 +8387,7 @@ tcpsock:getfd
 
 **syntax:** *fd, err = tcpsock:getfd()*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Get the file descriptor of the current tcp socket.
 
@@ -8350,7 +8401,7 @@ tcpsock:setclientcert
 
 **syntax:** *ok, err = tcpsock:setclientcert(cert, pkey)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Set client certificate chain and corresponding private key to the TCP socket object.
 The certificate chain and private key provided will be used later by the [tcpsock:sslhandshake](#tcpsocksslhandshake) method.
@@ -8375,7 +8426,7 @@ tcpsock:settrustedstore
 
 **syntax:** *ok, err = tcpsock:settrustedstore(x509_store)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;*
 
 Set an X509 trusted certificate store on the TCP socket object. The store will be used by the
 [tcpsock:sslhandshake](#tcpsocksslhandshake) method to verify the remote server's certificate, in
@@ -8405,7 +8456,7 @@ tcpsock:sslhandshake
 
 **syntax:** *session, err = tcpsock:sslhandshake(reused_session?, server_name?, ssl_verify?, send_status_req?)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Does SSL/TLS handshake on the currently established connection.
 
@@ -8454,7 +8505,7 @@ tcpsock:getsslpointer
 
 **syntax:** *sslpointer, err = tcpsock:getsslpointer()*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Retrieves the underlying SSL pointer (SSL_CTX structure) of the cosocket connection.
 
@@ -8469,7 +8520,7 @@ tcpsock:getsslctx
 
 **syntax:** *sslctx, err = tcpsock:getsslctx()*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Retrieves the underlying SSL pointer (SSL_CTX structure) of the cosocket connection.
 
@@ -8484,7 +8535,7 @@ tcpsock:getsslsession
 
 **syntax:** *session, err = tcpsock:getsslsession()*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Retrieves the SSL session object from the cosocket connection for session resumption purposes.
 
@@ -8499,7 +8550,7 @@ tcpsock:send
 
 **syntax:** *bytes, err = tcpsock:send(data)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Sends data without blocking on the current TCP or Unix Domain Socket connection.
 
@@ -8532,7 +8583,7 @@ tcpsock:receive
 
 **syntax:** *data, err, partial = tcpsock:receive(pattern?)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Receives data from the connected socket according to the reading pattern or size.
 
@@ -8575,7 +8626,7 @@ tcpsock:receiveany
 
 **syntax:** *data, err = tcpsock:receiveany(max)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Returns any data received by the connected socket, at most `max` bytes.
 
@@ -8610,7 +8661,7 @@ tcpsock:receiveuntil
 
 **syntax:** *iterator = tcpsock:receiveuntil(pattern, options?)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 This method returns an iterator Lua function that can be called to read the data stream until it sees the specified pattern or an error occurs.
 
@@ -8710,7 +8761,7 @@ tcpsock:close
 
 **syntax:** *ok, err = tcpsock:close()*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Closes the current TCP or stream unix domain socket. It returns the `1` in case of success and returns `nil` with a string describing the error otherwise.
 
@@ -8727,7 +8778,7 @@ tcpsock:settimeout
 
 **syntax:** *tcpsock:settimeout(time)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Set the timeout value in milliseconds for subsequent socket operations ([connect](#tcpsockconnect), [receive](#tcpsockreceive), and iterators returned from [receiveuntil](#tcpsockreceiveuntil)).
 
@@ -8744,7 +8795,7 @@ tcpsock:settimeouts
 
 **syntax:** *tcpsock:settimeouts(connect_timeout, send_timeout, read_timeout)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Respectively sets the connect, send, and read timeout thresholds (in milliseconds) for subsequent socket
 operations ([connect](#tcpsockconnect), [send](#tcpsocksend), [receive](#tcpsockreceive), and iterators returned from [receiveuntil](#tcpsockreceiveuntil)).
@@ -8764,7 +8815,7 @@ tcpsock:setoption
 
 **syntax:** *ok, err = tcpsock:setoption(option, value?)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 This function is added for [LuaSocket](http://w3.impa.br/~diego/software/luasocket/tcp.html) API compatibility, its functionality is implemented `v0.10.18`.
 
@@ -8867,7 +8918,7 @@ tcpsock:setkeepalive
 
 **syntax:** *ok, err = tcpsock:setkeepalive(timeout?, size?)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Puts the current socket's connection immediately into the cosocket built-in connection pool and keep it alive until other [connect](#tcpsockconnect) method calls request it or the associated maximal idle timeout is expired.
 
@@ -8914,7 +8965,7 @@ tcpsock:getreusedtimes
 
 **syntax:** *count, err = tcpsock:getreusedtimes()*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 This method returns the (successfully) reused times for the current connection. In case of error, it returns `nil` and a string describing the error.
 
@@ -8931,7 +8982,7 @@ ngx.socket.connect
 
 **syntax:** *tcpsock, err = ngx.socket.connect("unix:/path/to/unix-domain.socket")*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;*
 
 This function is a shortcut for combining [ngx.socket.tcp()](#ngxsockettcp) and the [connect()](#tcpsockconnect) method call in a single operation. It is actually implemented like this:
 
@@ -9002,7 +9053,7 @@ ngx.thread.spawn
 
 **syntax:** *co = ngx.thread.spawn(func, arg1, arg2, ...)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Spawns a new user "light thread" with the Lua function `func` as well as those optional arguments `arg1`, `arg2`, and etc. Returns a Lua thread (or Lua coroutine) object represents this "light thread".
 
@@ -9141,7 +9192,7 @@ ngx.thread.wait
 
 **syntax:** *ok, res1, res2, ... = ngx.thread.wait(thread1, thread2, ...)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Waits on one or more child "light threads" and returns the results of the first "light thread" that terminates (either successfully or with an error).
 
@@ -9245,7 +9296,7 @@ ngx.thread.kill
 
 **syntax:** *ok, err = ngx.thread.kill(thread)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, ngx.timer.&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Kills a running "light thread" created by [ngx.thread.spawn](#ngxthreadspawn). Returns a true value when successful or `nil` and a string describing the error otherwise.
 
@@ -9260,7 +9311,7 @@ ngx.on_abort
 
 **syntax:** *ok, err = ngx.on_abort(callback)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 Registers a user Lua function as the callback which gets called automatically when the client closes the (downstream) connection prematurely.
 
@@ -9773,7 +9824,7 @@ coroutine.create
 
 **syntax:** *co = coroutine.create(f)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, init_by_lua&#42;, ngx.timer.&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, init_by_lua&#42;, ngx.timer.&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Creates a user Lua coroutines with a Lua function, and returns a coroutine object.
 
@@ -9790,7 +9841,7 @@ coroutine.resume
 
 **syntax:** *ok, ... = coroutine.resume(co, ...)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, init_by_lua&#42;, ngx.timer.&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, init_by_lua&#42;, ngx.timer.&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Resumes the execution of a user Lua coroutine object previously yielded or just created.
 
@@ -9807,7 +9858,7 @@ coroutine.yield
 
 **syntax:** *... = coroutine.yield(...)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, init_by_lua&#42;, ngx.timer.&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, init_by_lua&#42;, ngx.timer.&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Yields the execution of the current user Lua coroutine.
 
@@ -9824,7 +9875,7 @@ coroutine.wrap
 
 **syntax:** *co = coroutine.wrap(f)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, init_by_lua&#42;, ngx.timer.&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, init_by_lua&#42;, ngx.timer.&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Similar to the standard Lua [coroutine.wrap](https://www.lua.org/manual/5.1/manual.html#pdf-coroutine.wrap) API, but works in the context of the Lua coroutines created by ngx_lua.
 
@@ -9839,7 +9890,7 @@ coroutine.running
 
 **syntax:** *co = coroutine.running()*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, init_by_lua&#42;, ngx.timer.&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, init_by_lua&#42;, ngx.timer.&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Identical to the standard Lua [coroutine.running](https://www.lua.org/manual/5.1/manual.html#pdf-coroutine.running) API.
 
@@ -9854,7 +9905,7 @@ coroutine.status
 
 **syntax:** *status = coroutine.status(co)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, init_by_lua&#42;, ngx.timer.&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, ssl_client_hello_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, init_by_lua&#42;, ngx.timer.&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, ssl_certificate_by_lua&#42;, ssl_session_fetch_by_lua&#42;, ssl_session_store_by_lua&#42;, ssl_client_hello_by_lua&#42;*
 
 Identical to the standard Lua [coroutine.status](https://www.lua.org/manual/5.1/manual.html#pdf-coroutine.status) API.
 
@@ -9869,7 +9920,7 @@ ngx.run_worker_thread
 
 **syntax:** *ok, res1, res2, ... = ngx.run_worker_thread(threadpool, module_name, func_name, arg1, arg2, ...)*
 
-**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
+**context:** *init_worker_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;*
 
 **This API is still experimental and may change in the future without notice.**
 

--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -344,6 +344,10 @@ struct ngx_http_lua_main_conf_s {
     unsigned             requires_capture_log:1;
     unsigned             requires_server_rewrite:1;
     unsigned             requires_precontent:1;
+
+    ngx_msec_t           init_worker_timeout;
+    ngx_queue_t          deferred_timers;
+    ngx_flag_t           init_worker_abort_on_error;
 };
 
 

--- a/src/ngx_http_lua_initworkerby.c
+++ b/src/ngx_http_lua_initworkerby.c
@@ -73,7 +73,7 @@ ngx_http_lua_init_worker_pump(ngx_cycle_t *cycle, ngx_msec_t budget)
 
     if (!ngx_queue_empty(&ngx_posted_next_events)) {
         ngx_event_move_posted_next(cycle);
-       timer = 0;
+        timer = 0;
     }
 
 #ifdef HAVE_POSTED_DELAYED_EVENTS_PATCH
@@ -124,6 +124,19 @@ ngx_http_lua_init_worker_toggle_accept(ngx_cycle_t *cycle, ngx_uint_t arm)
     ls = cycle->listening.elts;
 
     for (i = 0; i < cycle->listening.nelts; i++) {
+
+        /* only toggle plain HTTP TCP listeners; stream/mail/QUIC sockets
+         * must stay armed (QUIC: pre-1.25 uses a non-HTTP handler, newer
+         * versions set ls[i].quic) */
+#if (nginx_version >= 1025000)
+        if (ls[i].handler != ngx_http_init_connection || ls[i].quic) {
+            continue;
+        }
+#else
+        if (ls[i].handler != ngx_http_init_connection) {
+            continue;
+        }
+#endif
 
 #if (NGX_HAVE_REUSEPORT)
         if (ls[i].reuseport && ls[i].worker != ngx_worker) {

--- a/src/ngx_http_lua_initworkerby.c
+++ b/src/ngx_http_lua_initworkerby.c
@@ -4,6 +4,17 @@
  */
 
 
+#include "ngx_core.h"
+#include "ngx_event.h"
+#include "ngx_event_posted.h"
+#include "ngx_event_timer.h"
+#include "ngx_http.h"
+#include "ngx_http_lua_common.h"
+#include "ngx_http_request.h"
+#include "ngx_process_cycle.h"
+#include "ngx_string.h"
+#include "ngx_time.h"
+#include "ngx_times.h"
 #ifndef DDEBUG
 #define DDEBUG 0
 #endif
@@ -17,6 +28,236 @@
 
 static u_char *ngx_http_lua_log_init_worker_error(ngx_log_t *log,
     u_char *buf, size_t len);
+
+static void ngx_http_lua_init_worker_toggle_accept(
+    ngx_cycle_t *cycle, ngx_uint_t arm);
+
+static void ngx_http_lua_init_worker_pump(ngx_cycle_t *cycle,
+    ngx_msec_t budget);
+
+static void ngx_http_lua_init_worker_flush_timers(
+    ngx_http_lua_main_conf_t *lmcf);
+
+
+typedef struct {
+    unsigned     done:1;
+    unsigned     failed:1;
+    unsigned     timeout:1;
+} ngx_http_lua_init_worker_state_t;
+
+
+static void ngx_http_lua_init_worker_pump_loop(ngx_cycle_t *cycle,
+    ngx_http_lua_main_conf_t *lmcf,
+    ngx_http_lua_init_worker_state_t *st);
+
+
+static void
+ngx_http_lua_init_worker_done(void *data)
+{
+    ngx_http_lua_init_worker_state_t *state = data;
+
+    state->done = 1;
+}
+
+
+static void
+ngx_http_lua_init_worker_pump(ngx_cycle_t *cycle, ngx_msec_t budget)
+{
+    ngx_msec_t                   timer;
+
+    timer = ngx_event_find_timer();
+
+    if (timer == NGX_TIMER_INFINITE || timer > budget) {
+        timer = budget;
+    }
+
+    if (!ngx_queue_empty(&ngx_posted_next_events)) {
+        ngx_event_move_posted_next(cycle);
+       timer = 0;
+    }
+
+#ifdef HAVE_POSTED_DELAYED_EVENTS_PATCH
+    if (!ngx_queue_empty(&ngx_posted_delayed_events)) {
+        timer = 0;
+    }
+#endif
+
+    (void) ngx_process_events(cycle, timer, NGX_UPDATE_TIME | NGX_POST_EVENTS);
+
+    ngx_event_expire_timers();
+
+    ngx_event_process_posted(cycle, &ngx_posted_events);
+
+#ifdef HAVE_POSTED_DELAYED_EVENTS_PATCH
+    ngx_event_process_posted(cycle, &ngx_posted_delayed_events);
+#endif
+}
+
+
+static void
+ngx_http_lua_init_worker_toggle_accept(ngx_cycle_t *cycle, ngx_uint_t arm)
+{
+    ngx_listening_t    *ls;
+    ngx_connection_t   *c;
+    ngx_event_t        *rev;
+    ngx_uint_t          i;
+    ngx_uint_t          flags;
+#if (NGX_HAVE_EPOLLEXCLUSIVE)
+    ngx_uint_t          exclusive;
+#endif
+
+    if (ngx_use_accept_mutex) {
+        return;
+    }
+
+#if (NGX_HAVE_EPOLLEXCLUSIVE)
+    {
+        ngx_core_conf_t *ccf;
+
+        ccf = (ngx_core_conf_t *) ngx_get_conf(cycle->conf_ctx,
+                                               ngx_core_module);
+        exclusive = ((ngx_event_flags & NGX_USE_EPOLL_EVENT)
+                     && ccf->worker_processes > 1);
+    }
+#endif
+
+    ls = cycle->listening.elts;
+
+    for (i = 0; i < cycle->listening.nelts; i++) {
+
+#if (NGX_HAVE_REUSEPORT)
+        if (ls[i].reuseport && ls[i].worker != ngx_worker) {
+            /* other workers' sockets: ls[i].connection is NULL here */
+            continue;
+        }
+#endif
+
+        c = ls[i].connection;
+
+        if (c == NULL) {
+            continue;
+        }
+
+        rev = c->read;
+
+        if (!arm) {
+            if (rev->active
+                && ngx_del_event(rev, NGX_READ_EVENT, 0) == NGX_ERROR)
+            {
+                ngx_log_error(NGX_LOG_ALERT, cycle->log, 0,
+                              "init_worker: failed to disarm listen fd %d",
+                              c->fd);
+            }
+
+            continue;
+        }
+
+        if (rev->active) {
+            continue;
+        }
+
+        flags = 0;
+
+#if (NGX_HAVE_EPOLLEXCLUSIVE)
+        if (exclusive
+#if (NGX_HAVE_REUSEPORT)
+            /* upstream registers reuseport sockets with plain flags,
+             * before the EPOLLEXCLUSIVE branch (ngx_event.c:907) */
+            && !ls[i].reuseport
+#endif
+           )
+        {
+            flags = NGX_EXCLUSIVE_EVENT;
+        }
+#endif
+
+        if (ngx_add_event(rev, NGX_READ_EVENT, flags) == NGX_ERROR) {
+            ngx_log_error(NGX_LOG_ALERT, cycle->log, 0,
+                          "init_worker: failed to re-arm listen fd %d, "
+                          "worker will not accept on it", c->fd);
+        }
+    }
+}
+
+
+static void
+ngx_http_lua_init_worker_flush_timers(ngx_http_lua_main_conf_t *lmcf)
+{
+    ngx_queue_t    *q;
+    ngx_event_t    *ev;
+    ngx_msec_int_t  remaining;
+
+    while (!ngx_queue_empty(&lmcf->deferred_timers)) {
+        q = ngx_queue_head(&lmcf->deferred_timers);
+        ngx_queue_remove(q);
+
+        ev = ngx_queue_data(q, ngx_event_t, queue);
+        remaining = (ngx_msec_int_t) (ev->timer.key - ngx_current_msec);
+
+        if (remaining <= 0) {
+#ifdef HAVE_POSTED_DELAYED_EVENTS_PATCH
+            ngx_post_event(ev, &ngx_posted_delayed_events);
+#else
+            ngx_add_timer(ev, 0);
+#endif
+            continue;
+        }
+
+        ngx_add_timer(ev, (ngx_msec_t) remaining);
+    }
+}
+
+
+static void
+ngx_http_lua_init_worker_pump_loop(ngx_cycle_t *cycle,
+    ngx_http_lua_main_conf_t *lmcf, ngx_http_lua_init_worker_state_t *st)
+{
+    ngx_msec_t           deadline = 0, budget;
+    ngx_uint_t           unlimited;
+
+    unlimited = (lmcf->init_worker_timeout == 0);
+
+    if (!unlimited) {
+        ngx_time_update();
+        deadline = ngx_current_msec + lmcf->init_worker_timeout;
+    }
+
+    ngx_http_lua_init_worker_toggle_accept(cycle, 0);
+
+    for (;;) {
+
+        if (st->done) {
+            break;
+        }
+
+        if (ngx_terminate || ngx_quit || ngx_exiting) {
+            ngx_log_error(NGX_LOG_WARN, cycle->log, 0,
+                          "init_worker_by_lua* aborted by signal while "
+                          "waiting for a yielded operation");
+            break;
+        }
+
+        if (unlimited) {
+            budget = NGX_TIMER_INFINITE;
+
+        } else {
+            if ((ngx_msec_int_t) (deadline - ngx_current_msec) <= 0) {
+                st->timeout = 1;
+                ngx_log_error(NGX_LOG_ERR, cycle->log, 0,
+                              "init_worker_by_lua* timed out after %M ms",
+                              lmcf->init_worker_timeout);
+                break;
+            }
+
+            budget = deadline - ngx_current_msec;
+        }
+
+        ngx_http_lua_init_worker_pump(cycle, budget);
+    }
+
+
+    ngx_http_lua_init_worker_toggle_accept(cycle, 1);
+}
 
 
 ngx_int_t
@@ -39,6 +280,12 @@ ngx_http_lua_init_worker(ngx_cycle_t *cycle)
     ngx_http_lua_loc_conf_t     *top_llcf;
     ngx_http_lua_main_conf_t    *lmcf;
     ngx_http_core_loc_conf_t    *clcf, *top_clcf;
+    ngx_pool_cleanup_t          *cln;
+    lua_State                   *co;
+    ngx_int_t                    rc;
+    int                          co_ref = LUA_NOREF;
+
+    ngx_http_lua_init_worker_state_t   st;
 
     lmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_lua_module);
 
@@ -303,17 +550,95 @@ ngx_http_lua_init_worker(ngx_cycle_t *cycle)
     }
 
     ctx->context = NGX_HTTP_LUA_CONTEXT_INIT_WORKER;
-    ctx->cur_co_ctx = NULL;
+    ctx->cur_co_ctx = &ctx->entry_co_ctx;
     r->read_event_handler = ngx_http_block_reading;
 
-    ngx_http_lua_set_req(lmcf->lua, r);
+    if (lmcf->init_worker_handler(cycle->log, lmcf, lmcf->lua) != NGX_OK) {
+        ngx_http_lua_set_req(lmcf->lua, NULL);
+        ngx_http_lua_finalize_request(r, NGX_ERROR);
+        return NGX_OK;
+    }
 
-    (void) lmcf->init_worker_handler(cycle->log, lmcf, lmcf->lua);
+    co_ref = ngx_http_lua_new_cached_thread(lmcf->lua, &co, lmcf, 1);
 
+    lua_pop(lmcf->lua, 2);
+
+    cln = ngx_pool_cleanup_add(r->pool, 0);
+    if (cln == NULL) {
+        goto runner_failed;
+    }
+
+    cln->handler = ngx_http_lua_request_cleanup_handler;
+    cln->data = ctx;
+    ctx->cleanup = &cln->handler;
+
+    ngx_memzero(&st, sizeof(st));
+
+    cln = ngx_pool_cleanup_add(r->pool, 0);
+    if (cln == NULL) {
+        goto runner_failed;
+    }
+
+    cln->handler = ngx_http_lua_init_worker_done;
+    cln->data = &st;
+
+    ctx->entered_content_phase = 1;
+
+    ctx->cur_co_ctx->co = co;
+    ctx->cur_co_ctx->co_ref = co_ref;
+    ctx->cur_co_ctx->co_status = NGX_HTTP_LUA_CO_RUNNING;
+
+    ngx_http_lua_set_req(co, r);
+    ngx_http_lua_attach_co_ctx_to_L(co, ctx->cur_co_ctx);
+
+    lua_xmove(lmcf->lua, co, 1);
+
+#ifdef NGX_LUA_USE_ASSERT
+    ctx->cur_co_ctx->co_top = 1;
+#endif
+
+    rc = ngx_http_lua_run_thread(lmcf->lua, r, ctx, 0);
+
+    if (rc == NGX_AGAIN || rc == NGX_DONE) {
+        ngx_http_lua_init_worker_pump_loop(cycle, lmcf, &st);
+
+    } else {
+        st.done = 1;
+        st.failed = (rc == NGX_ERROR || rc >= NGX_HTTP_SPECIAL_RESPONSE);
+    }
+
+    if (!st.done) {
+        ngx_log_error(NGX_LOG_ERR, cycle->log, 0,
+                      "init_worker_by_lua* failed to complete");
+
+        ngx_http_lua_request_cleanup(ctx, 1);
+        ngx_http_lua_finalize_request(r, NGX_ERROR);
+
+    } else if (rc != NGX_AGAIN && rc != NGX_DONE) {
+        ngx_http_lua_finalize_request(r, rc);
+    }
+
+    ngx_http_lua_init_worker_flush_timers(lmcf);
     ngx_http_lua_set_req(lmcf->lua, NULL);
 
-    ngx_destroy_pool(c->pool);
+    if (st.failed || st.timeout) {
+        if (lmcf->init_worker_abort_on_error) {
+            return NGX_ERROR;
+        }
+    }
     return NGX_OK;
+
+runner_failed:
+
+    if (co_ref != LUA_NOREF) {
+        ngx_http_lua_free_thread(r, lmcf->lua, co_ref, co, lmcf);
+    }
+
+    if (c != NULL) {
+        ngx_http_lua_close_fake_connection(c);
+    }
+
+    return NGX_ERROR;
 
 failed:
 
@@ -344,8 +669,7 @@ ngx_http_lua_init_worker_by_inline(ngx_log_t *log,
     }
 
     status = luaL_loadbuffer(L, (char *) lmcf->init_worker_src.data,
-                             lmcf->init_worker_src.len, chunkname)
-             || ngx_http_lua_do_call(log, L);
+                             lmcf->init_worker_src.len, chunkname);
 
     return ngx_http_lua_report(log, L, status, "init_worker_by_lua");
 }
@@ -357,8 +681,7 @@ ngx_http_lua_init_worker_by_file(ngx_log_t *log, ngx_http_lua_main_conf_t *lmcf,
 {
     int         status;
 
-    status = luaL_loadfile(L, (char *) lmcf->init_worker_src.data)
-             || ngx_http_lua_do_call(log, L);
+    status = luaL_loadfile(L, (char *) lmcf->init_worker_src.data);
 
     return ngx_http_lua_report(log, L, status, "init_worker_by_lua_file");
 }

--- a/src/ngx_http_lua_initworkerby.c
+++ b/src/ngx_http_lua_initworkerby.c
@@ -125,19 +125,11 @@ ngx_http_lua_init_worker_toggle_accept(ngx_cycle_t *cycle, ngx_uint_t arm)
 
     for (i = 0; i < cycle->listening.nelts; i++) {
 
-        /* only toggle plain HTTP TCP listeners; stream/mail/QUIC sockets
-         * must stay armed (QUIC: pre-1.25 uses a non-HTTP handler, newer
-         * versions set ls[i].quic) */
-#if (nginx_version >= 1025000)
-        if (ls[i].handler != ngx_http_init_connection || ls[i].quic) {
-            continue;
-        }
-#else
-        if (ls[i].handler != ngx_http_init_connection) {
-            continue;
-        }
-#endif
-
+        /* disarm every listener, not just HTTP ones: any pending
+         * connection on an armed level-triggered listen fd would make the
+         * pump spin at 100% CPU, and re-arming is faithful for all
+         * subsystems since nginx arms all listeners via the same
+         * subsystem-independent path in ngx_event.c */
 #if (NGX_HAVE_REUSEPORT)
         if (ls[i].reuseport && ls[i].worker != ngx_worker) {
             /* other workers' sockets: ls[i].connection is NULL here */

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -801,6 +801,20 @@ static ngx_command_t ngx_http_lua_cmds[] = {
       offsetof(ngx_http_lua_main_conf_t, worker_thread_vm_pool_size),
       NULL },
 
+    { ngx_string("lua_init_worker_timeout"),
+      NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_msec_slot,
+      NGX_HTTP_MAIN_CONF_OFFSET,
+      offsetof(ngx_http_lua_main_conf_t, init_worker_timeout),
+      NULL },
+
+    { ngx_string("lua_init_worker_abort_on_error"),
+      NGX_HTTP_MAIN_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_MAIN_CONF_OFFSET,
+      offsetof(ngx_http_lua_main_conf_t, init_worker_abort_on_error),
+      NULL },
+
     ngx_null_command
 };
 
@@ -1174,6 +1188,11 @@ ngx_http_lua_create_main_conf(ngx_conf_t *cf)
 
     lmcf->worker_thread_vm_pool_size = NGX_CONF_UNSET;
 
+    lmcf->init_worker_timeout = NGX_CONF_UNSET_MSEC;
+
+    lmcf->init_worker_abort_on_error = NGX_CONF_UNSET;
+
+    ngx_queue_init(&lmcf->deferred_timers);
     dd("nginx Lua module main config structure initialized!");
 
     return lmcf;
@@ -1270,6 +1289,10 @@ ngx_http_lua_init_main_conf(ngx_conf_t *cf, void *conf)
     dd("init built in headers out hash size: %ld",
        lmcf->builtin_headers_out.size);
 
+    ngx_conf_init_msec_value(lmcf->init_worker_timeout, 0);
+    dd("init_worker_timeout: %lu", (unsigned long) lmcf->init_worker_timeout);
+
+    ngx_conf_init_value(lmcf->init_worker_abort_on_error, 0);
     return NGX_CONF_OK;
 }
 

--- a/src/ngx_http_lua_timer.c
+++ b/src/ngx_http_lua_timer.c
@@ -338,6 +338,13 @@ ngx_http_lua_ngx_timer_helper(lua_State *L, int every)
 
     lmcf->pending_timers++;
 
+    if (ctx->context == NGX_HTTP_LUA_CONTEXT_INIT_WORKER) {
+        ev->timer.key = ngx_current_msec + delay;
+        ngx_queue_insert_tail(&lmcf->deferred_timers, &ev->queue);
+        lua_pushinteger(L, 1);
+        return 1;
+    }
+
 #ifdef HAVE_POSTED_DELAYED_EVENTS_PATCH
     if (delay == 0 && !ngx_exiting) {
         dd("posting 0 sec sleep event to head of delayed queue");

--- a/src/ngx_http_lua_util.h
+++ b/src/ngx_http_lua_util.h
@@ -32,7 +32,8 @@
 
 #define NGX_HTTP_LUA_ESCAPE_HEADER_VALUE  8
 
-#define NGX_HTTP_LUA_CONTEXT_YIELDABLE (NGX_HTTP_LUA_CONTEXT_REWRITE         \
+#define NGX_HTTP_LUA_CONTEXT_YIELDABLE (NGX_HTTP_LUA_CONTEXT_INIT_WORKER     \
+                                | NGX_HTTP_LUA_CONTEXT_REWRITE               \
                                 | NGX_HTTP_LUA_CONTEXT_SERVER_REWRITE        \
                                 | NGX_HTTP_LUA_CONTEXT_ACCESS                \
                                 | NGX_HTTP_LUA_CONTEXT_PRECONTENT            \

--- a/t/194-init-worker-cosocket.t
+++ b/t/194-init-worker-cosocket.t
@@ -1,0 +1,985 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua;
+
+$ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
+$ENV{TEST_NGINX_RESOLVER} ||= '8.8.8.8';
+
+master_on();
+repeat_each(1);
+
+plan tests => repeat_each() * (blocks() * 3 + 4);
+
+no_long_string();
+
+# UDP echo server for the UDP cosocket test: memcached 1.6+ dropped the
+# text-over-UDP protocol, so we echo datagrams ourselves
+my $udp_echo_pid = fork();
+if (!$udp_echo_pid) {
+    require IO::Socket::INET;
+    my $srv = IO::Socket::INET->new(
+        LocalAddr => '127.0.0.1', LocalPort => 19849, Proto => 'udp')
+        or die "udp echo bind: $!";
+    while (my $peer = $srv->recv(my $buf, 4096)) {
+        $srv->send($buf, 0, $peer);
+    }
+    exit 0;
+}
+# TCP server that closes connections after 2s (for remote-disconnect test)
+my $kill_tcp_pid = fork();
+if (!$kill_tcp_pid) {
+    require IO::Socket::INET;
+    my $srv = IO::Socket::INET->new(
+        LocalAddr => '127.0.0.1', LocalPort => 19850, Proto => 'tcp',
+        Listen => 5, ReuseAddr => 1) or die "kill tcp bind: $!";
+    while (my $cli = $srv->accept()) {
+        # read a bit, then close after 2s (simulates remote going away)
+        my $buf;
+        recv($cli, $buf, 1024, 0);
+        sleep 2;
+        close $cli;
+    }
+    exit 0;
+}
+END { kill 'KILL', $udp_echo_pid if $udp_echo_pid; kill 'KILL', $kill_tcp_pid if $kill_tcp_pid; }
+
+
+
+our $HtmlDir = html_dir;
+
+our $wall_clock = <<'_EOC_';
+        local ffi = require("ffi")
+        ffi.cdef[[
+            typedef long time_t;
+            typedef struct timeval { time_t tv_sec; time_t tv_usec; } timeval;
+            int gettimeofday(struct timeval *t, void *tzp);
+        ]]
+        local tv = ffi.new("timeval")
+        function wall_us()
+            ffi.C.gettimeofday(tv, nil)
+            return tonumber(tv.tv_sec) * 1000000 + tonumber(tv.tv_usec)
+        end
+
+        ffi.cdef[[
+            typedef struct {
+                struct timeval ru_utime;
+                struct timeval ru_stime;
+                long pad[14];
+            } rusage_t;
+            int getrusage(int who, rusage_t *usage);
+        ]]
+        local ru = ffi.new("rusage_t")
+        function cpu_us()
+            ffi.C.getrusage(0, ru)   -- 0 = RUSAGE_SELF
+            return tonumber(ru.ru_utime.tv_sec) * 1000000
+                 + tonumber(ru.ru_utime.tv_usec)
+                 + tonumber(ru.ru_stime.tv_sec) * 1000000
+                 + tonumber(ru.ru_stime.tv_usec)
+        end
+_EOC_
+
+run_tests();
+
+__DATA__
+=== TEST 1: sanity: TCP cosocket connect/send/receive in init_worker_by_lua
+--- http_config eval
+qq{
+    init_by_lua_block {
+$main::wall_clock
+    }
+    lua_init_worker_timeout 10s;
+    init_worker_by_lua_block {
+        local begin = wall_us()
+
+        local sock = ngx.socket.tcp()
+        local ok, err = sock:connect("127.0.0.1", $ENV{TEST_NGINX_MEMCACHED_PORT})
+        if not ok then
+            iw_result = "connect failed: " .. (err or "unknown")
+            return
+        end
+
+        local bytes, err = sock:send("flush_all\\r\\n")
+        if not bytes then
+            iw_result = "send failed: " .. (err or "unknown")
+            return
+        end
+
+        local line, err = sock:receive()
+        if not line then
+            iw_result = "receive failed: " .. (err or "unknown")
+            return
+        end
+
+        sock:close()
+        iw_result = "received: " .. line
+        iw_elapsed = wall_us() - begin
+    }
+}
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say(iw_result or "no result")
+            if iw_elapsed then
+                ngx.say(iw_elapsed < 2000000 and "elapsed OK"
+                        or "elapsed too long: " .. iw_elapsed .. "us")
+            else
+                ngx.say("no elapsed")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+received: OK
+elapsed OK
+--- timeout: 15
+--- log_level: debug
+--- error_log
+lua run thread returned
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: ngx.sleep(0.1) and ngx.sleep(0) in init_worker_by_lua
+--- http_config eval
+qq{
+    init_by_lua_block {
+$main::wall_clock
+    }
+    lua_init_worker_timeout 5s;
+    init_worker_by_lua_block {
+        local t0 = wall_us()
+        ngx.sleep(0.1)
+        local t1 = wall_us()
+        ngx.sleep(0)
+        local t2 = wall_us()
+
+        iw_done = true
+        -- no lower-bound timing assertion here: under valgrind/loaded CI,
+        -- wall_us() can report less than the sleep target; the busy-spin
+        -- guard is TEST 5's cpu_us assertion, which is the right tool
+        iw_slept = true
+        iw_zero_ok = (t2 - t1) < 1000000
+    }
+}
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say(iw_done    and "done"     or "not done")
+            ngx.say(iw_slept   and "slept OK" or "sleep too short")
+            ngx.say(iw_zero_ok and "zero OK"  or "zero hung")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+slept OK
+zero OK
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: semaphore wait in init_worker, posted by a spawned uthread
+--- http_config eval
+qq{
+    init_by_lua_block {
+$main::wall_clock
+    }
+    lua_init_worker_timeout 5s;
+    init_worker_by_lua_block {
+        local sema = require("ngx.semaphore").new(0)
+
+        ngx.log(ngx.DEBUG, "iw: before spawn")
+        local child, serr = ngx.thread.spawn(function()
+            -- fetch over a real cosocket; the roundtrip takes real
+            -- event-loop time, so the parent's wait genuinely blocks
+            local sock = ngx.socket.tcp()
+            local ok, err = sock:connect("127.0.0.1",
+                                         $ENV{TEST_NGINX_MEMCACHED_PORT})
+            if not ok then
+                ngx.log(ngx.ERR, "child connect failed: ", err)
+                return
+            end
+            sock:send("flush_all\\r\\n")
+            sock:receive()
+            sock:close()
+            ngx.log(ngx.DEBUG, "iw: child posting")
+            sema:post(1)
+        end)
+        iw_spawn_ok = child and true or false
+
+        ngx.log(ngx.DEBUG, "iw: before wait")
+        local t0 = wall_us()
+
+        local wok, werr = sema:wait(3)
+
+        local t1 = wall_us()
+        ngx.log(ngx.DEBUG, "iw: after wait")
+        iw_wait_ok = wok and true or false
+        iw_wait_err = werr or "none"
+        iw_wait_us = t1 - t0
+
+        local jok = ngx.thread.wait(child)
+        iw_join_ok = jok and true or false
+    }
+}
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say(iw_spawn_ok and "spawn OK" or "spawn failed")
+            ngx.say(iw_wait_ok  and "wait OK"  or "wait failed: "
+                    .. (iw_wait_err or ""))
+            ngx.say(iw_wait_us and iw_wait_us < 2000000
+                    and "fast wakeup" or "slow wakeup")
+            ngx.say(iw_join_ok and "join OK" or "join failed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+spawn OK
+wait OK
+fast wakeup
+join OK
+--- log_level: debug
+--- grep_error_log eval: qr/iw: [^,\n]*/
+--- grep_error_log_out
+iw: before spawn
+iw: before wait
+iw: child posting
+iw: after wait
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: non-yielding init_worker code behaves unchanged
+--- http_config
+    init_worker_by_lua_block {
+        local s = 0
+        for i = 1, 100 do
+            s = s + i
+        end
+        iw_sync_sum = s
+        iw_sync_msg = "sync done"
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say(iw_sync_msg or "no result")
+            ngx.say(iw_sync_sum == 5050 and "sum OK" or "sum wrong")
+        }
+    }
+--- request
+GET /t
+--- response_body
+sync done
+sum OK
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: pump does not busy-spin with a finite timeout budget
+--- http_config eval
+qq{
+    init_by_lua_block {
+$main::wall_clock
+    }
+    lua_init_worker_timeout 5s;
+    init_worker_by_lua_block {
+        -- finite timeout: locks the deadline/clamp budget branch
+        -- (the default-0 sentinel path is covered by t/195)
+        local c0 = cpu_us()
+        ngx.sleep(2)
+        local c1 = cpu_us()
+        iw_slept = 1
+        iw_cpu_us = c1 - c0
+    }
+}
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say(iw_slept and "slept" or "not slept")
+            ngx.say(iw_cpu_us and iw_cpu_us < 50000
+                    and "cpu idle OK" or "cpu busy: " .. (iw_cpu_us or "?"))
+        }
+    }
+--- request
+GET /t
+--- response_body
+slept
+cpu idle OK
+--- timeout: 15
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: timer.at registered after the first yield rans only after init_worker finishes
+--- http_config
+    lua_shared_dict iw_state 1m;
+    init_worker_by_lua_block {
+        local shdict = ngx.shared.iw_state
+        shdict:set("chunk_done", 0)
+
+        ngx.sleep(0.1)          -- yield #1: pumping turns on
+
+        local tok, terr = ngx.timer.at(0, function(premature)
+            if premature then
+                return
+            end
+            shdict:set("cb_saw_done", shdict:get("chunk_done"))
+            shdict:set("cb_ran", 1)
+        end)
+        shdict:set("timer_ok", tok and 1 or 0)
+
+        ngx.sleep(0.3)          -- yield #2: an unfrozen 0ms timer would fire here
+
+        shdict:set("chunk_done", 1)
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            local shdict = ngx.shared.iw_state
+            for i = 1, 50 do
+                if shdict:get("cb_ran") then
+                    break
+                end
+                ngx.sleep(0.05)
+            end
+            ngx.say("timer_ok: " .. (shdict:get("timer_ok") == 1 and "OK" or "FAIL"))
+            ngx.say("cb_ran: " .. (shdict:get("cb_ran") == 1 and "OK" or "FAIL"))
+            ngx.say("cb_after_chunk: " .. (shdict:get("cb_saw_done") == 1 and "OK" or "FAIL"))
+        }
+    }
+--- request
+GET /t
+--- response_body
+timer_ok: OK
+cb_ran: OK
+cb_after_chunk: OK
+--- timeout: 10
+--- no_error_log
+[error]
+
+
+
+=== TEST 7: timer.at registered before the first yield also runs only after init_worker finishes
+--- http_config
+    lua_shared_dict iw_state 1m;
+    init_worker_by_lua_block {
+        local shdict = ngx.shared.iw_state
+        shdict:set("chunk_done", 0)
+
+        local tok, terr = ngx.timer.at(0, function(premature)
+            if premature then
+                return
+            end
+            shdict:set("cb_saw_done", shdict:get("chunk_done"))
+            shdict:set("cb_ran", 1)
+        end)
+        shdict:set("timer_ok", tok and 1 or 0)
+
+        ngx.sleep(0.3)          -- the only yield; if the freeze were broken,
+                                -- cb would fire inside the pump here
+
+        shdict:set("chunk_done", 1)
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            local shdict = ngx.shared.iw_state
+            for i = 1, 50 do
+                if shdict:get("cb_ran") then
+                    break
+                end
+                ngx.sleep(0.05)
+            end
+            ngx.say("timer_ok: " .. (shdict:get("timer_ok") == 1 and "OK" or "FAIL"))
+            ngx.say("cb_ran: " .. (shdict:get("cb_ran") == 1 and "OK" or "FAIL"))
+            ngx.say("cb_after_chunk: " .. (shdict:get("cb_saw_done") == 1 and "OK" or "FAIL"))
+        }
+    }
+--- request
+GET /t
+--- response_body
+timer_ok: OK
+cb_ran: OK
+cb_after_chunk: OK
+--- timeout: 10
+--- no_error_log
+[error]
+
+
+
+=== TEST 8: timer.at in a non-yielding init_worker runs only after init (legacy behavior unchanged)
+--- http_config
+    lua_shared_dict iw_state 1m;
+    init_worker_by_lua_block {
+        local shdict = ngx.shared.iw_state
+        shdict:set("chunk_done", 0)
+
+        local tok, terr = ngx.timer.at(0, function(premature)
+            if premature then
+                return
+            end
+            shdict:set("cb_saw_done", shdict:get("chunk_done"))
+            shdict:set("cb_ran", 1)
+        end)
+        shdict:set("timer_ok", tok and 1 or 0)
+
+        shdict:set("chunk_done", 1)
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            local shdict = ngx.shared.iw_state
+            for i = 1, 50 do
+                if shdict:get("cb_ran") then
+                    break
+                end
+                ngx.sleep(0.05)
+            end
+            ngx.say("timer_ok: " .. (shdict:get("timer_ok") == 1 and "OK" or "FAIL"))
+            ngx.say("cb_ran: " .. (shdict:get("cb_ran") == 1 and "OK" or "FAIL"))
+            ngx.say("cb_after_chunk: " .. (shdict:get("cb_saw_done") == 1 and "OK" or "FAIL"))
+        }
+    }
+--- request
+GET /t
+--- response_body
+timer_ok: OK
+cb_ran: OK
+cb_after_chunk: OK
+--- timeout: 10
+--- no_error_log
+[error]
+
+
+
+=== TEST 9: frozen timer survives a timeout abort and still fires
+--- http_config
+    lua_shared_dict iw_state 1m;
+    lua_init_worker_timeout 500ms;
+    init_worker_by_lua_block {
+        local shdict = ngx.shared.iw_state
+
+        local tok, terr = ngx.timer.at(0, function(premature)
+            if premature then
+                return
+            end
+            -- no chunk-local upvalues here: they are nil'd after a timeout abort
+            ngx.shared.iw_state:set("cb_ran", 1)
+        end)
+        shdict:set("timer_ok", tok and 1 or 0)
+
+        ngx.sleep(10)          -- never finishes; the 500ms budget aborts the chunk
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            local shdict = ngx.shared.iw_state
+            for i = 1, 50 do
+                if shdict:get("cb_ran") then
+                    break
+                end
+                ngx.sleep(0.05)
+            end
+            ngx.say("timer_ok: " .. (shdict:get("timer_ok") == 1 and "OK" or "FAIL"))
+            ngx.say("cb_ran: " .. (shdict:get("cb_ran") == 1 and "OK" or "FAIL"))
+        }
+    }
+--- request
+GET /t
+--- response_body
+timer_ok: OK
+cb_ran: OK
+--- timeout: 10
+--- error_log
+init_worker_by_lua* timed out
+
+
+
+=== TEST 10: compile error keeps the legacy log prefix, worker still starts
+--- http_config
+    init_worker_by_lua_block {
+        local x =
+        -- nothing after the "=": syntax error  at load time
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say("still serving")
+        }
+    }
+--- request
+GET /t
+--- response_body
+still serving
+--- error_log
+init_worker_by_lua error:
+--- no_error_log
+lua run thread returned:
+
+
+
+=== TEST 11: runtime error with default abort_on_error off uses the new prefix, worker still starts
+--- http_config
+   init_worker_by_lua_block {
+       error("boom")   -- runtime error before any yield
+   }
+--- config
+   location /t {
+       content_by_lua_block {
+           ngx.say("still serving")
+       }
+   }
+--- request
+GET /t
+--- response_body
+still serving
+--- error_log
+lua entry thread aborted:
+--- no_error_log
+init_worker_by_lua error:
+
+
+
+=== TEST 12: a stalled remote read times out via lua_init_worker_timeout, worker still starts
+--- http_config
+    lua_init_worker_timeout 500ms;
+    init_worker_by_lua_block {
+        local sock = ngx.socket.tcp()
+        local ok, err = sock:connect("127.0.0.1", $TEST_NGINX_MEMCACHED_PORT)
+        if not ok then
+            return
+        end
+        sock:send("get")   -- incomplete command: memcached waits for \r\n forever
+        sock:receive()     -- hangs here; the 500ms budget aborts mid-read
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say("still serving")
+        }
+    }
+--- request
+GET /t
+--- response_body
+still serving
+--- timeout: 10
+--- error_log
+init_worker_by_lua* timed out
+
+
+
+=== TEST 13: timer.every registered in init_worker fires only after init and renews normally
+--- http_config
+   lua_shared_dict iw_state 1m;
+   init_worker_by_lua_block {
+       local shdict = ngx.shared.iw_state
+       shdict:set("chunk_done", 0)
+       shdict:set("fires", 0)
+
+       local tok, err = ngx.timer.every(0.05, function(premature)
+           if premature then
+               return
+           end
+           shdict:set("fires", shdict:get("fires") + 1)
+           if shdict:get("chunk_done") ~= 1 then
+               shdict:set("bad_early", 1)
+           end
+       end)
+       shdict:set("timer_ok", tok and 1 or 0)
+
+       ngx.sleep(0.2)          -- 4 intervals elapse inside the pump;
+                               -- a broken freeze would fire the timer here
+
+       shdict:set("chunk_done", 1)
+   }
+--- config
+   location /t {
+       content_by_lua_block {
+           local shdict = ngx.shared.iw_state
+           for i = 1, 100 do
+               if (shdict:get("fires") or 0) >= 3 then
+                   break
+               end
+               ngx.sleep(0.05)
+           end
+           ngx.say("timer_ok: " .. (shdict:get("timer_ok") == 1 and "OK" or "FAIL"))
+           ngx.say("renewal: " .. ((shdict:get("fires") or 0) >= 3 and "OK" or "FAIL"))
+           ngx.say("no early fire: " .. (shdict:get("bad_early") and "FAIL" or "OK"))
+       }
+   }
+--- request
+GET /t
+--- response_body
+timer_ok: OK
+renewal: OK
+no early fire: OK
+--- timeout: 10
+--- no_error_log
+[error]
+
+
+
+=== TEST 14: ngx.thread.spawn + wait, child does a cosocket roundtrip
+--- http_config
+    lua_init_worker_timeout 5s;
+    init_worker_by_lua_block {
+        local child, serr = ngx.thread.spawn(function()
+            local sock = ngx.socket.tcp()
+            local ok, err = sock:connect("127.0.0.1", $TEST_NGINX_MEMCACHED_PORT)
+            if not ok then
+                iw_child_result = "connect failed: " .. (err or "?")
+                return
+            end
+            sock:send("flush_all\r\n")
+            local line = sock:receive()
+            sock:close()
+            iw_child_result = "received: " .. (line or "?")
+        end)
+        iw_spawn_ok = child and true or false
+
+        local jok = ngx.thread.wait(child)
+        iw_join_ok = jok and true or false
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say(iw_spawn_ok and "spawn OK" or "spawn failed")
+            ngx.say(iw_join_ok and "join OK" or "join failed")
+            ngx.say(iw_child_result or "no result")
+        }
+    }
+--- request
+GET /t
+--- response_body
+spawn OK
+join OK
+received: OK
+--- timeout: 15
+--- no_error_log
+[error]
+
+
+
+=== TEST 15: timer.at(0) is deferred on bundle builds too (delayed-events path)
+--- http_config
+    lua_shared_dict iw_state 1m;
+    init_worker_by_lua_block {
+        local shdict = ngx.shared.iw_state
+        shdict:set("chunk_done", 0)
+
+        ngx.sleep(0.1)          -- yield #1: pumping turns on
+
+        -- an unfrozen timer.at(0) lands in ngx_posted_delayed_events, which
+        -- the pump processes in the same round — the freeze must intercept
+        local tok, terr = ngx.timer.at(0, function(premature)
+            if premature then
+                return
+            end
+            shdict:set("cb_saw_done", shdict:get("chunk_done"))
+            shdict:set("cb_ran", 1)
+        end)
+        shdict:set("timer_ok", tok and 1 or 0)
+
+        ngx.sleep(0.3)          -- yield #2: the unfrozen delayed event would
+                                -- fire here on a bundle build
+
+        shdict:set("chunk_done", 1)
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            local shdict = ngx.shared.iw_state
+            for i = 1, 50 do
+                if shdict:get("cb_ran") then
+                    break
+                end
+                ngx.sleep(0.05)
+            end
+            ngx.say("timer_ok: " .. (shdict:get("timer_ok") == 1 and "OK" or "FAIL"))
+            ngx.say("cb_ran: " .. (shdict:get("cb_ran") == 1 and "OK" or "FAIL"))
+            ngx.say("cb_after_chunk: " .. (shdict:get("cb_saw_done") == 1 and "OK" or "FAIL"))
+        }
+    }
+--- request
+GET /t
+--- response_body
+timer_ok: OK
+cb_ran: OK
+cb_after_chunk: OK
+--- timeout: 10
+--- no_error_log
+[error]
+
+
+
+=== TEST 16: UDP cosocket roundtrip in init_worker
+--- http_config
+    lua_init_worker_timeout 5s;
+    init_worker_by_lua_block {
+        local sock = ngx.socket.udp()
+        local ok, err = sock:setpeername("127.0.0.1", 19849)
+        if not ok then
+            iw_udp_result = "setpeername failed: " .. (err or "?")
+            return
+        end
+        sock:settimeout(2000)
+        local bytes, err = sock:send("ping")
+        if not bytes then
+            iw_udp_result = "send failed: " .. (err or "?")
+            return
+        end
+        local data, err = sock:receive()
+        if not data then
+            iw_udp_result = "receive failed: " .. (err or "?")
+            return
+        end
+        sock:close()
+        iw_udp_result = "received: " .. data
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say(iw_udp_result or "no result")
+        }
+    }
+--- request
+GET /t
+--- response_body
+received: ping
+--- timeout: 10
+--- no_error_log
+[error]
+
+
+
+=== TEST 17: ngx.run_worker_thread under the pump
+--- main_config
+    thread_pool testpool threads=1;
+--- http_config eval
+qq{
+    lua_package_path "$::HtmlDir/?.lua;./?.lua;;";
+    lua_worker_thread_vm_pool_size 1;
+    lua_init_worker_timeout 5s;
+    init_worker_by_lua_block {
+        local ok, res = ngx.run_worker_thread("testpool", "hello", "hello")
+        iw_wt_ok = ok
+        iw_wt_res = res
+    }
+}
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say((iw_wt_ok and iw_wt_res == "hello") and "thread OK"
+                    or "thread failed: " .. tostring(iw_wt_res))
+        }
+    }
+--- user_files
+>>> hello.lua
+local function hello()
+    return "hello"
+end
+return {hello=hello}
+--- request
+GET /t
+--- response_body
+thread OK
+--- timeout: 10
+--- no_error_log
+[error]
+
+
+
+=== TEST 18: cosocket connect via resolver in init_worker
+--- http_config
+    resolver $TEST_NGINX_RESOLVER ipv6=off;
+    lua_init_worker_timeout 10s;
+    init_worker_by_lua_block {
+        local sock = ngx.socket.tcp()
+        local ok, err = sock:connect("openresty.org", 80)
+        if not ok then
+            iw_res_result = "connect failed: " .. (err or "?")
+            return
+        end
+        sock:close()
+        iw_res_result = "resolved and connected"
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say(iw_res_result or "no result")
+        }
+    }
+--- request
+GET /t
+--- response_body
+resolved and connected
+--- timeout: 15
+--- no_error_log
+[error]
+
+
+
+=== TEST 19: SSL cosocket handshake in init_worker
+--- http_config
+    resolver $TEST_NGINX_RESOLVER ipv6=off;
+    lua_init_worker_timeout 10s;
+    init_worker_by_lua_block {
+        local sock = ngx.socket.tcp()
+        sock:settimeout(5000)
+        local ok, err = sock:connect("openresty.org", 443)
+        if not ok then
+            iw_ssl_result = "connect failed: " .. (err or "?")
+            return
+        end
+        local sess, err = sock:sslhandshake(nil, "openresty.org", false)
+        if not sess then
+            iw_ssl_result = "handshake failed: " .. (err or "?")
+            return
+        end
+        sock:close()
+        iw_ssl_result = "ssl handshake OK"
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say(iw_ssl_result or "no result")
+        }
+    }
+--- request
+GET /t
+--- response_body
+ssl handshake OK
+--- timeout: 15
+--- no_error_log
+[error]
+
+
+=== TEST 20: unclosed cosocket reaped by pool cleanup on timeout
+--- http_config
+    lua_init_worker_timeout 500ms;
+    init_worker_by_lua_block {
+        local sock = ngx.socket.tcp()
+        local ok = sock:connect("127.0.0.1", $TEST_NGINX_MEMCACHED_PORT)
+        if not ok then
+            iw_result = "connect failed"
+            return
+        end
+        sock:send("get")
+        sock:receive()
+        -- deliberately no sock:close(): the pool cleanup must close the fd
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say("still serving")
+        }
+    }
+--- request
+GET /t
+--- response_body
+still serving
+--- timeout: 10
+--- error_log
+init_worker_by_lua* timed out
+
+
+
+=== TEST 21: stalled remote read times out cleanly, no memory errors
+--- http_config
+    lua_init_worker_timeout 500ms;
+    init_worker_by_lua_block {
+        local sock = ngx.socket.tcp()
+        local ok = sock:connect("127.0.0.1", $TEST_NGINX_MEMCACHED_PORT)
+        if not ok then
+            return
+        end
+        sock:send("get")
+        sock:receive()
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say("still serving")
+        }
+    }
+--- request
+GET /t
+--- response_body
+still serving
+--- timeout: 10
+--- error_log
+init_worker_by_lua* timed out
+
+
+
+=== TEST 22: normal cosocket roundtrip completes, runner does not touch freed request
+--- http_config
+    lua_init_worker_timeout 5s;
+    init_worker_by_lua_block {
+        local sock = ngx.socket.tcp()
+        local ok = sock:connect("127.0.0.1", $TEST_NGINX_MEMCACHED_PORT)
+        if not ok then
+            iw_result = "connect failed"
+            return
+        end
+        sock:send("flush_all\r\n")
+        local line = sock:receive()
+        sock:close()
+        iw_result = "received: " .. (line or "?")
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say(iw_result or "no result")
+        }
+    }
+--- request
+GET /t
+--- response_body
+received: OK
+--- timeout: 10
+--- no_error_log
+[error]
+
+
+
+=== TEST 23: remote disconnects while cosocket is yielded
+--- http_config
+    lua_init_worker_timeout 10s;
+    init_worker_by_lua_block {
+        local sock = ngx.socket.tcp()
+        local ok = sock:connect("127.0.0.1", 19850)
+        if not ok then
+            iw_result = "connect failed: " .. (err or "?")
+            return
+        end
+        sock:send("hello")
+        -- server closes after 2s; we're yielded waiting for a reply that
+        -- will never come — the cleanup chain must handle the RST cleanly
+        local data, err = sock:receive()
+        iw_result = data and ("received: " .. data) or ("recv err: " .. (err or "?"))
+        sock:close()
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say(iw_result or "no result")
+        }
+    }
+--- request
+GET /t
+--- response_body
+recv err: closed
+--- timeout: 15
+--- no_error_log
+[error]
+

--- a/t/195-init-worker-accept.t
+++ b/t/195-init-worker-accept.t
@@ -1,0 +1,79 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua;
+
+master_on();
+repeat_each(1);
+
+plan tests => repeat_each() * (blocks() * 3 + 2);
+
+no_long_string();
+
+our $wall_clock = <<'_EOC_';
+        local ffi = require("ffi")
+        ffi.cdef[[
+            typedef long time_t;
+            typedef struct timeval { time_t tv_sec; time_t tv_usec; } timeval;
+            int gettimeofday(struct timeval *t, void *tzp);
+            typedef struct {
+                struct timeval ru_utime;
+                struct timeval ru_stime;
+                long pad[14];
+            } rusage_t;
+            int getrusage(int who, rusage_t *usage);
+        ]]
+        local tv = ffi.new("timeval")
+        function wall_us()
+            ffi.C.gettimeofday(tv, nil)
+            return tonumber(tv.tv_sec) * 1000000 + tonumber(tv.tv_usec)
+        end
+        local ru = ffi.new("rusage_t")
+        function cpu_us()
+            ffi.C.getrusage(0, ru)   -- 0 = RUSAGE_SELF
+            return tonumber(ru.ru_utime.tv_sec) * 1000000
+                 + tonumber(ru.ru_utime.tv_usec)
+                 + tonumber(ru.ru_stime.tv_sec) * 1000000
+                 + tonumber(ru.ru_stime.tv_usec)
+        end
+_EOC_
+
+run_tests();
+
+__DATA__
+=== TEST 1: accept deferred, pump stays idle (1 worker, level-triggered)
+--- http_config eval
+qq{
+    init_by_lua_block {
+$main::wall_clock
+    }
+    init_worker_by_lua_block {
+        ngx.log(ngx.DEBUG, "iw: pump begin")
+        local c0 = cpu_us()
+        ngx.sleep(1)
+        local c1 = cpu_us()
+        ngx.log(ngx.DEBUG, "iw: pump done")
+        iw_cpu_us = c1 - c0
+    }
+}
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say("response ok")
+            ngx.say(iw_cpu_us and iw_cpu_us < 50000
+                    and "cpu idle OK" or "cpu busy: " .. (iw_cpu_us or "?"))
+        }
+    }
+--- request
+GET /t
+--- response_body
+response ok
+cpu idle OK
+--- timeout: 15
+--- log_level: debug
+--- grep_error_log eval: qr/iw: pump [a-z]+/
+--- grep_error_log_out
+iw: pump begin
+iw: pump done
+--- no_error_log
+[error]
+exited on signal

--- a/t/196-init-worker-accept-workers.t
+++ b/t/196-init-worker-accept-workers.t
@@ -1,0 +1,73 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua;
+
+master_on();
+repeat_each(1);
+workers(2);
+
+plan tests => repeat_each() * (blocks() * 3 + 1);
+
+no_long_string();
+
+our $wall_clock = <<'_EOC_';
+        local ffi = require("ffi")
+        ffi.cdef[[
+            typedef long time_t;
+            typedef struct timeval { time_t tv_sec; time_t tv_usec; } timeval;
+            int gettimeofday(struct timeval *t, void *tzp);
+            typedef struct {
+                struct timeval ru_utime;
+                struct timeval ru_stime;
+                long pad[14];
+            } rusage_t;
+            int getrusage(int who, rusage_t *usage);
+        ]]
+        local tv = ffi.new("timeval")
+        function wall_us()
+            ffi.C.gettimeofday(tv, nil)
+            return tonumber(tv.tv_sec) * 1000000 + tonumber(tv.tv_usec)
+        end
+        local ru = ffi.new("rusage_t")
+        function cpu_us()
+            ffi.C.getrusage(0, ru)   -- 0 = RUSAGE_SELF
+            return tonumber(ru.ru_utime.tv_sec) * 1000000
+                 + tonumber(ru.ru_utime.tv_usec)
+                 + tonumber(ru.ru_stime.tv_sec) * 1000000
+                 + tonumber(ru.ru_stime.tv_usec)
+        end
+_EOC_
+
+run_tests();
+
+__DATA__
+=== TEST 1: accept deferred, no crash, no spin (2 workers, EPOLLEXCLUSIVE re-arm)
+--- http_config eval
+qq{
+    init_by_lua_block {
+$main::wall_clock
+    }
+    init_worker_by_lua_block {
+        local c0 = cpu_us()
+        ngx.sleep(1)
+        local c1 = cpu_us()
+        iw_cpu_us = c1 - c0
+    }
+}
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say("response ok")
+            ngx.say(iw_cpu_us and iw_cpu_us < 50000
+                    and "cpu idle OK" or "cpu busy: " .. (iw_cpu_us or "?"))
+        }
+    }
+--- request
+GET /t
+--- response_body
+response ok
+cpu idle OK
+--- timeout: 15
+--- no_error_log
+[error]
+exited on signal

--- a/t/197-init-worker-accept-reuseport.t
+++ b/t/197-init-worker-accept-reuseport.t
@@ -1,0 +1,77 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua;
+
+plan(skip_all => "TEST_NGINX_REUSE_PORT=1 is required "
+     . "(TEST_NGINX_REUSE_PORT=1 prove t/197-init-worker-accept-reuseport.t)")
+    unless $ENV{TEST_NGINX_REUSE_PORT};
+
+master_on();
+repeat_each(1);
+workers(2);
+
+plan tests => repeat_each() * (blocks() * 3 + 1);
+
+no_long_string();
+
+our $wall_clock = <<'_EOC_';
+        local ffi = require("ffi")
+        ffi.cdef[[
+            typedef long time_t;
+            typedef struct timeval { time_t tv_sec; time_t tv_usec; } timeval;
+            int gettimeofday(struct timeval *t, void *tzp);
+            typedef struct {
+                struct timeval ru_utime;
+                struct timeval ru_stime;
+                long pad[14];
+            } rusage_t;
+            int getrusage(int who, rusage_t *usage);
+        ]]
+        local tv = ffi.new("timeval")
+        function wall_us()
+            ffi.C.gettimeofday(tv, nil)
+            return tonumber(tv.tv_sec) * 1000000 + tonumber(tv.tv_usec)
+        end
+        local ru = ffi.new("rusage_t")
+        function cpu_us()
+            ffi.C.getrusage(0, ru)   -- 0 = RUSAGE_SELF
+            return tonumber(ru.ru_utime.tv_sec) * 1000000
+                 + tonumber(ru.ru_utime.tv_usec)
+                 + tonumber(ru.ru_stime.tv_sec) * 1000000
+                 + tonumber(ru.ru_stime.tv_usec)
+        end
+_EOC_
+
+run_tests();
+
+__DATA__
+=== TEST 1: reuseport re-arm branch (2 workers, connection pinned to one worker)
+--- http_config eval
+qq{
+    init_by_lua_block {
+$main::wall_clock
+    }
+    init_worker_by_lua_block {
+        local c0 = cpu_us()
+        ngx.sleep(1)
+        local c1 = cpu_us()
+        iw_cpu_us = c1 - c0
+    }
+}
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say("response ok")
+            ngx.say(iw_cpu_us and iw_cpu_us < 50000
+                    and "cpu idle OK" or "cpu busy: " .. (iw_cpu_us or "?"))
+        }
+    }
+--- request
+GET /t
+--- response_body
+response ok
+cpu idle OK
+--- timeout: 15
+--- no_error_log
+[error]
+exited on signal

--- a/t/198-init-worker-abort.t
+++ b/t/198-init-worker-abort.t
@@ -1,0 +1,60 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua;
+
+# single-process mode (no master_on): an init_process failure exits
+# the whole nginx with code 2, which --- must_die asserts
+
+repeat_each(1);
+
+$Test::Nginx::Util::DaemonEnabled = 'off';
+
+plan tests => repeat_each() * (blocks() * 2 + 1);
+
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: abort_on_error on + runtime error before yield exits with code 2
+--- http_config
+   lua_init_worker_abort_on_error on;
+   init_worker_by_lua_block {
+       error("boom")   -- runtime error before any yield
+   }
+--- config
+   location /t {
+       content_by_lua_block {
+           ngx.say("never reached")
+       }
+   }
+--- request
+GET /t
+--- must_die: 2
+--- error_log
+lua entry thread aborted:
+
+
+
+=== TEST 2: exit_worker_by_lua is skipped when abort_on_error fires
+--- http_config
+   lua_init_worker_abort_on_error on;
+   init_worker_by_lua_block {
+       error("boom")   -- runtime error before any yield
+   }
+   exit_worker_by_lua_block {
+       ngx.log(ngx.ERR, "EXIT_RAN")
+   }
+--- config
+   location /t {
+       content_by_lua_block {
+           ngx.say("never reached")
+       }
+   }
+--- request
+GET /t
+--- must_die: 2
+--- error_log
+lua entry thread aborted:
+--- no_error_log
+EXIT_RAN

--- a/t/199-init-worker-blocked.t
+++ b/t/199-init-worker-blocked.t
@@ -1,0 +1,187 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use strict;
+use warnings;
+use FindBin;
+use Test::More;
+
+# Manual lifecycle tests: the worker stays blocked inside init_worker,
+# so it never serves requests and the Test::Nginx block cycle cannot apply.
+
+my $Nginx    = $ENV{TEST_NGINX_BINARY} || "$FindBin::Bin/../work/nginx/sbin/nginx";
+my $Port     = 19847;
+my $MemcPort = $ENV{TEST_NGINX_MEMCACHED_PORT} || 11211;
+
+sub run_one {
+    my ($name, $abort) = @_;
+
+    my $dir = "/tmp/init-worker-blocked-$name";
+    system("rm -rf $dir && mkdir -p $dir/logs");
+
+    open my $fh, '>', "$dir/nginx.conf" or die "write conf: $!";
+    printf $fh <<'EOF', $dir, $dir, $abort, $MemcPort, $Port;
+worker_processes 1;
+master_process off;
+daemon on;
+error_log %s/logs/error.log warn;
+pid %s/logs/nginx.pid;
+events { worker_connections 64; }
+http {
+    lua_init_worker_abort_on_error %s;
+    init_worker_by_lua_block {
+        local sock = ngx.socket.tcp()
+        local ok = sock:connect("127.0.0.1", %d)
+        if not ok then
+            return
+        end
+        sock:send("get")
+        sock:receive()
+    }
+    server { listen %d; location /t { return 200 "ok"; } }
+}
+EOF
+    close $fh;
+
+    system("$Nginx -p $dir -c nginx.conf") == 0
+        or die "nginx failed to start";
+
+    sleep 2;
+
+    open my $pf, '<', "$dir/logs/nginx.pid" or die "no pid file: $!";
+    chomp(my $pid = <$pf>);
+    close $pf;
+
+    my $alive = kill 0, $pid;
+
+    open my $lf, '<', "$dir/logs/error.log" or die "no error log: $!";
+    my $log = do { local $/; <$lf> };
+    close $lf;
+
+    ok($alive, "$name: worker still blocked (alive) after 2s");
+    unlike($log, qr/timed out/, "$name: no timeout fired (budget is infinite)");
+
+    kill 'TERM', $pid;
+    sleep 1;
+    kill 'KILL', $pid;
+}
+
+sub run_signal {
+    my ($name, $signal) = @_;
+
+    my $dir = "/tmp/init-worker-blocked-$name";
+    system("rm -rf $dir && mkdir -p $dir/logs");
+
+    open my $fh, '>', "$dir/nginx.conf" or die "write conf: $!";
+    printf $fh <<'EOF', $dir, $dir, $MemcPort, $Port + 1;
+worker_processes 1;
+master_process off;
+daemon off;
+error_log %s/logs/error.log warn;
+pid %s/logs/nginx.pid;
+events { worker_connections 64; }
+http {
+    init_worker_by_lua_block {
+        local sock = ngx.socket.tcp()
+        local ok = sock:connect("127.0.0.1", %d)
+        if not ok then
+            return
+        end
+        sock:send("get")
+        sock:receive()
+    }
+    server { listen %d; location /t { return 200 "ok"; } }
+}
+EOF
+    close $fh;
+
+    my $pid = fork();
+    die "fork: $!" unless defined $pid;
+
+    if ($pid == 0) {
+        exec $Nginx, '-p', $dir, '-c', 'nginx.conf';
+        die "exec: $!";
+    }
+
+    sleep 1;               # let init_worker reach the stalled read inside the pump
+
+    kill $signal, $pid;    # deliver the signal mid-yield
+
+    waitpid($pid, 0);
+    my $sig  = $? & 127;   # 0 = exited by itself, nonzero = killed by that signal
+    my $code = $? >> 8;
+
+    open my $lf, '<', "$dir/logs/error.log" or die "no error log: $!";
+    my $log = do { local $/; <$lf> };
+    close $lf;
+
+    like($log, qr/aborted by signal/, "$name: pump noticed the signal and bailed out");
+    is($sig, 0, "$name: exited by itself, not killed by the signal");
+    is($code, 0, "$name: clean exit code");
+}
+
+
+sub run_frozen_timer_signal {
+    my ($name, $signal) = @_;
+
+    my $dir = "/tmp/init-worker-blocked-$name";
+    system("rm -rf $dir && mkdir -p $dir/logs");
+
+    open my $fh, '>', "$dir/nginx.conf" or die "write conf: $!";
+    printf $fh <<'CONF', $dir, $dir, $MemcPort, $Port + 2;
+worker_processes 1;
+master_process off;
+daemon off;
+error_log %s/logs/error.log warn;
+pid %s/logs/nginx.pid;
+events { worker_connections 64; }
+http {
+    init_worker_by_lua_block {
+        ngx.shared.iw_state:set("cb_ran", 0)
+        ngx.timer.at(0, function(premature)
+            ngx.log(ngx.WARN, "frozen timer fired, premature=", premature)
+        end)
+        local sock = ngx.socket.tcp()
+        local ok = sock:connect("127.0.0.1", %d)
+        if not ok then
+            return
+        end
+        sock:send("get")
+        sock:receive()
+    }
+    lua_shared_dict iw_state 1m;
+    server { listen %d; location /t { return 200 "ok"; } }
+}
+CONF
+    close $fh;
+
+    my $pid = fork();
+    die "fork: $!" unless defined $pid;
+
+    if ($pid == 0) {
+        exec $Nginx, '-p', $dir, '-c', 'nginx.conf';
+        die "exec: $!";
+    }
+
+    sleep 1;               # timer is frozen; the stalled read holds the pump
+
+    kill $signal, $pid;    # signal fires mid-pump
+
+    waitpid($pid, 0);
+
+    open my $lf, '<', "$dir/logs/error.log" or die "no error log: $!";
+    my $log = do { local $/; <$lf> };
+    close $lf;
+
+    # the frozen timer was flushed before cleanup and executed as premature
+    like($log, qr/premature/, "$name: timer fired with premature flag");
+
+    # D10 invariant: pending_timers counter must not desync
+    unlike($log, qr/counter got out of sync/,
+           "$name: timer counter in sync");
+}
+
+run_one('stalled-remote-read', 'on');
+run_signal('sigterm-during-yield', 'TERM');
+run_frozen_timer_signal('sigterm-with-frozen-timer', 'TERM');
+
+done_testing();


### PR DESCRIPTION
Enable TCP/UDP cosockets, ngx.sleep, ngx.semaphore, ngx.thread.spawn, coroutine.*, and ngx.run_worker_thread inside init_worker_by_lua* by running a bounded event pump when the init code yields.

Key changes:
- Add ngx_http_lua_init_worker_pump() to drive the event loop during yields
- Add ngx_http_lua_init_worker_pump_loop() with timeout budget management
- Add ngx_http_lua_init_worker_toggle_accept() to disarm/re-arm listeners around the pump (prevents level-triggered busy-spin from pending accepts)
- Freeze ngx.timer.at registrations via ctx->context gate; flush at runner exit with absolute expiry preservation (timer ordering identical to before)
- Add lua_init_worker_timeout directive (default 0 = no timeout)
- Add lua_init_worker_abort_on_error directive (default off)
- Add INIT_WORKER to NGX_HTTP_LUA_CONTEXT_YIELDABLE mask in util.h
- Change runtime error prefix to "lua entry thread aborted:" (breaking)
- Update README: new directives, cosocket availability, 118 API context lines

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

sister PR: https://github.com/openresty/stream-lua-nginx-module/pull/409
