### PR TITLE
tests: fix the PR title check broken by the action bump to v6.1.1

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -18,13 +18,13 @@ jobs:
         with:
           # Configure which types are allowed.
           # Default: https://github.com/commitizen/conventional-commit-types
-          types: |
-            bugfix # bug fixes
-            change # backward incompatible changes
-            doc # documentation changes including code comments
-            editor # code editor related configurations
-            feature # implementing a new feature
-            optimize # performance optimizations
-            refactor # code refactoring and other code rearrangement
-            style # coding style changes
-            tests # test suite changes
+          types: |-
+            bugfix
+            change
+            doc
+            editor
+            feature
+            optimize
+            refactor
+            style
+            tests


### PR DESCRIPTION
Since v6.1.0 each line of the `types` input is treated as a regex pattern auto-wrapped in `^ $` (amannn/action-semantic-pull-request#292), so the trailing "# comment" became part of the pattern: the line "bugfix # bug fixes" means regex ^bugfix # bug fixes$, which can never match the type token in a PR title. Every PR has failed the "Lint PR" check since the bump in ff17f2b9.

Under `@v4` the input was split on whitespace into plain strings, so "bugfix # bug fixes" accidentally yielded the bare token "bugfix", which matched. That accidental tolerance is gone in v6.

Fix: list each type as one bare line, as the v6 docs describe and as other repos pinning the same v6.1.1 SHA do:
https://github.com/projen/projen/blob/main/.github/workflows/pull-request-lint.yml#L23-L30

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
